### PR TITLE
fix: improve screen events reliability - fix deadlock, flush on close, handle 2xx/4xx, add event_uid

### DIFF
--- a/Sources/NoCodes/NetworkLayer/RequestProcessor/RequestProcessor.swift
+++ b/Sources/NoCodes/NetworkLayer/RequestProcessor/RequestProcessor.swift
@@ -63,7 +63,7 @@ class RequestProcessor: RequestProcessorInterface {
       throw error!
     }
     
-    if responseCode == ResponseCode.noContent.rawValue && T.self is EmptyApiResponse.Type {
+    if T.self is EmptyApiResponse.Type && (ResponseCode.successMin.rawValue...ResponseCode.successMax.rawValue).contains(responseCode) && responseBody.isEmpty {
       return EmptyApiResponse() as! T
     }
     

--- a/Sources/NoCodes/NoCodesViewController.swift
+++ b/Sources/NoCodes/NoCodesViewController.swift
@@ -226,6 +226,7 @@ final class NoCodesViewController: UIViewController {
         "happened_at": Int(Date().timeIntervalSince1970)
       ])
       screenEventsService?.track(event: event)
+      screenEventsService?.flush()
     }
   }
 
@@ -316,6 +317,7 @@ extension NoCodesViewController {
       "happened_at": Int(Date().timeIntervalSince1970)
     ])
     screenEventsService.track(event: event)
+    screenEventsService.flush()
   }
 
   private var isModalPresentation: Bool {

--- a/Sources/NoCodes/Services/ScreenEventsService.swift
+++ b/Sources/NoCodes/Services/ScreenEventsService.swift
@@ -38,12 +38,18 @@ final class ScreenEventsService: ScreenEventsServiceInterface {
   }
 
   func track(event: ScreenEvent) {
+    var data = event.data
+    if data["event_uid"] == nil {
+      data["event_uid"] = UUID().uuidString
+    }
+    let enrichedEvent = ScreenEvent(data: data)
+
     var shouldFlush = false
     queue.sync(flags: .barrier) {
-      buffer.append(event)
+      buffer.append(enrichedEvent)
       shouldFlush = buffer.count >= Self.batchSize
     }
-    logger.debug("Tracked screen event: \(event.data["type"] ?? "unknown")")
+    logger.debug("Tracked screen event: \(enrichedEvent.data["type"] ?? "unknown")")
     if shouldFlush {
       flush()
     }
@@ -51,7 +57,7 @@ final class ScreenEventsService: ScreenEventsServiceInterface {
 
   func flush() {
     let eventsToSend: [ScreenEvent] = queue.sync(flags: .barrier) {
-      guard !isFlushing else { return [] }
+      guard !isFlushing, !buffer.isEmpty else { return [] }
       isFlushing = true
       let copy = buffer
       buffer.removeAll()
@@ -80,12 +86,22 @@ final class ScreenEventsService: ScreenEventsServiceInterface {
         queue.sync(flags: .barrier) { isFlushing = false }
       } catch {
         logger.error(LoggerInfoMessages.screenEventTrackingFailed.rawValue)
-        // Re-buffer events on failure so they can be retried on next flush
+        // Only rebuffer on transient errors (5xx / network). Don't retry 4xx (permanent).
+        let isTransient: Bool
+        if let noCodesError = error as? NoCodesError {
+          // .internal = 5xx server error → transient, worth retrying
+          isTransient = (noCodesError.type == .internal)
+        } else {
+          // Network error, timeout, etc. → transient
+          isTransient = true
+        }
+
         queue.sync(flags: .barrier) {
-          buffer.insert(contentsOf: eventsToSend, at: 0)
-          // Drop oldest events if buffer exceeds max size
-          if buffer.count > Self.maxBufferSize {
-            buffer = Array(buffer.suffix(Self.maxBufferSize))
+          if isTransient {
+            buffer.insert(contentsOf: eventsToSend, at: 0)
+            if buffer.count > Self.maxBufferSize {
+              buffer = Array(buffer.suffix(Self.maxBufferSize))
+            }
           }
           isFlushing = false
         }


### PR DESCRIPTION
## Summary
- **Fix 0 (CRITICAL)**: Fix `isFlushing` deadlock — `flush()` on empty buffer permanently locked the service. Guard now checks `!buffer.isEmpty` before setting `isFlushing = true`
- **Fix 2a**: Handle any 2xx with empty body as success for `EmptyApiResponse` (previously only 204 was handled)
- **Fix 2b**: Only rebuffer on transient errors (`.internal` = 5xx). 4xx permanent errors are discarded.
- **Fix 1**: Flush remaining events on screen close and in `deinit` fallback
- **Fix 3**: Generate UUID `event_uid` per event in `track()` for deduplication

## Context
Part of Screen Events Reliability initiative (5 repos). Ships with next SDK release (Phase B).

## Files changed
- `ScreenEventsService.swift` — deadlock fix, 4xx no-rebuffer, event_uid generation
- `RequestProcessor.swift` — handle any 2xx with empty body
- `NoCodesViewController.swift` — flush on screen close + deinit

## Test plan
- [ ] TC-0.1: flush() with empty buffer doesn't deadlock
- [ ] TC-0.2: rapid flush() calls don't deadlock
- [ ] TC-1.2: Events flushed on screen close (iOS)
- [ ] TC-2.3: No retry loop on 202 (iOS)
- [ ] TC-3.3: event_uid present in POST body (UUID format)