### PR TITLE
Add user switching on restore

### DIFF
--- a/Qonversion.xcodeproj/project.pbxproj
+++ b/Qonversion.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		45FFA2DE24BE1015007EFB8F /* QNTestConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 45FFA2DD24BE1015007EFB8F /* QNTestConstants.m */; };
 		45FFA2E024BE1549007EFB8F /* broken_data.json in Resources */ = {isa = PBXBuildFile; fileRef = 45FFA2DF24BE1548007EFB8F /* broken_data.json */; };
 		45FFA2EB24BEEA9A007EFB8F /* ProductCenterManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 45FFA2EA24BEEA9A007EFB8F /* ProductCenterManagerTests.m */; };
+		AA0001012D5B0A0000000001 /* ProductCenterManagerRestoreUserSwitchTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA0001002D5B0A0000000001 /* ProductCenterManagerRestoreUserSwitchTests.m */; };
 		45FFA2ED24BEF379007EFB8F /* full_init.json in Resources */ = {isa = PBXBuildFile; fileRef = 45FFA2EC24BEF379007EFB8F /* full_init.json */; };
 		6A121DAC2BB445AE0073B330 /* QONRemoteConfigList.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A121DAB2BB445AE0073B330 /* QONRemoteConfigList.m */; };
 		6A121DAE2BB446740073B330 /* QONRemoteConfigList.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A121DAD2BB446740073B330 /* QONRemoteConfigList.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -377,6 +378,7 @@
 		45FFA2DD24BE1015007EFB8F /* QNTestConstants.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QNTestConstants.m; sourceTree = "<group>"; };
 		45FFA2DF24BE1548007EFB8F /* broken_data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = broken_data.json; sourceTree = "<group>"; };
 		45FFA2EA24BEEA9A007EFB8F /* ProductCenterManagerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ProductCenterManagerTests.m; sourceTree = "<group>"; };
+		AA0001002D5B0A0000000001 /* ProductCenterManagerRestoreUserSwitchTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ProductCenterManagerRestoreUserSwitchTests.m; sourceTree = "<group>"; };
 		45FFA2EC24BEF379007EFB8F /* full_init.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = full_init.json; sourceTree = "<group>"; };
 		6A121DAB2BB445AE0073B330 /* QONRemoteConfigList.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QONRemoteConfigList.m; sourceTree = "<group>"; };
 		6A121DAD2BB446740073B330 /* QONRemoteConfigList.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = QONRemoteConfigList.h; sourceTree = "<group>"; };
@@ -813,6 +815,7 @@
 				45FFA2DC24BE1015007EFB8F /* QNTestConstants.h */,
 				45FFA2DD24BE1015007EFB8F /* QNTestConstants.m */,
 				45FFA2EA24BEEA9A007EFB8F /* ProductCenterManagerTests.m */,
+				AA0001002D5B0A0000000001 /* ProductCenterManagerRestoreUserSwitchTests.m */,
 			);
 			path = QonversionTests;
 			sourceTree = "<group>";
@@ -2351,6 +2354,7 @@
 				45FFA2DE24BE1015007EFB8F /* QNTestConstants.m in Sources */,
 				459DAC0D243E4D610011ECF3 /* XCTestCase+TestJSON.m in Sources */,
 				45FFA2EB24BEEA9A007EFB8F /* ProductCenterManagerTests.m in Sources */,
+				AA0001012D5B0A0000000001 /* ProductCenterManagerRestoreUserSwitchTests.m in Sources */,
 				89673C2926F35D29008D209A /* QNIdentityServiceTests.m in Sources */,
 				89A192A52604974800C3FCD9 /* QNUserInfoServiceTests.m in Sources */,
 				454BE21B247C2F0E001FE771 /* QInMemoryStorageTests.m in Sources */,

--- a/QonversionTests/ProductCenterManagerRestoreUserSwitchTests.m
+++ b/QonversionTests/ProductCenterManagerRestoreUserSwitchTests.m
@@ -1,0 +1,138 @@
+#import <XCTest/XCTest.h>
+#import <OCMock/OCMock.h>
+#import "QNProductCenterManager.h"
+#import "QNAPIClient.h"
+#import "QNUserDefaultsStorage.h"
+#import "QNStoreKitService.h"
+#import "QNTestConstants.h"
+#import "QONLaunchResult.h"
+#import "QONLaunchResult+Protected.h"
+#import "QNUserInfoService.h"
+#import "QNIdentityManager.h"
+#import "QNLocalStorage.h"
+#import "QONFallbackService.h"
+#import "QONRemoteConfigManager.h"
+#import "QONRequestTrigger.h"
+
+@interface QNProductCenterManager (RestoreTestPrivate)
+
+@property (nonatomic) QNStoreKitService *storeKitService;
+@property (nonatomic) QNUserDefaultsStorage *persistentStorage;
+@property (nonatomic) QNAPIClient *apiClient;
+@property (nonatomic) QONLaunchResult *launchResult;
+@property (nonatomic) NSError *launchError;
+@property (nonatomic, assign) BOOL launchingFinished;
+@property (nonatomic, assign) BOOL receiptRestoreInProgress;
+@property (nonatomic, assign) BOOL restoreInProgress;
+@property (nonatomic, assign) BOOL awaitingRestoreResult;
+
+- (void)handleUserSwitchIfNeededWithResult:(QONLaunchResult *)result;
+
+@end
+
+@interface ProductCenterManagerRestoreUserSwitchTests : XCTestCase
+
+@property (nonatomic, strong) id mockClient;
+@property (nonatomic, strong) id mockUserInfoService;
+@property (nonatomic, strong) id mockRemoteConfigManager;
+@property (nonatomic, strong) QNProductCenterManager *manager;
+
+@end
+
+@implementation ProductCenterManagerRestoreUserSwitchTests
+
+- (void)setUp {
+  _mockClient = OCMClassMock([QNAPIClient class]);
+  OCMStub([_mockClient shared]).andReturn(_mockClient);
+  
+  _mockUserInfoService = OCMProtocolMock(@protocol(QNUserInfoServiceInterface));
+  id mockIdentityManager = OCMClassMock([QNIdentityManager class]);
+  id mockLocalStorage = OCMProtocolMock(@protocol(QNLocalStorage));
+  id mockFallbackService = OCMClassMock([QONFallbackService class]);
+  
+  _manager = [[QNProductCenterManager alloc] initWithUserInfoService:_mockUserInfoService
+                                                     identityManager:mockIdentityManager
+                                                        localStorage:mockLocalStorage
+                                                     fallbackService:mockFallbackService];
+  [_manager setApiClient:_mockClient];
+  
+  _mockRemoteConfigManager = OCMClassMock([QONRemoteConfigManager class]);
+  _manager.remoteConfigManager = _mockRemoteConfigManager;
+}
+
+- (void)tearDown {
+  [_mockClient stopMocking];
+  _manager = nil;
+}
+
+#pragma mark - handleUserSwitchIfNeededWithResult: Tests
+
+- (void)testHandleUserSwitch_SameUid_NoSwitch {
+  // Given
+  NSString *currentUserId = @"user_123";
+  OCMStub([_mockUserInfoService obtainUserID]).andReturn(currentUserId);
+  
+  QONLaunchResult *launchResult = [[QONLaunchResult alloc] init];
+  launchResult.uid = currentUserId;
+  
+  // Set up reject expectations before the action
+  OCMReject([_mockUserInfoService storeIdentity:[OCMArg any]]);
+  OCMReject([_mockRemoteConfigManager userHasBeenChanged]);
+  
+  // When
+  [_manager handleUserSwitchIfNeededWithResult:launchResult];
+  
+  // Then - if rejected calls were made, the test would have failed already
+  OCMVerifyAll(_mockUserInfoService);
+  OCMVerifyAll(_mockRemoteConfigManager);
+}
+
+- (void)testHandleUserSwitch_DifferentUid_SwitchOccurs {
+  // Given
+  NSString *currentUserId = @"user_new";
+  NSString *originalUserId = @"user_old";
+  OCMStub([_mockUserInfoService obtainUserID]).andReturn(currentUserId);
+  
+  QONLaunchResult *launchResult = [[QONLaunchResult alloc] init];
+  launchResult.uid = originalUserId;
+  
+  // When
+  [_manager handleUserSwitchIfNeededWithResult:launchResult];
+  
+  // Then
+  OCMVerify([_mockUserInfoService storeIdentity:originalUserId]);
+  OCMVerify([_mockClient setUserID:originalUserId]);
+  OCMVerify([_mockRemoteConfigManager userHasBeenChanged]);
+}
+
+- (void)testHandleUserSwitch_NilResult_NoSwitch {
+  // Given - set up reject expectations before the action
+  OCMReject([_mockUserInfoService storeIdentity:[OCMArg any]]);
+  OCMReject([_mockRemoteConfigManager userHasBeenChanged]);
+  
+  // When
+  [_manager handleUserSwitchIfNeededWithResult:nil];
+  
+  // Then
+  OCMVerifyAll(_mockUserInfoService);
+  OCMVerifyAll(_mockRemoteConfigManager);
+}
+
+- (void)testHandleUserSwitch_EmptyUid_NoSwitch {
+  // Given
+  QONLaunchResult *launchResult = [[QONLaunchResult alloc] init];
+  launchResult.uid = @"";
+  
+  // Set up reject expectations before the action
+  OCMReject([_mockUserInfoService storeIdentity:[OCMArg any]]);
+  OCMReject([_mockRemoteConfigManager userHasBeenChanged]);
+  
+  // When
+  [_manager handleUserSwitchIfNeededWithResult:launchResult];
+  
+  // Then
+  OCMVerifyAll(_mockUserInfoService);
+  OCMVerifyAll(_mockRemoteConfigManager);
+}
+
+@end

--- a/Sources/Qonversion/Qonversion/Main/QNProductCenterManager/QNProductCenterManager.m
+++ b/Sources/Qonversion/Qonversion/Main/QNProductCenterManager/QNProductCenterManager.m
@@ -521,6 +521,10 @@ static NSString * const kUserDefaultsSuiteName = @"qonversion.product-center.sui
   __block __weak QNProductCenterManager *weakSelf = self;
   [self.storeKitService receipt:^(NSString * _Nonnull receipt) {
     [weakSelf launchWithTrigger:QONRequestTriggerRestore completion:^(QONLaunchResult * _Nonnull result, NSError * _Nullable error) {
+      if (!error) {
+        [weakSelf handleUserSwitchIfNeededWithResult:result];
+      }
+
       @synchronized (weakSelf) {
         weakSelf.receiptRestoreInProgress = NO;
         NSArray<QONEntitlementsCompletionHandler> *completions = [self.receiptRestoreBlocks copy];
@@ -1097,6 +1101,7 @@ static NSString * const kUserDefaultsSuiteName = @"qonversion.product-center.sui
         [weakSelf executeRestoreBlocksWithResult:@{} error:error];
       }
     } else if (result) {
+      [weakSelf handleUserSwitchIfNeededWithResult:result];
       [weakSelf storeLaunchResultIfNeeded:result];
       weakSelf.launchResult = result;
       [weakSelf executeRestoreBlocksWithResult:result.entitlements error:error];
@@ -1243,6 +1248,24 @@ static NSString * const kUserDefaultsSuiteName = @"qonversion.product-center.sui
   self.entitlements = nil;
   [self.persistentStorage removeObjectForKey:kKeyQUserDefaultsPermissions];
   [self.persistentStorage removeObjectForKey:kKeyQUserDefaultsPermissionsTimestamp];
+}
+
+- (void)handleUserSwitchIfNeededWithResult:(QONLaunchResult *)result {
+  if (!result || result.uid.length == 0) {
+    return;
+  }
+
+  NSString *currentUserID = [self.userInfoService obtainUserID];
+  if ([currentUserID isEqualToString:result.uid]) {
+    return;
+  }
+
+  QONVERSION_LOG(@"🔄 Restore: user switch detected from %@ to %@", currentUserID, result.uid);
+
+  [self.userInfoService storeIdentity:result.uid];
+  [[QNAPIClient shared] setUserID:result.uid];
+  [self.remoteConfigManager userHasBeenChanged];
+  [self resetActualPermissionsCache];
 }
 
 // MARK: - Move to separate file


### PR DESCRIPTION
## Summary

- Added `handleUserSwitchIfNeededWithResult:` to `QNProductCenterManager` which detects when a restore response returns a different user ID than the locally stored one
- When a user switch is detected, the SDK updates the local identity (`storeIdentity:`), sets the API client user ID, notifies the remote config manager, and clears the entitlements cache
- The user switch check is invoked in both restore flows:
  - `restoreReceipt:` (receipt-based restore via `launchWithTrigger:QONRequestTriggerRestore`)
  - `handleRestoreCompletedTransactionsFinished` (StoreKit transaction-based restore via `restoreTransactions:`)

## Test plan

- [x] Unit test: same uid → no user switch occurs
- [x] Unit test: different uid → `storeIdentity:`, `setUserID:`, and `userHasBeenChanged` are called
- [x] Unit test: nil result → no crash, no user switch
- [x] Unit test: empty uid → no user switch
- [x] Manual test: reinstall app → restore → verify original user ID is returned and SDK updates locally
- [x] Verify no regressions in existing restore flows (same user case)
