### PR TITLE
fix(ci/nocodes): restore iOS Simulator destination and production API URL

### DIFF
--- a/Sources/NoCodes/Assemblies/ServicesAssembly.swift
+++ b/Sources/NoCodes/Assemblies/ServicesAssembly.swift
@@ -11,7 +11,7 @@ import Foundation
 #if os(iOS)
 
 fileprivate enum StringConstants: String {
-  case baseURL = "https://main.api-gateway.stage.qmoons.me/"
+  case baseURL = "https://api2.qonversion.io/"
 }
 
 fileprivate enum ServicesConstants {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -116,8 +116,9 @@ def runTests(suite)
     workspace: "./#{PROJECT_NAME}.xcworkspace",
     scheme: PROJECT_SCHEME,
     only_testing: suite,
+    destination: "platform=iOS Simulator,name=iPhone 16 Pro",
     xcargs: "CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -allowProvisioningUpdates -allowProvisioningDeviceRegistration"
   }
-  
+
   run_tests(test_params)
 end


### PR DESCRIPTION
## Summary
- Restore iOS Simulator destination in Fastlane — tests were running on macOS since commit `a047f3a` (Jan 29), causing all integration tests to fail for 2 months
- Restore production NoCodes API URL (`api2.qonversion.io`) — commit `cb0e88e` (Mar 17) accidentally replaced it with staging (`main.api-gateway.stage.qmoons.me`)

⚠️ **Production impact:** NoCodes SDK in released versions (6.4.0+) sends screen requests to staging instead of production. Needs hotfix release.

## Test plan
- [x] CI integration tests pass: https://github.com/qonversion/qonversion-ios-sdk/actions/runs/23603103578 (38/38 tests, first success in 2 months)

Fixes DEV-700

🤖 Generated with [Claude Code](https://claude.com/claude-code)