### PR TITLE
Update QNAPIClient.m

### DIFF
--- a/Sources/Qonversion/Qonversion/Services/QNAPIClient/QNAPIClient.m
+++ b/Sources/Qonversion/Qonversion/Services/QNAPIClient/QNAPIClient.m
@@ -385,7 +385,7 @@
 
 - (void)removeStoredRequestForTransactionId:(NSString *)transactionId {
   NSMutableDictionary *storedRequests = [[self storedPurchasesRequests] mutableCopy];
-  if (transactionId) {
+  if (transactionId.length > 0) {
     storedRequests[transactionId] = nil;
   }
   

--- a/Sources/Qonversion/Qonversion/Services/QNAPIClient/QNAPIClient.m
+++ b/Sources/Qonversion/Qonversion/Services/QNAPIClient/QNAPIClient.m
@@ -385,7 +385,9 @@
 
 - (void)removeStoredRequestForTransactionId:(NSString *)transactionId {
   NSMutableDictionary *storedRequests = [[self storedPurchasesRequests] mutableCopy];
-  storedRequests[transactionId] = nil;
+  if (transactionId) {
+    storedRequests[transactionId] = nil;
+  }
   
   [self storePurchaseRequests:storedRequests];
 }


### PR DESCRIPTION
Fix crash in removeStoredRequestForTransactionId 
 of QNAPIClient when transactionId is nil