### PR TITLE
feat: add QPurchaseResult to QONEntitlementsUpdateListener (SUP-292)

### DIFF
--- a/Qonversion.xcodeproj/project.pbxproj
+++ b/Qonversion.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		45FFA2E024BE1549007EFB8F /* broken_data.json in Resources */ = {isa = PBXBuildFile; fileRef = 45FFA2DF24BE1548007EFB8F /* broken_data.json */; };
 		45FFA2EB24BEEA9A007EFB8F /* ProductCenterManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 45FFA2EA24BEEA9A007EFB8F /* ProductCenterManagerTests.m */; };
 		AA0001012D5B0A0000000001 /* ProductCenterManagerRestoreUserSwitchTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA0001002D5B0A0000000001 /* ProductCenterManagerRestoreUserSwitchTests.m */; };
+		AA0002012D5B0A0000000001 /* EntitlementsUpdateListenerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA0002002D5B0A0000000001 /* EntitlementsUpdateListenerTests.m */; };
 		45FFA2ED24BEF379007EFB8F /* full_init.json in Resources */ = {isa = PBXBuildFile; fileRef = 45FFA2EC24BEF379007EFB8F /* full_init.json */; };
 		6A121DAC2BB445AE0073B330 /* QONRemoteConfigList.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A121DAB2BB445AE0073B330 /* QONRemoteConfigList.m */; };
 		6A121DAE2BB446740073B330 /* QONRemoteConfigList.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A121DAD2BB446740073B330 /* QONRemoteConfigList.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -379,6 +380,7 @@
 		45FFA2DF24BE1548007EFB8F /* broken_data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = broken_data.json; sourceTree = "<group>"; };
 		45FFA2EA24BEEA9A007EFB8F /* ProductCenterManagerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ProductCenterManagerTests.m; sourceTree = "<group>"; };
 		AA0001002D5B0A0000000001 /* ProductCenterManagerRestoreUserSwitchTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ProductCenterManagerRestoreUserSwitchTests.m; sourceTree = "<group>"; };
+		AA0002002D5B0A0000000001 /* EntitlementsUpdateListenerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EntitlementsUpdateListenerTests.m; sourceTree = "<group>"; };
 		45FFA2EC24BEF379007EFB8F /* full_init.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = full_init.json; sourceTree = "<group>"; };
 		6A121DAB2BB445AE0073B330 /* QONRemoteConfigList.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QONRemoteConfigList.m; sourceTree = "<group>"; };
 		6A121DAD2BB446740073B330 /* QONRemoteConfigList.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = QONRemoteConfigList.h; sourceTree = "<group>"; };
@@ -816,6 +818,7 @@
 				45FFA2DD24BE1015007EFB8F /* QNTestConstants.m */,
 				45FFA2EA24BEEA9A007EFB8F /* ProductCenterManagerTests.m */,
 				AA0001002D5B0A0000000001 /* ProductCenterManagerRestoreUserSwitchTests.m */,
+				AA0002002D5B0A0000000001 /* EntitlementsUpdateListenerTests.m */,
 			);
 			path = QonversionTests;
 			sourceTree = "<group>";
@@ -2355,6 +2358,7 @@
 				459DAC0D243E4D610011ECF3 /* XCTestCase+TestJSON.m in Sources */,
 				45FFA2EB24BEEA9A007EFB8F /* ProductCenterManagerTests.m in Sources */,
 				AA0001012D5B0A0000000001 /* ProductCenterManagerRestoreUserSwitchTests.m in Sources */,
+				AA0002012D5B0A0000000001 /* EntitlementsUpdateListenerTests.m in Sources */,
 				89673C2926F35D29008D209A /* QNIdentityServiceTests.m in Sources */,
 				89A192A52604974800C3FCD9 /* QNUserInfoServiceTests.m in Sources */,
 				454BE21B247C2F0E001FE771 /* QInMemoryStorageTests.m in Sources */,

--- a/QonversionTests/EntitlementsUpdateListenerTests.m
+++ b/QonversionTests/EntitlementsUpdateListenerTests.m
@@ -1,0 +1,150 @@
+#import <XCTest/XCTest.h>
+#import <OCMock/OCMock.h>
+#import "QNProductCenterManager.h"
+#import "QNAPIClient.h"
+#import "QNStoreKitService.h"
+#import "QNTestConstants.h"
+#import "QONLaunchResult.h"
+#import "QNUserInfoService.h"
+#import "QNIdentityManager.h"
+#import "QNLocalStorage.h"
+#import "QONFallbackService.h"
+#import "QONEntitlementsUpdateListener.h"
+#import "QONPurchaseResult.h"
+#import "QONEntitlement.h"
+
+@interface QNProductCenterManager (ListenerTestPrivate)
+
+@property (nonatomic, weak) id<QONEntitlementsUpdateListener> purchasesDelegate;
+
+@end
+
+// MARK: - Mock listener implementing ONLY the old method (backward compat)
+@interface MockOldEntitlementsListener : NSObject <QONEntitlementsUpdateListener>
+
+@property (nonatomic, strong) NSDictionary<NSString *, QONEntitlement *> *receivedEntitlements;
+@property (nonatomic, assign) BOOL didReceiveCalled;
+
+@end
+
+@implementation MockOldEntitlementsListener
+
+- (void)didReceiveUpdatedEntitlements:(NSDictionary<NSString *, QONEntitlement *> *)entitlements {
+  self.receivedEntitlements = entitlements;
+  self.didReceiveCalled = YES;
+}
+
+@end
+
+// MARK: - Mock listener implementing the NEW method with purchaseResult
+@interface MockNewEntitlementsListener : NSObject <QONEntitlementsUpdateListener>
+
+@property (nonatomic, strong) NSDictionary<NSString *, QONEntitlement *> *receivedEntitlements;
+@property (nonatomic, strong) QONPurchaseResult *receivedPurchaseResult;
+@property (nonatomic, assign) BOOL oldMethodCalled;
+@property (nonatomic, assign) BOOL newMethodCalled;
+
+@end
+
+@implementation MockNewEntitlementsListener
+
+- (void)didReceiveUpdatedEntitlements:(NSDictionary<NSString *, QONEntitlement *> *)entitlements {
+  self.oldMethodCalled = YES;
+}
+
+- (void)didReceiveUpdatedEntitlements:(NSDictionary<NSString *, QONEntitlement *> *)entitlements
+                       purchaseResult:(QONPurchaseResult *)purchaseResult {
+  self.receivedEntitlements = entitlements;
+  self.receivedPurchaseResult = purchaseResult;
+  self.newMethodCalled = YES;
+}
+
+@end
+
+// MARK: - Tests
+
+@interface EntitlementsUpdateListenerTests : XCTestCase
+
+@property (nonatomic, strong) QNProductCenterManager *manager;
+
+@end
+
+@implementation EntitlementsUpdateListenerTests
+
+- (void)setUp {
+  id mockUserInfoService = OCMClassMock([QNUserInfoService class]);
+  id mockIdentityManager = OCMClassMock([QNIdentityManager class]);
+  id mockLocalStorage = OCMProtocolMock(@protocol(QNLocalStorage));
+  id mockFallbackService = OCMClassMock([QONFallbackService class]);
+  _manager = [[QNProductCenterManager alloc] initWithUserInfoService:mockUserInfoService
+                                                     identityManager:mockIdentityManager
+                                                        localStorage:mockLocalStorage
+                                                     fallbackService:mockFallbackService];
+}
+
+- (void)tearDown {
+  _manager = nil;
+}
+
+#pragma mark - Protocol Conformance Tests
+
+- (void)testOldListenerConformsToProtocol {
+  MockOldEntitlementsListener *listener = [MockOldEntitlementsListener new];
+  XCTAssertTrue([listener conformsToProtocol:@protocol(QONEntitlementsUpdateListener)]);
+}
+
+- (void)testNewListenerConformsToProtocol {
+  MockNewEntitlementsListener *listener = [MockNewEntitlementsListener new];
+  XCTAssertTrue([listener conformsToProtocol:@protocol(QONEntitlementsUpdateListener)]);
+}
+
+#pragma mark - Old Listener (backward compatibility)
+
+- (void)testOldListenerReceivesEntitlements {
+  MockOldEntitlementsListener *listener = [MockOldEntitlementsListener new];
+  NSDictionary *entitlements = @{};
+
+  [listener didReceiveUpdatedEntitlements:entitlements];
+
+  XCTAssertTrue(listener.didReceiveCalled);
+  XCTAssertEqualObjects(listener.receivedEntitlements, entitlements);
+}
+
+- (void)testOldListenerDoesNotRespondToNewSelector {
+  MockOldEntitlementsListener *listener = [MockOldEntitlementsListener new];
+
+  BOOL respondsToNew = [listener respondsToSelector:@selector(didReceiveUpdatedEntitlements:purchaseResult:)];
+  XCTAssertFalse(respondsToNew);
+}
+
+#pragma mark - New Listener
+
+- (void)testNewListenerRespondsToNewSelector {
+  MockNewEntitlementsListener *listener = [MockNewEntitlementsListener new];
+
+  BOOL respondsToNew = [listener respondsToSelector:@selector(didReceiveUpdatedEntitlements:purchaseResult:)];
+  XCTAssertTrue(respondsToNew);
+}
+
+- (void)testNewListenerReceivesEntitlementsAndPurchaseResult {
+  MockNewEntitlementsListener *listener = [MockNewEntitlementsListener new];
+  NSDictionary *entitlements = @{};
+
+  [listener didReceiveUpdatedEntitlements:entitlements purchaseResult:nil];
+
+  XCTAssertTrue(listener.newMethodCalled);
+  XCTAssertFalse(listener.oldMethodCalled);
+  XCTAssertEqualObjects(listener.receivedEntitlements, entitlements);
+  XCTAssertNil(listener.receivedPurchaseResult);
+}
+
+#pragma mark - Delegate Assignment
+
+- (void)testSetEntitlementsUpdateListenerAssignsDelegate {
+  MockOldEntitlementsListener *listener = [MockOldEntitlementsListener new];
+  [_manager setEntitlementsUpdateListener:listener];
+
+  XCTAssertEqualObjects(_manager.purchasesDelegate, listener);
+}
+
+@end

--- a/Sample/Views/EntitlementsView.swift
+++ b/Sample/Views/EntitlementsView.swift
@@ -126,6 +126,15 @@ class EntitlementsListenerHandler: NSObject, Qonversion.EntitlementsUpdateListen
             appState?.entitlements = entitlements
         }
     }
+
+    func didReceiveUpdatedEntitlements(_ entitlements: [String: Qonversion.Entitlement], purchaseResult: Qonversion.PurchaseResult?) {
+        Task { @MainActor in
+            appState?.entitlements = entitlements
+            if let purchaseResult, purchaseResult.isSuccessful, entitlements.isEmpty {
+                appState?.successMessage = "Consumable purchase completed in background"
+            }
+        }
+    }
 }
 
 // MARK: - Action Button

--- a/Sources/Qonversion/Public/QONEntitlementsUpdateListener.h
+++ b/Sources/Qonversion/Public/QONEntitlementsUpdateListener.h
@@ -9,9 +9,22 @@
 #import <Foundation/Foundation.h>
 #import "QONEntitlement.h"
 
+@class QONPurchaseResult;
+
 NS_SWIFT_NAME(Qonversion.EntitlementsUpdateListener)
 @protocol QONEntitlementsUpdateListener <NSObject>
 
+/// Called when user entitlements are updated asynchronously (e.g. deferred purchases, SCA, Ask to Buy).
 - (void)didReceiveUpdatedEntitlements:(NSDictionary<NSString *, QONEntitlement *>  * _Nonnull)entitlements;
+
+@optional
+
+/// Called when user entitlements are updated asynchronously with associated purchase result.
+/// For consumable purchases that complete in the background, entitlements may be empty
+/// while purchaseResult contains the purchase details.
+/// @param entitlements all current entitlements of the user.
+/// @param purchaseResult the purchase result associated with this update, if available.
+- (void)didReceiveUpdatedEntitlements:(NSDictionary<NSString *, QONEntitlement *>  * _Nonnull)entitlements
+                       purchaseResult:(QONPurchaseResult * _Nullable)purchaseResult;
 
 @end

--- a/Sources/Qonversion/Qonversion/Main/QNProductCenterManager/QNProductCenterManager.m
+++ b/Sources/Qonversion/Qonversion/Main/QNProductCenterManager/QNProductCenterManager.m
@@ -1052,18 +1052,30 @@ static NSString * const kUserDefaultsSuiteName = @"qonversion.product-center.sui
           }
         } else {
           NSDictionary<NSString *, QONEntitlement *> *resultEntitlements = launchResult.entitlements;
+          QONPurchaseResult *listenerPurchaseResult;
           if (resultError) {
             if ([weakSelf shouldCalculateEntitlementsForError:resultError]) {
               resultEntitlements = [weakSelf calculateEntitlementsForTransactions:@[transaction] products:@[product]];
-              [weakSelf.purchasesDelegate didReceiveUpdatedEntitlements:resultEntitlements];
+              listenerPurchaseResult = [QONPurchaseResult successFromFallbackWithEntitlements:resultEntitlements transaction:transaction];
+              [weakSelf notifyEntitlementsUpdateListener:resultEntitlements purchaseResult:listenerPurchaseResult];
             }
           } else {
-            [weakSelf.purchasesDelegate didReceiveUpdatedEntitlements:resultEntitlements];
+            listenerPurchaseResult = [QONPurchaseResult successWithEntitlements:resultEntitlements transaction:transaction];
+            [weakSelf notifyEntitlementsUpdateListener:resultEntitlements purchaseResult:listenerPurchaseResult];
           }
         }
       }
     }];
   }];
+}
+
+- (void)notifyEntitlementsUpdateListener:(NSDictionary<NSString *, QONEntitlement *> *)entitlements
+                          purchaseResult:(QONPurchaseResult *)purchaseResult {
+  if ([self.purchasesDelegate respondsToSelector:@selector(didReceiveUpdatedEntitlements:purchaseResult:)]) {
+    [self.purchasesDelegate didReceiveUpdatedEntitlements:entitlements purchaseResult:purchaseResult];
+  } else {
+    [self.purchasesDelegate didReceiveUpdatedEntitlements:entitlements];
+  }
 }
 
 - (BOOL)shouldCalculateEntitlementsForError:(NSError *)error {


### PR DESCRIPTION
## Summary
- Add `@optional` method `didReceiveUpdatedEntitlements:purchaseResult:` to `QONEntitlementsUpdateListener` protocol
- Update 2 call sites in `QNProductCenterManager` to dispatch via `respondsToSelector:` — new method gets `QONPurchaseResult`, old method works unchanged
- Update sample app to demonstrate the new listener method
- Add unit tests for protocol conformance and selector dispatch

## Context
iOS parity with Android SDK PR #769. For deferred/background purchases (consumables, SCA, Ask to Buy), the listener now receives the `QONPurchaseResult` alongside entitlements, allowing developers to access purchase details even when entitlements are empty.

**Non-breaking**: Uses `@optional` protocol method — existing implementations continue to work without code changes.

**Linear**: SUP-292
**Related**: [Android PR #769](https://github.com/qonversion/android-sdk/pull/769)

## Test plan
- [x] Unit tests for old listener (backward compat) and new listener (with purchaseResult)
- [x] Framework builds (`Qonversion-iOS` scheme)
- [ ] CI: full test suite passes
- [ ] Verify Sample app entitlements listener works with new method

🤖 Generated with [Claude Code](https://claude.com/claude-code)