### PR TITLE
iOS commitment metadata for 12-month-commitment subscriptions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -39,6 +39,7 @@ jobs:
       - name: SPM validation
         run: |
           swift build
+          swift test
   
   common-checks:
     runs-on: ubuntu-latest

--- a/Package.swift
+++ b/Package.swift
@@ -89,5 +89,9 @@ let package = Package(
                 ],
                 swiftSettings: [
                     .define("SWIFT_PACKAGE")
-                ])]
+                ]),
+              .testTarget(
+                name: "QonversionSwiftTests",
+                dependencies: ["QonversionSwift"],
+                path: "QonversionSwiftTests")]
 )

--- a/Qonversion.xcodeproj/project.pbxproj
+++ b/Qonversion.xcodeproj/project.pbxproj
@@ -16,7 +16,8 @@
 		3521C548C169154D45835C38 /* ScreenEventsServiceInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB17D0ADC1EB86E558F459FD /* ScreenEventsServiceInterface.swift */; };
 		405978D53C69C2F10939A4D4 /* NoCodesContextBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B82604A89181D262616958 /* NoCodesContextBuilder.swift */; };
 		4531CBC6245789D40022C422 /* QDeviceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4531CBC5245789D40022C422 /* QDeviceTests.m */; };
-		DEV906AA00000001AAAAAAAA /* QONTransactionCommitmentInfoTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DEV906AA00000002AAAAAAAA /* QONTransactionCommitmentInfoTests.m */; };
+		7DE906BB2E7B0001C0000003 /* QONTransactionCommitmentInfoTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7DE906A12E7B0001C0000003 /* QONTransactionCommitmentInfoTests.m */; };
+		7DE906BB2E7B0001C0000004 /* ProductCenterManagerCommitmentInfoTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7DE906A12E7B0001C0000004 /* ProductCenterManagerCommitmentInfoTests.m */; };
 		4531CBC824578D300022C422 /* Podfile in Resources */ = {isa = PBXBuildFile; fileRef = 4531CBC724578D300022C422 /* Podfile */; };
 		4531CBCB24581BD80022C422 /* QNUserInfoTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4531CBC92457F6E00022C422 /* QNUserInfoTests.m */; };
 		454BE21B247C2F0E001FE771 /* QInMemoryStorageTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 454BE21A247C2F0E001FE771 /* QInMemoryStorageTests.m */; };
@@ -86,8 +87,8 @@
 		700636152C12125900BB9F9C /* NSError+Sugare.m in Sources */ = {isa = PBXBuildFile; fileRef = 700636132C12125900BB9F9C /* NSError+Sugare.m */; };
 		700B9D4D2E742CBB0031B056 /* QONPurchaseResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 700B9D4C2E742CBB0031B056 /* QONPurchaseResult.m */; };
 		700B9D4E2E742CBB0031B056 /* QONPurchaseResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 700B9D4B2E742CBB0031B056 /* QONPurchaseResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DEV906BB00000001 /* QONTransactionCommitmentInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = DEV906AA00000001 /* QONTransactionCommitmentInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DEV906BB00000002 /* QONTransactionCommitmentInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = DEV906AA00000002 /* QONTransactionCommitmentInfo.m */; };
+		7DE906BB2E7B0001C0000001 /* QONTransactionCommitmentInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 7DE906A12E7B0001C0000001 /* QONTransactionCommitmentInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7DE906BB2E7B0001C0000002 /* QONTransactionCommitmentInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 7DE906A12E7B0001C0000002 /* QONTransactionCommitmentInfo.m */; };
 		700B9D502E742E5D0031B056 /* QONPurchaseResult+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 700B9D4F2E742E5D0031B056 /* QONPurchaseResult+Protected.h */; };
 		700EC173291277130032E205 /* QONExperimentGroup+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 700EC171291277130032E205 /* QONExperimentGroup+Protected.h */; };
 		701922732B10981200724926 /* QONSubscriptionPeriod.h in Headers */ = {isa = PBXBuildFile; fileRef = 701922712B10981200724926 /* QONSubscriptionPeriod.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -359,7 +360,8 @@
 		4502E457257FDF90006FC750 /* OCMock.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OCMock.framework; path = "../../../../Volumes/OCMock 3.7.1/iOS framework/OCMock.framework"; sourceTree = "<group>"; };
 		45239D6E2517CEB00085D0A8 /* QonversionFramework.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = QonversionFramework.h; sourceTree = "<group>"; };
 		4531CBC5245789D40022C422 /* QDeviceTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QDeviceTests.m; sourceTree = "<group>"; };
-		DEV906AA00000002AAAAAAAA /* QONTransactionCommitmentInfoTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QONTransactionCommitmentInfoTests.m; sourceTree = "<group>"; };
+		7DE906A12E7B0001C0000003 /* QONTransactionCommitmentInfoTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QONTransactionCommitmentInfoTests.m; sourceTree = "<group>"; };
+		7DE906A12E7B0001C0000004 /* ProductCenterManagerCommitmentInfoTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ProductCenterManagerCommitmentInfoTests.m; sourceTree = "<group>"; };
 		4531CBC724578D300022C422 /* Podfile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Podfile; sourceTree = "<group>"; };
 		4531CBC92457F6E00022C422 /* QNUserInfoTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QNUserInfoTests.m; sourceTree = "<group>"; };
 		454BE21A247C2F0E001FE771 /* QInMemoryStorageTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QInMemoryStorageTests.m; sourceTree = "<group>"; };
@@ -444,8 +446,8 @@
 		700636122C12125900BB9F9C /* NSError+Sugare.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSError+Sugare.h"; sourceTree = "<group>"; };
 		700636132C12125900BB9F9C /* NSError+Sugare.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSError+Sugare.m"; sourceTree = "<group>"; };
 		700B9D4B2E742CBB0031B056 /* QONPurchaseResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = QONPurchaseResult.h; sourceTree = "<group>"; };
-		DEV906AA00000001 /* QONTransactionCommitmentInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = QONTransactionCommitmentInfo.h; sourceTree = "<group>"; };
-		DEV906AA00000002 /* QONTransactionCommitmentInfo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QONTransactionCommitmentInfo.m; sourceTree = "<group>"; };
+		7DE906A12E7B0001C0000001 /* QONTransactionCommitmentInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = QONTransactionCommitmentInfo.h; sourceTree = "<group>"; };
+		7DE906A12E7B0001C0000002 /* QONTransactionCommitmentInfo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QONTransactionCommitmentInfo.m; sourceTree = "<group>"; };
 		700B9D4C2E742CBB0031B056 /* QONPurchaseResult.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QONPurchaseResult.m; sourceTree = "<group>"; };
 		700B9D4F2E742E5D0031B056 /* QONPurchaseResult+Protected.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "QONPurchaseResult+Protected.h"; sourceTree = "<group>"; };
 		700EC171291277130032E205 /* QONExperimentGroup+Protected.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "QONExperimentGroup+Protected.h"; sourceTree = "<group>"; };
@@ -834,7 +836,8 @@
 				459DAB79243E329F0011ECF3 /* Info.plist */,
 				4531CBC5245789D40022C422 /* QDeviceTests.m */,
 				4531CBC92457F6E00022C422 /* QNUserInfoTests.m */,
-				DEV906AA00000002AAAAAAAA /* QONTransactionCommitmentInfoTests.m */,
+				7DE906A12E7B0001C0000003 /* QONTransactionCommitmentInfoTests.m */,
+				7DE906A12E7B0001C0000004 /* ProductCenterManagerCommitmentInfoTests.m */,
 				454BE22C247C3EDC001FE771 /* QonversionPropertiesTests.m */,
 				4587136B24AB963100F4B418 /* QRequestSerializerTests.m */,
 				458A8CCA24B9A3DF00637130 /* StoreKitServiceTests.m */,
@@ -1342,8 +1345,8 @@
 				895731BF26DD03A2009507A6 /* QONEntitlement.h */,
 				70B917622B3314BD00BF0689 /* QONTransaction.h */,
 				70B917632B3314BD00BF0689 /* QONTransaction.m */,
-				DEV906AA00000001 /* QONTransactionCommitmentInfo.h */,
-				DEV906AA00000002 /* QONTransactionCommitmentInfo.m */,
+				7DE906A12E7B0001C0000001 /* QONTransactionCommitmentInfo.h */,
+				7DE906A12E7B0001C0000002 /* QONTransactionCommitmentInfo.m */,
 				895731C026DD03A2009507A6 /* QONLaunchResult.h */,
 				895731C126DD03A2009507A6 /* QONExperimentGroup.m */,
 				895731C326DD03A2009507A6 /* QONAutomations.m */,
@@ -1877,7 +1880,7 @@
 				8957330126DD03A3009507A6 /* QNUserInfoServiceInterface.h in Headers */,
 				895732C926DD03A3009507A6 /* QNInternalConstants.h in Headers */,
 				70B917642B3314BD00BF0689 /* QONTransaction.h in Headers */,
-				DEV906BB00000001 /* QONTransactionCommitmentInfo.h in Headers */,
+				7DE906BB2E7B0001C0000001 /* QONTransactionCommitmentInfo.h in Headers */,
 				8957328926DD03A3009507A6 /* QONProduct.h in Headers */,
 				702DBDEC2A3216C900D590D0 /* QONExperiment+Protected.h in Headers */,
 				70CB7CDD2C246DF200241FF1 /* QONPromotionalOffer.h in Headers */,
@@ -2281,7 +2284,7 @@
 				895732C626DD03A3009507A6 /* QNAPIConstants.m in Sources */,
 				6A21BF552AB205AC005BDA7C /* QONRequest.m in Sources */,
 				70B917652B3314BD00BF0689 /* QONTransaction.m in Sources */,
-				DEV906BB00000002 /* QONTransactionCommitmentInfo.m in Sources */,
+				7DE906BB2E7B0001C0000002 /* QONTransactionCommitmentInfo.m in Sources */,
 				70D05A8F29C9FC1600EA5DDF /* QONRemoteConfigManager.m in Sources */,
 				895732C426DD03A3009507A6 /* QNRequestBuilder.m in Sources */,
 				8957329726DD03A3009507A6 /* QONStoreKitSugare.m in Sources */,
@@ -2413,7 +2416,8 @@
 				454BE22D247C3EDC001FE771 /* QonversionPropertiesTests.m in Sources */,
 				458A8CCB24B9A3DF00637130 /* StoreKitServiceTests.m in Sources */,
 				4531CBC6245789D40022C422 /* QDeviceTests.m in Sources */,
-				DEV906AA00000001AAAAAAAA /* QONTransactionCommitmentInfoTests.m in Sources */,
+				7DE906BB2E7B0001C0000003 /* QONTransactionCommitmentInfoTests.m in Sources */,
+				7DE906BB2E7B0001C0000004 /* ProductCenterManagerCommitmentInfoTests.m in Sources */,
 				891DEA802703BA1B0079B439 /* QNErrorsMapperTests.m in Sources */,
 				89673C2F26F49BAA008D209A /* QNIdentityManagerTests.m in Sources */,
 				4531CBCB24581BD80022C422 /* QNUserInfoTests.m in Sources */,

--- a/Qonversion.xcodeproj/project.pbxproj
+++ b/Qonversion.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		3521C548C169154D45835C38 /* ScreenEventsServiceInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB17D0ADC1EB86E558F459FD /* ScreenEventsServiceInterface.swift */; };
 		405978D53C69C2F10939A4D4 /* NoCodesContextBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B82604A89181D262616958 /* NoCodesContextBuilder.swift */; };
 		4531CBC6245789D40022C422 /* QDeviceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4531CBC5245789D40022C422 /* QDeviceTests.m */; };
+		DEV906AA00000001AAAAAAAA /* QONTransactionCommitmentInfoTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DEV906AA00000002AAAAAAAA /* QONTransactionCommitmentInfoTests.m */; };
 		4531CBC824578D300022C422 /* Podfile in Resources */ = {isa = PBXBuildFile; fileRef = 4531CBC724578D300022C422 /* Podfile */; };
 		4531CBCB24581BD80022C422 /* QNUserInfoTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4531CBC92457F6E00022C422 /* QNUserInfoTests.m */; };
 		454BE21B247C2F0E001FE771 /* QInMemoryStorageTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 454BE21A247C2F0E001FE771 /* QInMemoryStorageTests.m */; };
@@ -358,6 +359,7 @@
 		4502E457257FDF90006FC750 /* OCMock.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OCMock.framework; path = "../../../../Volumes/OCMock 3.7.1/iOS framework/OCMock.framework"; sourceTree = "<group>"; };
 		45239D6E2517CEB00085D0A8 /* QonversionFramework.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = QonversionFramework.h; sourceTree = "<group>"; };
 		4531CBC5245789D40022C422 /* QDeviceTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QDeviceTests.m; sourceTree = "<group>"; };
+		DEV906AA00000002AAAAAAAA /* QONTransactionCommitmentInfoTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QONTransactionCommitmentInfoTests.m; sourceTree = "<group>"; };
 		4531CBC724578D300022C422 /* Podfile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Podfile; sourceTree = "<group>"; };
 		4531CBC92457F6E00022C422 /* QNUserInfoTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QNUserInfoTests.m; sourceTree = "<group>"; };
 		454BE21A247C2F0E001FE771 /* QInMemoryStorageTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QInMemoryStorageTests.m; sourceTree = "<group>"; };
@@ -832,6 +834,7 @@
 				459DAB79243E329F0011ECF3 /* Info.plist */,
 				4531CBC5245789D40022C422 /* QDeviceTests.m */,
 				4531CBC92457F6E00022C422 /* QNUserInfoTests.m */,
+				DEV906AA00000002AAAAAAAA /* QONTransactionCommitmentInfoTests.m */,
 				454BE22C247C3EDC001FE771 /* QonversionPropertiesTests.m */,
 				4587136B24AB963100F4B418 /* QRequestSerializerTests.m */,
 				458A8CCA24B9A3DF00637130 /* StoreKitServiceTests.m */,
@@ -2410,6 +2413,7 @@
 				454BE22D247C3EDC001FE771 /* QonversionPropertiesTests.m in Sources */,
 				458A8CCB24B9A3DF00637130 /* StoreKitServiceTests.m in Sources */,
 				4531CBC6245789D40022C422 /* QDeviceTests.m in Sources */,
+				DEV906AA00000001AAAAAAAA /* QONTransactionCommitmentInfoTests.m in Sources */,
 				891DEA802703BA1B0079B439 /* QNErrorsMapperTests.m in Sources */,
 				89673C2F26F49BAA008D209A /* QNIdentityManagerTests.m in Sources */,
 				4531CBCB24581BD80022C422 /* QNUserInfoTests.m in Sources */,

--- a/Qonversion.xcodeproj/project.pbxproj
+++ b/Qonversion.xcodeproj/project.pbxproj
@@ -85,6 +85,8 @@
 		700636152C12125900BB9F9C /* NSError+Sugare.m in Sources */ = {isa = PBXBuildFile; fileRef = 700636132C12125900BB9F9C /* NSError+Sugare.m */; };
 		700B9D4D2E742CBB0031B056 /* QONPurchaseResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 700B9D4C2E742CBB0031B056 /* QONPurchaseResult.m */; };
 		700B9D4E2E742CBB0031B056 /* QONPurchaseResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 700B9D4B2E742CBB0031B056 /* QONPurchaseResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DEV906BB00000001 /* QONTransactionCommitmentInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = DEV906AA00000001 /* QONTransactionCommitmentInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DEV906BB00000002 /* QONTransactionCommitmentInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = DEV906AA00000002 /* QONTransactionCommitmentInfo.m */; };
 		700B9D502E742E5D0031B056 /* QONPurchaseResult+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 700B9D4F2E742E5D0031B056 /* QONPurchaseResult+Protected.h */; };
 		700EC173291277130032E205 /* QONExperimentGroup+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 700EC171291277130032E205 /* QONExperimentGroup+Protected.h */; };
 		701922732B10981200724926 /* QONSubscriptionPeriod.h in Headers */ = {isa = PBXBuildFile; fileRef = 701922712B10981200724926 /* QONSubscriptionPeriod.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -440,6 +442,8 @@
 		700636122C12125900BB9F9C /* NSError+Sugare.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSError+Sugare.h"; sourceTree = "<group>"; };
 		700636132C12125900BB9F9C /* NSError+Sugare.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSError+Sugare.m"; sourceTree = "<group>"; };
 		700B9D4B2E742CBB0031B056 /* QONPurchaseResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = QONPurchaseResult.h; sourceTree = "<group>"; };
+		DEV906AA00000001 /* QONTransactionCommitmentInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = QONTransactionCommitmentInfo.h; sourceTree = "<group>"; };
+		DEV906AA00000002 /* QONTransactionCommitmentInfo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QONTransactionCommitmentInfo.m; sourceTree = "<group>"; };
 		700B9D4C2E742CBB0031B056 /* QONPurchaseResult.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QONPurchaseResult.m; sourceTree = "<group>"; };
 		700B9D4F2E742E5D0031B056 /* QONPurchaseResult+Protected.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "QONPurchaseResult+Protected.h"; sourceTree = "<group>"; };
 		700EC171291277130032E205 /* QONExperimentGroup+Protected.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "QONExperimentGroup+Protected.h"; sourceTree = "<group>"; };
@@ -1335,6 +1339,8 @@
 				895731BF26DD03A2009507A6 /* QONEntitlement.h */,
 				70B917622B3314BD00BF0689 /* QONTransaction.h */,
 				70B917632B3314BD00BF0689 /* QONTransaction.m */,
+				DEV906AA00000001 /* QONTransactionCommitmentInfo.h */,
+				DEV906AA00000002 /* QONTransactionCommitmentInfo.m */,
 				895731C026DD03A2009507A6 /* QONLaunchResult.h */,
 				895731C126DD03A2009507A6 /* QONExperimentGroup.m */,
 				895731C326DD03A2009507A6 /* QONAutomations.m */,
@@ -1868,6 +1874,7 @@
 				8957330126DD03A3009507A6 /* QNUserInfoServiceInterface.h in Headers */,
 				895732C926DD03A3009507A6 /* QNInternalConstants.h in Headers */,
 				70B917642B3314BD00BF0689 /* QONTransaction.h in Headers */,
+				DEV906BB00000001 /* QONTransactionCommitmentInfo.h in Headers */,
 				8957328926DD03A3009507A6 /* QONProduct.h in Headers */,
 				702DBDEC2A3216C900D590D0 /* QONExperiment+Protected.h in Headers */,
 				70CB7CDD2C246DF200241FF1 /* QONPromotionalOffer.h in Headers */,
@@ -2271,6 +2278,7 @@
 				895732C626DD03A3009507A6 /* QNAPIConstants.m in Sources */,
 				6A21BF552AB205AC005BDA7C /* QONRequest.m in Sources */,
 				70B917652B3314BD00BF0689 /* QONTransaction.m in Sources */,
+				DEV906BB00000002 /* QONTransactionCommitmentInfo.m in Sources */,
 				70D05A8F29C9FC1600EA5DDF /* QONRemoteConfigManager.m in Sources */,
 				895732C426DD03A3009507A6 /* QNRequestBuilder.m in Sources */,
 				8957329726DD03A3009507A6 /* QONStoreKitSugare.m in Sources */,

--- a/QonversionSwiftTests/CommitmentInfoParserTests.swift
+++ b/QonversionSwiftTests/CommitmentInfoParserTests.swift
@@ -1,0 +1,62 @@
+//
+//  CommitmentInfoParserTests.swift
+//  QonversionSwiftTests
+//
+//  Copyright © 2026 Qonversion Inc. All rights reserved.
+//
+
+import XCTest
+import Foundation
+@testable import QonversionSwift
+import Qonversion
+
+final class CommitmentInfoParserTests: XCTestCase {
+
+  // Apple's canonical decoded-transaction payload, taken from the `commitmentInfo` block of
+  // app-store-server-library's `signedTransaction.json`. `Transaction.jsonRepresentation`
+  // follows this same schema, so these are the exact keys/encodings the SDK sees in production:
+  // commitmentPrice is Int64 milliunits (119880 -> 119.88) and commitmentExpiresDate is epoch ms.
+  private let applePayload = """
+  {
+    "transactionId": "23456",
+    "productId": "com.example.product",
+    "price": 10990,
+    "currency": "USD",
+    "expiresDate": 1698149000000,
+    "billingPlanType": "MONTHLY",
+    "commitmentInfo": {
+      "billingPeriodNumber": 3,
+      "commitmentExpiresDate": 1698150000000,
+      "commitmentPrice": 119880,
+      "totalBillingPeriods": 12
+    }
+  }
+  """.data(using: .utf8)!
+
+  // Regression guard for DEV-906: the parser must decode Apple's real commitmentInfo keys.
+  // The original implementation read `price`/`expirationDate`, which are absent from Apple's
+  // schema, so the decode threw and commitmentInfo was silently always nil.
+  @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, visionOS 1.0, *)
+  func testParsesAppleCommitmentInfoSchema() throws {
+    let info = try XCTUnwrap(PurchasesMapper().parseCommitmentInfo(from: applePayload))
+
+    XCTAssertEqual(info.billingPeriodNumber, 3)
+    XCTAssertEqual(info.totalBillingPeriods, 12)
+    // 119880 milliunits -> 119.88 in currency units (the whole-commitment total).
+    XCTAssertEqual(info.commitmentPrice.doubleValue, 119.88, accuracy: 0.0001)
+    // 1698150000000 ms -> 1698150000 s (the whole-commitment expiry).
+    XCTAssertEqual(info.commitmentExpirationDate, Date(timeIntervalSince1970: 1698150000))
+  }
+
+  @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, visionOS 1.0, *)
+  func testReturnsNilWhenCommitmentBlockAbsent() {
+    let nonCommitment = #"{"transactionId":"1","productId":"p","price":9990}"#.data(using: .utf8)!
+    XCTAssertNil(PurchasesMapper().parseCommitmentInfo(from: nonCommitment))
+  }
+
+  @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, visionOS 1.0, *)
+  func testReturnsNilForMalformedJSON() {
+    let garbage = "not json".data(using: .utf8)!
+    XCTAssertNil(PurchasesMapper().parseCommitmentInfo(from: garbage))
+  }
+}

--- a/QonversionTests/ProductCenterManagerCommitmentInfoTests.m
+++ b/QonversionTests/ProductCenterManagerCommitmentInfoTests.m
@@ -80,8 +80,8 @@
     QONTransactionCommitmentInfo *info =
       [[QONTransactionCommitmentInfo alloc] initWithBillingPeriodNumber:4
                                                     totalBillingPeriods:12
-                                                  pricePerBillingPeriod:[NSDecimalNumber decimalNumberWithString:@"9.99"]
-                                     currentBillingPeriodExpirationDate:[NSDate dateWithTimeIntervalSince1970:1800000000]];
+                                                        commitmentPrice:[NSDecimalNumber decimalNumberWithString:@"9.99"]
+                                               commitmentExpirationDate:[NSDate dateWithTimeIntervalSince1970:1800000000]];
 
     QONStoreKit2PurchaseModel *model = [QONStoreKit2PurchaseModel new];
     model.transactionId = @"txn-1";
@@ -119,8 +119,8 @@
     QONTransactionCommitmentInfo *info =
       [[QONTransactionCommitmentInfo alloc] initWithBillingPeriodNumber:1
                                                     totalBillingPeriods:12
-                                                  pricePerBillingPeriod:[NSDecimalNumber decimalNumberWithString:@"4.99"]
-                                     currentBillingPeriodExpirationDate:[NSDate dateWithTimeIntervalSince1970:1900000000]];
+                                                        commitmentPrice:[NSDecimalNumber decimalNumberWithString:@"4.99"]
+                                               commitmentExpirationDate:[NSDate dateWithTimeIntervalSince1970:1900000000]];
 
     QONStoreKit2PurchaseModel *model = [QONStoreKit2PurchaseModel new];
     model.transactionId = @"txn-pending";

--- a/QonversionTests/ProductCenterManagerCommitmentInfoTests.m
+++ b/QonversionTests/ProductCenterManagerCommitmentInfoTests.m
@@ -1,0 +1,159 @@
+//
+//  ProductCenterManagerCommitmentInfoTests.m
+//  QonversionTests
+//
+//  Created by Qonversion on 2026.
+//  Copyright © 2026 Qonversion Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import <OCMock/OCMock.h>
+#import "QNProductCenterManager.h"
+#import "QNAPIClient.h"
+#import "QNUserInfoService.h"
+#import "QNIdentityManager.h"
+#import "QNLocalStorage.h"
+#import "QONFallbackService.h"
+#import "QONEntitlement.h"
+#import "QONTransaction.h"
+#import "QONTransaction+Protected.h"
+#import "QONTransactionCommitmentInfo.h"
+#import "QONStoreKit2PurchaseModel.h"
+
+@interface QNProductCenterManager (CommitmentInfoTests)
+@property (nonatomic, strong) NSMutableDictionary<NSString *, QONTransactionCommitmentInfo *> *commitmentInfoByTransactionId;
+- (void)cacheCommitmentInfoFromPurchaseModels:(NSArray<QONStoreKit2PurchaseModel *> *)purchaseModels;
+- (void)enrichEntitlementsWithCommitmentInfo:(NSDictionary<NSString *, QONEntitlement *> *)entitlements;
+@end
+
+@interface ProductCenterManagerCommitmentInfoTests : XCTestCase
+@property (nonatomic) QNProductCenterManager *manager;
+@end
+
+@implementation ProductCenterManagerCommitmentInfoTests
+
+- (void)setUp {
+  [super setUp];
+  id userInfoService = OCMClassMock([QNUserInfoService class]);
+  id identityManager = OCMClassMock([QNIdentityManager class]);
+  id localStorage = OCMProtocolMock(@protocol(QNLocalStorage));
+  id fallbackService = OCMClassMock([QONFallbackService class]);
+  _manager = [[QNProductCenterManager alloc] initWithUserInfoService:userInfoService
+                                                     identityManager:identityManager
+                                                        localStorage:localStorage
+                                                     fallbackService:fallbackService];
+}
+
+- (void)tearDown {
+  _manager = nil;
+  [super tearDown];
+}
+
+#pragma mark - Helpers
+
+- (QONTransaction *)makeTransactionWithId:(NSString *)transactionId {
+  return [[QONTransaction alloc] initWithOriginalTransactionId:transactionId
+                                                 transactionId:transactionId
+                                                     offerCode:nil
+                                               transactionDate:[NSDate date]
+                                                expirationDate:nil
+                                     transactionRevocationDate:nil
+                                                  promoOfferId:nil
+                                                   environment:QONTransactionEnvironmentProduction
+                                                 ownershipType:QONTransactionOwnershipTypeOwner
+                                                          type:QONTransactionTypeSubscriptionRenewed];
+}
+
+- (QONEntitlement *)makeEntitlementWithTransactions:(NSArray<QONTransaction *> *)transactions {
+  QONEntitlement *entitlement = [[QONEntitlement alloc] init];
+  entitlement.entitlementID = @"premium";
+  entitlement.productID = @"monthly_with_commitment";
+  entitlement.transactions = transactions;
+  return entitlement;
+}
+
+#pragma mark - Tests
+
+- (void)testCacheAndEnrichmentAppliesCommitmentInfoOnce {
+  if (@available(iOS 26.4, macOS 26.4, watchOS 26.4, tvOS 26.4, visionOS 26.4, *)) {
+    // Given a purchase model carrying commitment info for transaction "txn-1"
+    QONTransactionCommitmentInfo *info =
+      [[QONTransactionCommitmentInfo alloc] initWithBillingPeriodNumber:4
+                                                    totalBillingPeriods:12
+                                                  pricePerBillingPeriod:[NSDecimalNumber decimalNumberWithString:@"9.99"]
+                                     currentBillingPeriodExpirationDate:[NSDate dateWithTimeIntervalSince1970:1800000000]];
+
+    QONStoreKit2PurchaseModel *model = [QONStoreKit2PurchaseModel new];
+    model.transactionId = @"txn-1";
+    model.commitmentInfo = info;
+
+    // And an entitlement that holds a server-built QONTransaction with the same id
+    QONTransaction *txn = [self makeTransactionWithId:@"txn-1"];
+    QONEntitlement *entitlement = [self makeEntitlementWithTransactions:@[txn]];
+    NSDictionary<NSString *, QONEntitlement *> *entitlements = @{@"premium": entitlement};
+
+    // When the manager caches the SK2-side commitment info and then enriches entitlements
+    [_manager cacheCommitmentInfoFromPurchaseModels:@[model]];
+    XCTAssertEqualObjects(_manager.commitmentInfoByTransactionId[@"txn-1"], info);
+
+    [_manager enrichEntitlementsWithCommitmentInfo:entitlements];
+
+    // Then the transaction is enriched and the cache entry is consumed (one-shot)
+    XCTAssertEqualObjects(txn.commitmentInfo, info);
+    XCTAssertNil(_manager.commitmentInfoByTransactionId[@"txn-1"]);
+    XCTAssertEqual(_manager.commitmentInfoByTransactionId.count, (NSUInteger)0);
+
+    // And a second enrichment pass is a no-op (idempotent / no double-apply)
+    txn.commitmentInfo = nil;
+    [_manager enrichEntitlementsWithCommitmentInfo:entitlements];
+    XCTAssertNil(txn.commitmentInfo);
+  } else {
+    XCTSkip(@"Requires iOS 26.4+");
+  }
+}
+
+- (void)testEnrichmentLeavesCacheEntryWhenTransactionNotInEntitlements {
+  if (@available(iOS 26.4, macOS 26.4, watchOS 26.4, tvOS 26.4, visionOS 26.4, *)) {
+    // Given a cached commitment info for "txn-pending" that the backend has not yet
+    // surfaced through entitlements (typical post-purchase / pre-launch window)
+    QONTransactionCommitmentInfo *info =
+      [[QONTransactionCommitmentInfo alloc] initWithBillingPeriodNumber:1
+                                                    totalBillingPeriods:12
+                                                  pricePerBillingPeriod:[NSDecimalNumber decimalNumberWithString:@"4.99"]
+                                     currentBillingPeriodExpirationDate:[NSDate dateWithTimeIntervalSince1970:1900000000]];
+
+    QONStoreKit2PurchaseModel *model = [QONStoreKit2PurchaseModel new];
+    model.transactionId = @"txn-pending";
+    model.commitmentInfo = info;
+    [_manager cacheCommitmentInfoFromPurchaseModels:@[model]];
+
+    // And an entitlements snapshot that only contains "txn-other"
+    QONTransaction *otherTxn = [self makeTransactionWithId:@"txn-other"];
+    QONEntitlement *entitlement = [self makeEntitlementWithTransactions:@[otherTxn]];
+
+    // When we enrich
+    [_manager enrichEntitlementsWithCommitmentInfo:@{@"premium": entitlement}];
+
+    // Then "txn-other" is untouched and the cached info is preserved for the next pass
+    XCTAssertNil(otherTxn.commitmentInfo);
+    XCTAssertEqualObjects(_manager.commitmentInfoByTransactionId[@"txn-pending"], info);
+  } else {
+    XCTSkip(@"Requires iOS 26.4+");
+  }
+}
+
+- (void)testCacheIgnoresPurchaseModelsWithoutCommitmentInfo {
+  if (@available(iOS 26.4, macOS 26.4, watchOS 26.4, tvOS 26.4, visionOS 26.4, *)) {
+    QONStoreKit2PurchaseModel *bare = [QONStoreKit2PurchaseModel new];
+    bare.transactionId = @"txn-bare";
+    // bare.commitmentInfo intentionally nil
+
+    [_manager cacheCommitmentInfoFromPurchaseModels:@[bare]];
+
+    XCTAssertEqual(_manager.commitmentInfoByTransactionId.count, (NSUInteger)0);
+  } else {
+    XCTSkip(@"Requires iOS 26.4+");
+  }
+}
+
+@end

--- a/QonversionTests/QONTransactionCommitmentInfoTests.m
+++ b/QonversionTests/QONTransactionCommitmentInfoTests.m
@@ -21,13 +21,13 @@
   QONTransactionCommitmentInfo *info = [[QONTransactionCommitmentInfo alloc]
     initWithBillingPeriodNumber:4
     totalBillingPeriods:12
-    pricePerBillingPeriod:price
-    currentBillingPeriodExpirationDate:expirationDate];
+    commitmentPrice:price
+    commitmentExpirationDate:expirationDate];
 
   XCTAssertEqual(info.billingPeriodNumber, (NSUInteger)4);
   XCTAssertEqual(info.totalBillingPeriods, (NSUInteger)12);
-  XCTAssertEqualObjects(info.pricePerBillingPeriod, price);
-  XCTAssertEqualObjects(info.currentBillingPeriodExpirationDate, expirationDate);
+  XCTAssertEqualObjects(info.commitmentPrice, price);
+  XCTAssertEqualObjects(info.commitmentExpirationDate, expirationDate);
 }
 
 - (void)testQONTransactionCommitmentInfo_NSCoding_roundtrip {
@@ -37,8 +37,8 @@
   QONTransactionCommitmentInfo *original = [[QONTransactionCommitmentInfo alloc]
     initWithBillingPeriodNumber:2
     totalBillingPeriods:6
-    pricePerBillingPeriod:price
-    currentBillingPeriodExpirationDate:expirationDate];
+    commitmentPrice:price
+    commitmentExpirationDate:expirationDate];
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -49,8 +49,8 @@
   XCTAssertNotNil(decoded);
   XCTAssertEqual(decoded.billingPeriodNumber, (NSUInteger)2);
   XCTAssertEqual(decoded.totalBillingPeriods, (NSUInteger)6);
-  XCTAssertEqualObjects(decoded.pricePerBillingPeriod, price);
-  XCTAssertEqualObjects(decoded.currentBillingPeriodExpirationDate, expirationDate);
+  XCTAssertEqualObjects(decoded.commitmentPrice, price);
+  XCTAssertEqualObjects(decoded.commitmentExpirationDate, expirationDate);
 }
 
 @end

--- a/QonversionTests/QONTransactionCommitmentInfoTests.m
+++ b/QonversionTests/QONTransactionCommitmentInfoTests.m
@@ -1,0 +1,56 @@
+//
+//  QONTransactionCommitmentInfoTests.m
+//  QonversionTests
+//
+//  Created by Qonversion on 2026.
+//  Copyright © 2026 Qonversion Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "QONTransactionCommitmentInfo.h"
+
+@interface QONTransactionCommitmentInfoTests : XCTestCase
+@end
+
+@implementation QONTransactionCommitmentInfoTests
+
+- (void)testQONTransactionCommitmentInfo_init_setsAllFields {
+  NSDecimalNumber *price = [NSDecimalNumber decimalNumberWithString:@"9.99"];
+  NSDate *expirationDate = [NSDate dateWithTimeIntervalSince1970:1800000000];
+
+  QONTransactionCommitmentInfo *info = [[QONTransactionCommitmentInfo alloc]
+    initWithBillingPeriodNumber:4
+    totalBillingPeriods:12
+    pricePerBillingPeriod:price
+    currentBillingPeriodExpirationDate:expirationDate];
+
+  XCTAssertEqual(info.billingPeriodNumber, (NSUInteger)4);
+  XCTAssertEqual(info.totalBillingPeriods, (NSUInteger)12);
+  XCTAssertEqualObjects(info.pricePerBillingPeriod, price);
+  XCTAssertEqualObjects(info.currentBillingPeriodExpirationDate, expirationDate);
+}
+
+- (void)testQONTransactionCommitmentInfo_NSCoding_roundtrip {
+  NSDecimalNumber *price = [NSDecimalNumber decimalNumberWithString:@"4.99"];
+  NSDate *expirationDate = [NSDate dateWithTimeIntervalSince1970:2000000000];
+
+  QONTransactionCommitmentInfo *original = [[QONTransactionCommitmentInfo alloc]
+    initWithBillingPeriodNumber:2
+    totalBillingPeriods:6
+    pricePerBillingPeriod:price
+    currentBillingPeriodExpirationDate:expirationDate];
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  NSData *data = [NSKeyedArchiver archivedDataWithRootObject:original];
+  QONTransactionCommitmentInfo *decoded = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+#pragma clang diagnostic pop
+
+  XCTAssertNotNil(decoded);
+  XCTAssertEqual(decoded.billingPeriodNumber, (NSUInteger)2);
+  XCTAssertEqual(decoded.totalBillingPeriods, (NSUInteger)6);
+  XCTAssertEqualObjects(decoded.pricePerBillingPeriod, price);
+  XCTAssertEqualObjects(decoded.currentBillingPeriodExpirationDate, expirationDate);
+}
+
+@end

--- a/Sources/Qonversion/Public/QONStoreKit2PurchaseModel.h
+++ b/Sources/Qonversion/Public/QONStoreKit2PurchaseModel.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "QONTransactionCommitmentInfo.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -32,6 +33,13 @@ NS_SWIFT_NAME(Qonversion.StoreKit2PurchaseModel)
 @property (nonatomic, copy, nullable) NSString *promoOfferPeriodNumberOfUnits;
 @property (nonatomic, copy, nullable) NSString *promoOfferPaymentMode;
 @property (nonatomic, copy, nullable) NSString *storefrontCountryCode;
+
+/**
+ Commitment info parsed from the local StoreKit2 transaction (iOS 26.4+).
+ Populated in PurchasesMapper from Transaction.jsonRepresentation and forwarded to
+ QONTransaction once the Qonversion backend includes commitment data in transaction responses.
+ */
+@property (nonatomic, strong, nullable) QONTransactionCommitmentInfo *commitmentInfo API_AVAILABLE(ios(26.4), macosx(26.4), watchos(26.4), tvos(26.4), visionos(26.4));
 
 @end
 

--- a/Sources/Qonversion/Public/QONStoreKit2PurchaseModel.m
+++ b/Sources/Qonversion/Public/QONStoreKit2PurchaseModel.m
@@ -32,8 +32,11 @@
   [description appendFormat:@"promoOfferPeriodNumberOfUnits=%@,\n", self.promoOfferPeriodNumberOfUnits];
   [description appendFormat:@"promoOfferPaymentMode=%@,\n", self.promoOfferPaymentMode];
   [description appendFormat:@"storefrontCountryCode=%@,\n", self.storefrontCountryCode];
+  if (@available(iOS 26.4, macOS 26.4, watchOS 26.4, tvOS 26.4, visionOS 26.4, *)) {
+    [description appendFormat:@"commitmentInfo=%@,\n", self.commitmentInfo];
+  }
   [description appendString:@">"];
-  
+
   return [description copy];
 }
 

--- a/Sources/Qonversion/Public/QONTransaction.h
+++ b/Sources/Qonversion/Public/QONTransaction.h
@@ -87,6 +87,11 @@ NS_SWIFT_NAME(Qonversion.Transaction)
 /**
  Commitment information for subscriptions with a fixed-term billing commitment (e.g. a monthly price paid over 12 months).
  Non-nil only when the transaction is part of such a commitment. Requires iOS 26.4 or later to be populated.
+
+ Populated from StoreKit 2 transactions forwarded through `Qonversion.shared.handlePurchases(_:)`
+ (typically via `Qonversion.StoreKit2Service` or your own SK2 observer). Transactions originating
+ from the SDK's legacy StoreKit 1 purchase path do not carry commitment data and will leave this
+ property nil.
  */
 @property (nonatomic, strong, nullable) QONTransactionCommitmentInfo *commitmentInfo API_AVAILABLE(ios(26.4), macosx(26.4), watchos(26.4), tvos(26.4), visionos(26.4));
 

--- a/Sources/Qonversion/Public/QONTransaction.h
+++ b/Sources/Qonversion/Public/QONTransaction.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "QONTransactionCommitmentInfo.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -82,6 +83,12 @@ NS_SWIFT_NAME(Qonversion.Transaction)
  Type of the transaction.
  */
 @property (nonatomic, assign) QONTransactionType type;
+
+/**
+ Commitment information for subscriptions with a fixed-term billing commitment (e.g. a monthly price paid over 12 months).
+ Non-nil only when the transaction is part of such a commitment. Requires iOS 26.4 or later to be populated.
+ */
+@property (nonatomic, strong, nullable) QONTransactionCommitmentInfo *commitmentInfo API_AVAILABLE(ios(26.4), macosx(26.4), watchos(26.4), tvos(26.4), visionos(26.4));
 
 @end
 

--- a/Sources/Qonversion/Public/QONTransaction.m
+++ b/Sources/Qonversion/Public/QONTransaction.m
@@ -20,30 +20,6 @@
                                   environment:(QONTransactionEnvironment)environment
                                 ownershipType:(QONTransactionOwnershipType)ownershipType
                                          type:(QONTransactionType)type {
-  return [self initWithOriginalTransactionId:originalTransactionId
-                               transactionId:transactionId
-                                   offerCode:offerCode
-                             transactionDate:transactionDate
-                              expirationDate:expirationDate
-                   transactionRevocationDate:transactionRevocationDate
-                                promoOfferId:promoOfferId
-                                 environment:environment
-                               ownershipType:ownershipType
-                                        type:type
-                              commitmentInfo:nil];
-}
-
-- (instancetype)initWithOriginalTransactionId:(NSString *)originalTransactionId
-                                transactionId:(NSString *)transactionId
-                                    offerCode:(NSString *)offerCode
-                              transactionDate:(NSDate *)transactionDate
-                               expirationDate:(NSDate *)expirationDate
-                    transactionRevocationDate:(NSDate *)transactionRevocationDate
-                                 promoOfferId:(NSString *)promoOfferId
-                                  environment:(QONTransactionEnvironment)environment
-                                ownershipType:(QONTransactionOwnershipType)ownershipType
-                                         type:(QONTransactionType)type
-                               commitmentInfo:(nullable QONTransactionCommitmentInfo *)commitmentInfo {
   self = [super init];
 
   if (self) {
@@ -57,9 +33,6 @@
     _environment = environment;
     _ownershipType = ownershipType;
     _type = type;
-    if (@available(iOS 26.4, macOS 26.4, watchOS 26.4, tvOS 26.4, visionOS 26.4, *)) {
-      _commitmentInfo = commitmentInfo;
-    }
   }
 
   return self;
@@ -113,9 +86,12 @@
   [description appendFormat:@"environment=%@ (enum value = %li),\n", [self prettyEnvironment], (long) self.environment];
   [description appendFormat:@"ownershipType=%@ (enum value = %li),\n", [self prettyOwnershipType], (long) self.ownershipType];
   [description appendFormat:@"type=%@ (enum value = %li),\n", [self prettyType], (long) self.type];
-  
+  if (@available(iOS 26.4, macOS 26.4, watchOS 26.4, tvOS 26.4, visionOS 26.4, *)) {
+    [description appendFormat:@"commitmentInfo=%@,\n", self.commitmentInfo];
+  }
+
   [description appendString:@">"];
-  
+
   return [description copy];
 }
 

--- a/Sources/Qonversion/Public/QONTransaction.m
+++ b/Sources/Qonversion/Public/QONTransaction.m
@@ -20,8 +20,32 @@
                                   environment:(QONTransactionEnvironment)environment
                                 ownershipType:(QONTransactionOwnershipType)ownershipType
                                          type:(QONTransactionType)type {
+  return [self initWithOriginalTransactionId:originalTransactionId
+                               transactionId:transactionId
+                                   offerCode:offerCode
+                             transactionDate:transactionDate
+                              expirationDate:expirationDate
+                   transactionRevocationDate:transactionRevocationDate
+                                promoOfferId:promoOfferId
+                                 environment:environment
+                               ownershipType:ownershipType
+                                        type:type
+                              commitmentInfo:nil];
+}
+
+- (instancetype)initWithOriginalTransactionId:(NSString *)originalTransactionId
+                                transactionId:(NSString *)transactionId
+                                    offerCode:(NSString *)offerCode
+                              transactionDate:(NSDate *)transactionDate
+                               expirationDate:(NSDate *)expirationDate
+                    transactionRevocationDate:(NSDate *)transactionRevocationDate
+                                 promoOfferId:(NSString *)promoOfferId
+                                  environment:(QONTransactionEnvironment)environment
+                                ownershipType:(QONTransactionOwnershipType)ownershipType
+                                         type:(QONTransactionType)type
+                               commitmentInfo:(nullable QONTransactionCommitmentInfo *)commitmentInfo {
   self = [super init];
-  
+
   if (self) {
     _originalTransactionId = originalTransactionId;
     _transactionId = transactionId;
@@ -33,8 +57,11 @@
     _environment = environment;
     _ownershipType = ownershipType;
     _type = type;
+    if (@available(iOS 26.4, macOS 26.4, watchOS 26.4, tvOS 26.4, visionOS 26.4, *)) {
+      _commitmentInfo = commitmentInfo;
+    }
   }
-  
+
   return self;
 }
 
@@ -51,6 +78,9 @@
     _environment = [coder decodeIntegerForKey:NSStringFromSelector(@selector(environment))];
     _ownershipType = [coder decodeIntegerForKey:NSStringFromSelector(@selector(ownershipType))];
     _type = [coder decodeIntegerForKey:NSStringFromSelector(@selector(type))];
+    if (@available(iOS 26.4, macOS 26.4, watchOS 26.4, tvOS 26.4, visionOS 26.4, *)) {
+      _commitmentInfo = [coder decodeObjectForKey:NSStringFromSelector(@selector(commitmentInfo))];
+    }
   }
   return self;
 }
@@ -66,6 +96,9 @@
   [coder encodeInteger:_environment forKey:NSStringFromSelector(@selector(environment))];
   [coder encodeInteger:_ownershipType forKey:NSStringFromSelector(@selector(ownershipType))];
   [coder encodeInteger:_type forKey:NSStringFromSelector(@selector(type))];
+  if (@available(iOS 26.4, macOS 26.4, watchOS 26.4, tvOS 26.4, visionOS 26.4, *)) {
+    [coder encodeObject:_commitmentInfo forKey:NSStringFromSelector(@selector(commitmentInfo))];
+  }
 }
 
 - (NSString *)description {

--- a/Sources/Qonversion/Public/QONTransactionCommitmentInfo.h
+++ b/Sources/Qonversion/Public/QONTransactionCommitmentInfo.h
@@ -31,20 +31,22 @@ NS_SWIFT_NAME(Qonversion.TransactionCommitmentInfo)
 @property (nonatomic, assign) NSUInteger totalBillingPeriods;
 
 /**
- The price charged per billing period.
+ The total price of the whole commitment (for example, the full 12-month amount),
+ in the transaction's currency. This is the commitment total, not a single billing period.
  */
-@property (nonatomic, strong, nonnull) NSDecimalNumber *pricePerBillingPeriod;
+@property (nonatomic, strong, nonnull) NSDecimalNumber *commitmentPrice;
 
 /**
- The expiration date of the current billing period.
+ The date the whole commitment expires (the end of the final billing period),
+ not the expiration of the current billing period.
  */
-@property (nonatomic, strong, nonnull) NSDate *currentBillingPeriodExpirationDate;
+@property (nonatomic, strong, nonnull) NSDate *commitmentExpirationDate;
 
 - (instancetype)initWithBillingPeriodNumber:(NSUInteger)billingPeriodNumber
                         totalBillingPeriods:(NSUInteger)totalBillingPeriods
-                       pricePerBillingPeriod:(NSDecimalNumber *)pricePerBillingPeriod
-      currentBillingPeriodExpirationDate:(NSDate *)currentBillingPeriodExpirationDate
-NS_SWIFT_NAME(init(billingPeriodNumber:totalBillingPeriods:pricePerBillingPeriod:currentBillingPeriodExpirationDate:));
+                            commitmentPrice:(NSDecimalNumber *)commitmentPrice
+                   commitmentExpirationDate:(NSDate *)commitmentExpirationDate
+NS_SWIFT_NAME(init(billingPeriodNumber:totalBillingPeriods:commitmentPrice:commitmentExpirationDate:));
 
 @end
 

--- a/Sources/Qonversion/Public/QONTransactionCommitmentInfo.h
+++ b/Sources/Qonversion/Public/QONTransactionCommitmentInfo.h
@@ -1,0 +1,51 @@
+//
+//  QONTransactionCommitmentInfo.h
+//  Qonversion
+//
+//  Created by Qonversion on 2026.
+//  Copyright © 2026 Qonversion Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Commitment information for a subscription with a fixed-term billing commitment
+ (e.g. a monthly subscription with a 12-month commitment).
+ Maps to Transaction.CommitmentInfo (iOS 26.4+).
+ */
+NS_SWIFT_NAME(Qonversion.TransactionCommitmentInfo)
+@interface QONTransactionCommitmentInfo : NSObject <NSCoding>
+
+/**
+ The current billing period number within the commitment (1-based).
+ For example, 4 means the user is in their 4th billing period.
+ */
+@property (nonatomic, assign) NSUInteger billingPeriodNumber;
+
+/**
+ The total number of billing periods in the commitment.
+ For example, 12 for a 12-month commitment.
+ */
+@property (nonatomic, assign) NSUInteger totalBillingPeriods;
+
+/**
+ The price charged per billing period.
+ */
+@property (nonatomic, strong, nonnull) NSDecimalNumber *pricePerBillingPeriod;
+
+/**
+ The expiration date of the current billing period.
+ */
+@property (nonatomic, strong, nonnull) NSDate *currentBillingPeriodExpirationDate;
+
+- (instancetype)initWithBillingPeriodNumber:(NSUInteger)billingPeriodNumber
+                        totalBillingPeriods:(NSUInteger)totalBillingPeriods
+                       pricePerBillingPeriod:(NSDecimalNumber *)pricePerBillingPeriod
+      currentBillingPeriodExpirationDate:(NSDate *)currentBillingPeriodExpirationDate
+NS_SWIFT_NAME(init(billingPeriodNumber:totalBillingPeriods:pricePerBillingPeriod:currentBillingPeriodExpirationDate:));
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Qonversion/Public/QONTransactionCommitmentInfo.m
+++ b/Sources/Qonversion/Public/QONTransactionCommitmentInfo.m
@@ -1,0 +1,57 @@
+//
+//  QONTransactionCommitmentInfo.m
+//  Qonversion
+//
+//  Created by Qonversion on 2026.
+//  Copyright © 2026 Qonversion Inc. All rights reserved.
+//
+
+#import "QONTransactionCommitmentInfo.h"
+
+@implementation QONTransactionCommitmentInfo
+
+- (instancetype)initWithBillingPeriodNumber:(NSUInteger)billingPeriodNumber
+                        totalBillingPeriods:(NSUInteger)totalBillingPeriods
+                      pricePerBillingPeriod:(NSDecimalNumber *)pricePerBillingPeriod
+          currentBillingPeriodExpirationDate:(NSDate *)currentBillingPeriodExpirationDate {
+  self = [super init];
+
+  if (self) {
+    _billingPeriodNumber = billingPeriodNumber;
+    _totalBillingPeriods = totalBillingPeriods;
+    _pricePerBillingPeriod = pricePerBillingPeriod;
+    _currentBillingPeriodExpirationDate = currentBillingPeriodExpirationDate;
+  }
+
+  return self;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)coder {
+  self = [super init];
+  if (self) {
+    _billingPeriodNumber = [coder decodeIntegerForKey:NSStringFromSelector(@selector(billingPeriodNumber))];
+    _totalBillingPeriods = [coder decodeIntegerForKey:NSStringFromSelector(@selector(totalBillingPeriods))];
+    _pricePerBillingPeriod = [coder decodeObjectForKey:NSStringFromSelector(@selector(pricePerBillingPeriod))];
+    _currentBillingPeriodExpirationDate = [coder decodeObjectForKey:NSStringFromSelector(@selector(currentBillingPeriodExpirationDate))];
+  }
+  return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)coder {
+  [coder encodeInteger:_billingPeriodNumber forKey:NSStringFromSelector(@selector(billingPeriodNumber))];
+  [coder encodeInteger:_totalBillingPeriods forKey:NSStringFromSelector(@selector(totalBillingPeriods))];
+  [coder encodeObject:_pricePerBillingPeriod forKey:NSStringFromSelector(@selector(pricePerBillingPeriod))];
+  [coder encodeObject:_currentBillingPeriodExpirationDate forKey:NSStringFromSelector(@selector(currentBillingPeriodExpirationDate))];
+}
+
+- (NSString *)description {
+  NSMutableString *description = [NSMutableString stringWithFormat:@"<%@: ", NSStringFromClass([self class])];
+  [description appendFormat:@"billingPeriodNumber=%lu,\n", (unsigned long)self.billingPeriodNumber];
+  [description appendFormat:@"totalBillingPeriods=%lu,\n", (unsigned long)self.totalBillingPeriods];
+  [description appendFormat:@"pricePerBillingPeriod=%@,\n", self.pricePerBillingPeriod];
+  [description appendFormat:@"currentBillingPeriodExpirationDate=%@\n", self.currentBillingPeriodExpirationDate];
+  [description appendString:@">"];
+  return [description copy];
+}
+
+@end

--- a/Sources/Qonversion/Public/QONTransactionCommitmentInfo.m
+++ b/Sources/Qonversion/Public/QONTransactionCommitmentInfo.m
@@ -12,15 +12,15 @@
 
 - (instancetype)initWithBillingPeriodNumber:(NSUInteger)billingPeriodNumber
                         totalBillingPeriods:(NSUInteger)totalBillingPeriods
-                      pricePerBillingPeriod:(NSDecimalNumber *)pricePerBillingPeriod
-          currentBillingPeriodExpirationDate:(NSDate *)currentBillingPeriodExpirationDate {
+                            commitmentPrice:(NSDecimalNumber *)commitmentPrice
+                   commitmentExpirationDate:(NSDate *)commitmentExpirationDate {
   self = [super init];
 
   if (self) {
     _billingPeriodNumber = billingPeriodNumber;
     _totalBillingPeriods = totalBillingPeriods;
-    _pricePerBillingPeriod = pricePerBillingPeriod;
-    _currentBillingPeriodExpirationDate = currentBillingPeriodExpirationDate;
+    _commitmentPrice = commitmentPrice;
+    _commitmentExpirationDate = commitmentExpirationDate;
   }
 
   return self;
@@ -31,8 +31,8 @@
   if (self) {
     _billingPeriodNumber = [coder decodeIntegerForKey:NSStringFromSelector(@selector(billingPeriodNumber))];
     _totalBillingPeriods = [coder decodeIntegerForKey:NSStringFromSelector(@selector(totalBillingPeriods))];
-    _pricePerBillingPeriod = [coder decodeObjectForKey:NSStringFromSelector(@selector(pricePerBillingPeriod))];
-    _currentBillingPeriodExpirationDate = [coder decodeObjectForKey:NSStringFromSelector(@selector(currentBillingPeriodExpirationDate))];
+    _commitmentPrice = [coder decodeObjectForKey:NSStringFromSelector(@selector(commitmentPrice))];
+    _commitmentExpirationDate = [coder decodeObjectForKey:NSStringFromSelector(@selector(commitmentExpirationDate))];
   }
   return self;
 }
@@ -40,16 +40,16 @@
 - (void)encodeWithCoder:(NSCoder *)coder {
   [coder encodeInteger:_billingPeriodNumber forKey:NSStringFromSelector(@selector(billingPeriodNumber))];
   [coder encodeInteger:_totalBillingPeriods forKey:NSStringFromSelector(@selector(totalBillingPeriods))];
-  [coder encodeObject:_pricePerBillingPeriod forKey:NSStringFromSelector(@selector(pricePerBillingPeriod))];
-  [coder encodeObject:_currentBillingPeriodExpirationDate forKey:NSStringFromSelector(@selector(currentBillingPeriodExpirationDate))];
+  [coder encodeObject:_commitmentPrice forKey:NSStringFromSelector(@selector(commitmentPrice))];
+  [coder encodeObject:_commitmentExpirationDate forKey:NSStringFromSelector(@selector(commitmentExpirationDate))];
 }
 
 - (NSString *)description {
   NSMutableString *description = [NSMutableString stringWithFormat:@"<%@: ", NSStringFromClass([self class])];
   [description appendFormat:@"billingPeriodNumber=%lu,\n", (unsigned long)self.billingPeriodNumber];
   [description appendFormat:@"totalBillingPeriods=%lu,\n", (unsigned long)self.totalBillingPeriods];
-  [description appendFormat:@"pricePerBillingPeriod=%@,\n", self.pricePerBillingPeriod];
-  [description appendFormat:@"currentBillingPeriodExpirationDate=%@\n", self.currentBillingPeriodExpirationDate];
+  [description appendFormat:@"commitmentPrice=%@,\n", self.commitmentPrice];
+  [description appendFormat:@"commitmentExpirationDate=%@\n", self.commitmentExpirationDate];
   [description appendString:@">"];
   return [description copy];
 }

--- a/Sources/Qonversion/Qonversion/Main/QNProductCenterManager/QNProductCenterManager.m
+++ b/Sources/Qonversion/Qonversion/Main/QNProductCenterManager/QNProductCenterManager.m
@@ -625,18 +625,21 @@ static NSString * const kUserDefaultsSuiteName = @"qonversion.product-center.sui
     return;
   }
   if (@available(iOS 26.4, macOS 26.4, watchOS 26.4, tvOS 26.4, visionOS 26.4, *)) {
-    NSDictionary<NSString *, QONTransactionCommitmentInfo *> *snapshot;
+    // One-shot consume: each transactionId is applied at most once and then removed
+    // from the cache. Entries that never match a returned QONTransaction (e.g. server
+    // omits the txn from the response) persist until process exit; this is acceptable
+    // given typical SK2 batch sizes of 1-12 transactions per session.
     @synchronized (self.commitmentInfoByTransactionId) {
       if (self.commitmentInfoByTransactionId.count == 0) {
         return;
       }
-      snapshot = [self.commitmentInfoByTransactionId copy];
-    }
-    for (QONEntitlement *entitlement in entitlements.allValues) {
-      for (QONTransaction *transaction in entitlement.transactions) {
-        QONTransactionCommitmentInfo *info = snapshot[transaction.transactionId];
-        if (info) {
-          transaction.commitmentInfo = info;
+      for (QONEntitlement *entitlement in entitlements.allValues) {
+        for (QONTransaction *transaction in entitlement.transactions) {
+          QONTransactionCommitmentInfo *info = self.commitmentInfoByTransactionId[transaction.transactionId];
+          if (info) {
+            transaction.commitmentInfo = info;
+            [self.commitmentInfoByTransactionId removeObjectForKey:transaction.transactionId];
+          }
         }
       }
     }

--- a/Sources/Qonversion/Qonversion/Main/QNProductCenterManager/QNProductCenterManager.m
+++ b/Sources/Qonversion/Qonversion/Main/QNProductCenterManager/QNProductCenterManager.m
@@ -26,6 +26,9 @@
 #import "QONPromotionalOffer.h"
 #import "QONPurchaseOptions.h"
 #import "QONPurchaseResult+Protected.h"
+#import "QONTransaction.h"
+#import "QONTransactionCommitmentInfo.h"
+#import "QONEntitlement.h"
 #import <StoreKit/StoreKit.h>
 #import "QONRequestTrigger.h"
 
@@ -66,6 +69,11 @@ static NSString * const kUserDefaultsSuiteName = @"qonversion.product-center.sui
 @property (nonatomic, strong) QONUser *user;
 
 @property (nonatomic, copy) NSDictionary<NSString *, QONPurchaseOptions *> *processingPurchaseOptions;
+
+// Cache of locally-parsed SK2 commitment info, keyed by transactionId. Populated by
+// handlePurchases: (SK2 path) and consumed when QONTransaction instances built from the
+// server response are returned to the consumer. Server does not relay this field.
+@property (nonatomic, strong) NSMutableDictionary<NSString *, QONTransactionCommitmentInfo *> *commitmentInfoByTransactionId;
 
 @property (nonatomic, assign) BOOL launchingFinished;
 @property (nonatomic, assign) BOOL productsLoading;
@@ -112,8 +120,9 @@ static NSString * const kUserDefaultsSuiteName = @"qonversion.product-center.sui
     _offeringsBlocks = [NSMutableArray new];
     _userInfoBlocks = [NSMutableArray new];
     _pendingIdentityBlocks = [NSMutableDictionary new];
+    _commitmentInfoByTransactionId = [NSMutableDictionary new];
   }
-  
+
   return self;
 }
 
@@ -604,9 +613,33 @@ static NSString * const kUserDefaultsSuiteName = @"qonversion.product-center.sui
   }
 
   if (entitlementsAreActual) {
+    [self enrichEntitlementsWithCommitmentInfo:entitlements];
     run_block_on_main(completion, entitlements, nil);
   } else {
     [self actualizeEntitlements:completion];
+  }
+}
+
+- (void)enrichEntitlementsWithCommitmentInfo:(NSDictionary<NSString *, QONEntitlement *> *)entitlements {
+  if (!entitlements) {
+    return;
+  }
+  if (@available(iOS 26.4, macOS 26.4, watchOS 26.4, tvOS 26.4, visionOS 26.4, *)) {
+    NSDictionary<NSString *, QONTransactionCommitmentInfo *> *snapshot;
+    @synchronized (self.commitmentInfoByTransactionId) {
+      if (self.commitmentInfoByTransactionId.count == 0) {
+        return;
+      }
+      snapshot = [self.commitmentInfoByTransactionId copy];
+    }
+    for (QONEntitlement *entitlement in entitlements.allValues) {
+      for (QONTransaction *transaction in entitlement.transactions) {
+        QONTransactionCommitmentInfo *info = snapshot[transaction.transactionId];
+        if (info) {
+          transaction.commitmentInfo = info;
+        }
+      }
+    }
   }
 }
 
@@ -919,6 +952,7 @@ static NSString * const kUserDefaultsSuiteName = @"qonversion.product-center.sui
           launchResult = [QNMapper fillLaunchResult:mappedResult.data];
         }
       }
+      [weakSelf enrichLaunchResultWithCommitmentInfo:launchResult];
       completion(launchResult, error);
       return;
     }
@@ -936,6 +970,7 @@ static NSString * const kUserDefaultsSuiteName = @"qonversion.product-center.sui
     [weakSelf.persistentStorage storeObject:weakSelf.productsEntitlementsRelation forKey:kKeyQUserDefaultsProductsPermissionsRelation];
 
     QONLaunchResult *launchResult = [QNMapper fillLaunchResult:result.data];
+    [weakSelf enrichLaunchResultWithCommitmentInfo:launchResult];
     completion(launchResult, nil);
     
     static dispatch_once_t onceToken;
@@ -969,6 +1004,8 @@ static NSString * const kUserDefaultsSuiteName = @"qonversion.product-center.sui
 }
 
 - (void)handlePurchases:(NSArray<QONStoreKit2PurchaseModel *> *)purchasesInfo completion:(QONDefaultCompletionHandler)completion {
+  [self cacheCommitmentInfoFromPurchaseModels:purchasesInfo];
+
   __block __weak QNProductCenterManager *weakSelf = self;
   __block QONDefaultCompletionHandler resultCompletion = [completion copy];
   [self.storeKitService receipt:^(NSString * receipt) {
@@ -983,7 +1020,7 @@ static NSString * const kUserDefaultsSuiteName = @"qonversion.product-center.sui
         } else {
           [weakSelf.apiClient removeStoredRequestForTransactionId:purchaseModel.transactionId];
         }
-        
+
         if (resultCompletion) {
           resultCompletion(success, error);
           resultCompletion = nil;
@@ -991,6 +1028,22 @@ static NSString * const kUserDefaultsSuiteName = @"qonversion.product-center.sui
       }];
     }
   }];
+}
+
+- (void)cacheCommitmentInfoFromPurchaseModels:(NSArray<QONStoreKit2PurchaseModel *> *)purchaseModels {
+  if (@available(iOS 26.4, macOS 26.4, watchOS 26.4, tvOS 26.4, visionOS 26.4, *)) {
+    @synchronized (self.commitmentInfoByTransactionId) {
+      for (QONStoreKit2PurchaseModel *model in purchaseModels) {
+        if (model.commitmentInfo && model.transactionId.length > 0) {
+          self.commitmentInfoByTransactionId[model.transactionId] = model.commitmentInfo;
+        }
+      }
+    }
+  }
+}
+
+- (void)enrichLaunchResultWithCommitmentInfo:(QONLaunchResult *)launchResult {
+  [self enrichEntitlementsWithCommitmentInfo:launchResult.entitlements];
 }
 
 // MARK: - QNStoreKitServiceDelegate
@@ -1046,13 +1099,14 @@ static NSString * const kUserDefaultsSuiteName = @"qonversion.product-center.sui
       }
       
       QONLaunchResult *launchResult = [QNMapper fillLaunchResult:result.data];
-      
+      [weakSelf enrichLaunchResultWithCommitmentInfo:launchResult];
+
       if (!resultError) {
         @synchronized (weakSelf) {
           weakSelf.launchResult = launchResult;
           weakSelf.launchError = nil;
         }
-        
+
         [weakSelf storeLaunchResultIfNeeded:launchResult];
       }
       

--- a/Sources/Qonversion/Qonversion/Mappers/QNMapper/QNMapper.m
+++ b/Sources/Qonversion/Qonversion/Mappers/QNMapper/QNMapper.m
@@ -9,7 +9,6 @@
 #import "QONIntroEligibility.h"
 #import "QONExperimentGroup.h"
 #import "QONTransaction.h"
-#import "QONTransactionCommitmentInfo.h"
 
 #import "QONLaunchResult+Protected.h"
 #import "QONOfferings+Protected.h"
@@ -295,43 +294,9 @@
   NSNumber *transactionTypeNumber = transactionTypes[typeRaw];
   QONTransactionType transactionType = transactionTypes ? transactionTypeNumber.integerValue : QONTransactionTypeUnknown;
   
-  QONTransactionCommitmentInfo *commitmentInfo = nil;
-  if (@available(iOS 26.4, macOS 26.4, watchOS 26.4, tvOS 26.4, visionOS 26.4, *)) {
-    commitmentInfo = [self mapCommitmentInfo:rawTransaction[@"commitment_info"]];
-  }
-
-  QONTransaction *transaction = [[QONTransaction alloc] initWithOriginalTransactionId:originalTransactionId transactionId:transactionId offerCode:offerCode transactionDate:transactionDate expirationDate:expirationDate transactionRevocationDate:transactionRevocationDate promoOfferId:promoOfferId environment:environment ownershipType:ownershipType type:transactionType commitmentInfo:commitmentInfo];
+  QONTransaction *transaction = [[QONTransaction alloc] initWithOriginalTransactionId:originalTransactionId transactionId:transactionId offerCode:offerCode transactionDate:transactionDate expirationDate:expirationDate transactionRevocationDate:transactionRevocationDate promoOfferId:promoOfferId environment:environment ownershipType:ownershipType type:transactionType];
 
   return transaction;
-}
-
-+ (QONTransactionCommitmentInfo *)mapCommitmentInfo:(NSDictionary *)rawCommitmentInfo API_AVAILABLE(ios(26.4), macosx(26.4), watchos(26.4), tvos(26.4), visionos(26.4)) {
-  if (![rawCommitmentInfo isKindOfClass:[NSDictionary class]]) {
-    return nil;
-  }
-
-  NSNumber *billingPeriodNumberRaw = rawCommitmentInfo[@"billingPeriodNumber"];
-  NSNumber *totalBillingPeriodsRaw = rawCommitmentInfo[@"totalBillingPeriods"];
-  NSNumber *priceRaw = rawCommitmentInfo[@"price"];
-  NSString *expirationDateRaw = rawCommitmentInfo[@"expirationDate"];
-
-  if (!billingPeriodNumberRaw || !totalBillingPeriodsRaw || !priceRaw || !expirationDateRaw) {
-    return nil;
-  }
-
-  NSDecimalNumber *price = [NSDecimalNumber decimalNumberWithString:[priceRaw stringValue]];
-
-  // expirationDate in Transaction.jsonRepresentation is an ISO 8601 string
-  NSISO8601DateFormatter *formatter = [[NSISO8601DateFormatter alloc] init];
-  NSDate *expirationDate = [formatter dateFromString:expirationDateRaw];
-  if (!expirationDate) {
-    return nil;
-  }
-
-  return [[QONTransactionCommitmentInfo alloc] initWithBillingPeriodNumber:billingPeriodNumberRaw.unsignedIntegerValue
-                                                       totalBillingPeriods:totalBillingPeriodsRaw.unsignedIntegerValue
-                                                     pricePerBillingPeriod:price
-                                         currentBillingPeriodExpirationDate:expirationDate];
 }
 
 + (NSDate *)mapDateFromSource:(NSDictionary *)source key:(NSString *)key {

--- a/Sources/Qonversion/Qonversion/Mappers/QNMapper/QNMapper.m
+++ b/Sources/Qonversion/Qonversion/Mappers/QNMapper/QNMapper.m
@@ -9,6 +9,7 @@
 #import "QONIntroEligibility.h"
 #import "QONExperimentGroup.h"
 #import "QONTransaction.h"
+#import "QONTransactionCommitmentInfo.h"
 
 #import "QONLaunchResult+Protected.h"
 #import "QONOfferings+Protected.h"
@@ -294,9 +295,43 @@
   NSNumber *transactionTypeNumber = transactionTypes[typeRaw];
   QONTransactionType transactionType = transactionTypes ? transactionTypeNumber.integerValue : QONTransactionTypeUnknown;
   
-  QONTransaction *transaction = [[QONTransaction alloc] initWithOriginalTransactionId:originalTransactionId transactionId:transactionId offerCode:offerCode transactionDate:transactionDate expirationDate:expirationDate transactionRevocationDate:transactionRevocationDate promoOfferId:promoOfferId environment:environment ownershipType:ownershipType type:transactionType];
-  
+  QONTransactionCommitmentInfo *commitmentInfo = nil;
+  if (@available(iOS 26.4, macOS 26.4, watchOS 26.4, tvOS 26.4, visionOS 26.4, *)) {
+    commitmentInfo = [self mapCommitmentInfo:rawTransaction[@"commitment_info"]];
+  }
+
+  QONTransaction *transaction = [[QONTransaction alloc] initWithOriginalTransactionId:originalTransactionId transactionId:transactionId offerCode:offerCode transactionDate:transactionDate expirationDate:expirationDate transactionRevocationDate:transactionRevocationDate promoOfferId:promoOfferId environment:environment ownershipType:ownershipType type:transactionType commitmentInfo:commitmentInfo];
+
   return transaction;
+}
+
++ (QONTransactionCommitmentInfo *)mapCommitmentInfo:(NSDictionary *)rawCommitmentInfo API_AVAILABLE(ios(26.4), macosx(26.4), watchos(26.4), tvos(26.4), visionos(26.4)) {
+  if (![rawCommitmentInfo isKindOfClass:[NSDictionary class]]) {
+    return nil;
+  }
+
+  NSNumber *billingPeriodNumberRaw = rawCommitmentInfo[@"billingPeriodNumber"];
+  NSNumber *totalBillingPeriodsRaw = rawCommitmentInfo[@"totalBillingPeriods"];
+  NSNumber *priceRaw = rawCommitmentInfo[@"price"];
+  NSString *expirationDateRaw = rawCommitmentInfo[@"expirationDate"];
+
+  if (!billingPeriodNumberRaw || !totalBillingPeriodsRaw || !priceRaw || !expirationDateRaw) {
+    return nil;
+  }
+
+  NSDecimalNumber *price = [NSDecimalNumber decimalNumberWithString:[priceRaw stringValue]];
+
+  // expirationDate in Transaction.jsonRepresentation is an ISO 8601 string
+  NSISO8601DateFormatter *formatter = [[NSISO8601DateFormatter alloc] init];
+  NSDate *expirationDate = [formatter dateFromString:expirationDateRaw];
+  if (!expirationDate) {
+    return nil;
+  }
+
+  return [[QONTransactionCommitmentInfo alloc] initWithBillingPeriodNumber:billingPeriodNumberRaw.unsignedIntegerValue
+                                                       totalBillingPeriods:totalBillingPeriodsRaw.unsignedIntegerValue
+                                                     pricePerBillingPeriod:price
+                                         currentBillingPeriodExpirationDate:expirationDate];
 }
 
 + (NSDate *)mapDateFromSource:(NSDictionary *)source key:(NSString *)key {

--- a/Sources/Qonversion/Qonversion/Models/Protected/QONTransaction+Protected.h
+++ b/Sources/Qonversion/Qonversion/Models/Protected/QONTransaction+Protected.h
@@ -23,18 +23,6 @@ NS_ASSUME_NONNULL_BEGIN
                                 ownershipType:(QONTransactionOwnershipType)ownershipType
                                          type:(QONTransactionType)type;
 
-- (instancetype)initWithOriginalTransactionId:(NSString *)originalTransactionId
-                                transactionId:(NSString *)transactionId
-                                    offerCode:(NSString *)offerCode
-                              transactionDate:(NSDate *)transactionDate
-                               expirationDate:(NSDate *)expirationDate
-                    transactionRevocationDate:(NSDate *)transactionRevocationDate
-                                 promoOfferId:(NSString *)promoOfferId
-                                  environment:(QONTransactionEnvironment)environment
-                                ownershipType:(QONTransactionOwnershipType)ownershipType
-                                         type:(QONTransactionType)type
-                               commitmentInfo:(nullable QONTransactionCommitmentInfo *)commitmentInfo API_AVAILABLE(ios(26.4), macosx(26.4), watchos(26.4), tvos(26.4), visionos(26.4));
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Qonversion/Qonversion/Models/Protected/QONTransaction+Protected.h
+++ b/Sources/Qonversion/Qonversion/Models/Protected/QONTransaction+Protected.h
@@ -23,6 +23,18 @@ NS_ASSUME_NONNULL_BEGIN
                                 ownershipType:(QONTransactionOwnershipType)ownershipType
                                          type:(QONTransactionType)type;
 
+- (instancetype)initWithOriginalTransactionId:(NSString *)originalTransactionId
+                                transactionId:(NSString *)transactionId
+                                    offerCode:(NSString *)offerCode
+                              transactionDate:(NSDate *)transactionDate
+                               expirationDate:(NSDate *)expirationDate
+                    transactionRevocationDate:(NSDate *)transactionRevocationDate
+                                 promoOfferId:(NSString *)promoOfferId
+                                  environment:(QONTransactionEnvironment)environment
+                                ownershipType:(QONTransactionOwnershipType)ownershipType
+                                         type:(QONTransactionType)type
+                               commitmentInfo:(nullable QONTransactionCommitmentInfo *)commitmentInfo API_AVAILABLE(ios(26.4), macosx(26.4), watchos(26.4), tvos(26.4), visionos(26.4));
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Swift/PurchasesMapper.swift
+++ b/Sources/Swift/PurchasesMapper.swift
@@ -105,9 +105,11 @@ final class PurchasesMapper {
     return nil
   }
 
+  // Apple has not published the JSON encoding of Transaction.CommitmentInfo.expirationDate
+  // in jsonRepresentation. We handle ms-number and ISO-8601 string defensively. Once Xcode
+  // supports iOS 26.4, swap to typed Transaction.commitmentInfo?.expirationDate and delete
+  // this fallback.
   private func parseDate(from value: Any?) -> Date? {
-    // Transaction.jsonRepresentation typically encodes dates as Unix timestamps in milliseconds,
-    // but ISO 8601 strings have been observed in some payloads. Try both before giving up.
     if let millis = value as? NSNumber {
       return Date(timeIntervalSince1970: millis.doubleValue / 1000.0)
     }

--- a/Sources/Swift/PurchasesMapper.swift
+++ b/Sources/Swift/PurchasesMapper.swift
@@ -83,13 +83,9 @@ final class PurchasesMapper {
           let raw = jsonDict["commitmentInfo"] as? [String: Any],
           let billingPeriodNumber = raw["billingPeriodNumber"] as? UInt64,
           let totalBillingPeriods = raw["totalBillingPeriods"] as? UInt64,
-          let priceValue = raw["price"],
-          let expirationDateString = raw["expirationDate"] as? String
+          let priceDecimal = decimalNumber(from: raw["price"]),
+          let expirationDate = parseDate(from: raw["expirationDate"])
     else { return nil }
-
-    let priceDecimal = NSDecimalNumber(string: "\(priceValue)")
-    let formatter = ISO8601DateFormatter()
-    guard let expirationDate = formatter.date(from: expirationDateString) else { return nil }
 
     return Qonversion.TransactionCommitmentInfo(
       billingPeriodNumber: UInt(billingPeriodNumber),
@@ -97,6 +93,34 @@ final class PurchasesMapper {
       pricePerBillingPeriod: priceDecimal,
       currentBillingPeriodExpirationDate: expirationDate
     )
+  }
+
+  private func decimalNumber(from value: Any?) -> NSDecimalNumber? {
+    if let number = value as? NSNumber {
+      return NSDecimalNumber(decimal: number.decimalValue)
+    }
+    if let string = value as? String, let decimal = Decimal(string: string) {
+      return NSDecimalNumber(decimal: decimal)
+    }
+    return nil
+  }
+
+  private func parseDate(from value: Any?) -> Date? {
+    // Transaction.jsonRepresentation typically encodes dates as Unix timestamps in milliseconds,
+    // but ISO 8601 strings have been observed in some payloads. Try both before giving up.
+    if let millis = value as? NSNumber {
+      return Date(timeIntervalSince1970: millis.doubleValue / 1000.0)
+    }
+    if let string = value as? String {
+      let isoFormatter = ISO8601DateFormatter()
+      if let date = isoFormatter.date(from: string) {
+        return date
+      }
+      if let millis = Double(string) {
+        return Date(timeIntervalSince1970: millis / 1000.0)
+      }
+    }
+    return nil
   }
   
   private func convert(paymentMode: Product.SubscriptionOffer.PaymentMode) -> String {

--- a/Sources/Swift/PurchasesMapper.swift
+++ b/Sources/Swift/PurchasesMapper.swift
@@ -71,58 +71,81 @@ final class PurchasesMapper {
       // Transitional: parse Transaction.CommitmentInfo from jsonRepresentation.
       // Swap for direct typed access (transaction.commitmentInfo?.billingPeriodNumber)
       // once Xcode ships with the iOS 26.4 SDK.
-      purchaseInfo.commitmentInfo = parseCommitmentInfo(from: transaction)
+      purchaseInfo.commitmentInfo = parseCommitmentInfo(from: transaction.jsonRepresentation)
     }
 
     return purchaseInfo
   }
 
   @available(iOS 26.4, macOS 26.4, watchOS 26.4, tvOS 26.4, visionOS 26.4, *)
-  private func parseCommitmentInfo(from transaction: Transaction) -> Qonversion.TransactionCommitmentInfo? {
-    guard let jsonDict = (try? JSONSerialization.jsonObject(with: transaction.jsonRepresentation)) as? [String: Any],
-          let raw = jsonDict["commitmentInfo"] as? [String: Any],
-          let billingPeriodNumber = raw["billingPeriodNumber"] as? UInt64,
-          let totalBillingPeriods = raw["totalBillingPeriods"] as? UInt64,
-          let priceDecimal = decimalNumber(from: raw["price"]),
-          let expirationDate = parseDate(from: raw["expirationDate"])
+  func parseCommitmentInfo(from jsonRepresentation: Data) -> Qonversion.TransactionCommitmentInfo? {
+    // Decode straight from raw JSON bytes so that `price` is parsed as a Swift Decimal
+    // without round-tripping through Double, and so `billingPeriodNumber` /
+    // `totalBillingPeriods` survive whether Apple emits them as JSON ints or floats.
+    guard let envelope = try? JSONDecoder().decode(TransactionEnvelope.self, from: jsonRepresentation),
+          let info = envelope.commitmentInfo
     else { return nil }
 
     return Qonversion.TransactionCommitmentInfo(
-      billingPeriodNumber: UInt(billingPeriodNumber),
-      totalBillingPeriods: UInt(totalBillingPeriods),
-      pricePerBillingPeriod: priceDecimal,
-      currentBillingPeriodExpirationDate: expirationDate
+      billingPeriodNumber: UInt(info.billingPeriodNumber),
+      totalBillingPeriods: UInt(info.totalBillingPeriods),
+      pricePerBillingPeriod: NSDecimalNumber(decimal: info.price),
+      currentBillingPeriodExpirationDate: info.expirationDate
     )
   }
 
-  private func decimalNumber(from value: Any?) -> NSDecimalNumber? {
-    if let number = value as? NSNumber {
-      return NSDecimalNumber(decimal: number.decimalValue)
-    }
-    if let string = value as? String, let decimal = Decimal(string: string) {
-      return NSDecimalNumber(decimal: decimal)
-    }
-    return nil
+  @available(iOS 26.4, macOS 26.4, watchOS 26.4, tvOS 26.4, visionOS 26.4, *)
+  private struct TransactionEnvelope: Decodable {
+    let commitmentInfo: CommitmentInfoJSON?
   }
 
-  // Apple has not published the JSON encoding of Transaction.CommitmentInfo.expirationDate
-  // in jsonRepresentation. We handle ms-number and ISO-8601 string defensively. Once Xcode
-  // supports iOS 26.4, swap to typed Transaction.commitmentInfo?.expirationDate and delete
-  // this fallback.
-  private func parseDate(from value: Any?) -> Date? {
-    if let millis = value as? NSNumber {
-      return Date(timeIntervalSince1970: millis.doubleValue / 1000.0)
+  @available(iOS 26.4, macOS 26.4, watchOS 26.4, tvOS 26.4, visionOS 26.4, *)
+  private struct CommitmentInfoJSON: Decodable {
+    let billingPeriodNumber: UInt64
+    let totalBillingPeriods: UInt64
+    let price: Decimal
+    let expirationDate: Date
+
+    enum CodingKeys: String, CodingKey {
+      case billingPeriodNumber
+      case totalBillingPeriods
+      case price
+      case expirationDate
     }
-    if let string = value as? String {
-      let isoFormatter = ISO8601DateFormatter()
-      if let date = isoFormatter.date(from: string) {
-        return date
-      }
-      if let millis = Double(string) {
+
+    init(from decoder: Decoder) throws {
+      let container = try decoder.container(keyedBy: CodingKeys.self)
+      billingPeriodNumber = try container.decode(UInt64.self, forKey: .billingPeriodNumber)
+      totalBillingPeriods = try container.decode(UInt64.self, forKey: .totalBillingPeriods)
+      price = try container.decode(Decimal.self, forKey: .price)
+      expirationDate = try Self.decodeExpirationDate(from: container)
+    }
+
+    // Apple has not yet published the JSON encoding of Transaction.CommitmentInfo.expirationDate
+    // in jsonRepresentation. Other Transaction date fields (purchaseDate, expiresDate,
+    // signedDate) are Unix milliseconds, so we expect a number, but accept ISO-8601 and
+    // numeric strings defensively. Swap to typed transaction.commitmentInfo?.expirationDate
+    // and delete these fallbacks once the iOS 26.4 SDK ships.
+    private static func decodeExpirationDate(
+      from container: KeyedDecodingContainer<CodingKeys>
+    ) throws -> Date {
+      if let millis = try? container.decode(Double.self, forKey: .expirationDate) {
         return Date(timeIntervalSince1970: millis / 1000.0)
       }
+
+      let raw = try container.decode(String.self, forKey: .expirationDate)
+      if let date = ISO8601DateFormatter().date(from: raw) {
+        return date
+      }
+      if let millis = Double(raw) {
+        return Date(timeIntervalSince1970: millis / 1000.0)
+      }
+
+      throw DecodingError.dataCorruptedError(
+        forKey: .expirationDate, in: container,
+        debugDescription: "Unrecognized expirationDate encoding: \(raw)"
+      )
     }
-    return nil
   }
   
   private func convert(paymentMode: Product.SubscriptionOffer.PaymentMode) -> String {

--- a/Sources/Swift/PurchasesMapper.swift
+++ b/Sources/Swift/PurchasesMapper.swift
@@ -68,84 +68,54 @@ final class PurchasesMapper {
     purchaseInfo.storefrontCountryCode = await Storefront.current?.countryCode
 
     if #available(iOS 26.4, macOS 26.4, watchOS 26.4, tvOS 26.4, visionOS 26.4, *) {
-      // Transitional: parse Transaction.CommitmentInfo from jsonRepresentation.
-      // Swap for direct typed access (transaction.commitmentInfo?.billingPeriodNumber)
-      // once Xcode ships with the iOS 26.4 SDK.
+      // The typed `transaction.commitmentInfo` (StoreKit, iOS 26.4+) is not in the build SDK yet
+      // (CI builds against Xcode 26.2), so we read the commitment block out of
+      // `transaction.jsonRepresentation`, which follows the App Store Server API transaction schema.
+      // Swap to the typed property once the build SDK reaches iOS 26.4.
       purchaseInfo.commitmentInfo = parseCommitmentInfo(from: transaction.jsonRepresentation)
     }
 
     return purchaseInfo
   }
 
-  @available(iOS 26.4, macOS 26.4, watchOS 26.4, tvOS 26.4, visionOS 26.4, *)
+  /// Parses Apple's `commitmentInfo` block out of `Transaction.jsonRepresentation`.
+  ///
+  /// Keys and encodings are verified against Apple's `app-store-server-library`
+  /// `TransactionCommitmentInfo` model and its `signedTransaction.json` fixture:
+  /// - `commitmentPrice` is an `Int64` in milliunits of the currency (e.g. 119880 -> 119.88) and is
+  ///   the price of the whole commitment, not a single billing period.
+  /// - `commitmentExpiresDate` is epoch milliseconds and marks when the whole commitment ends.
+  /// The block is absent on pre-26.4 OSes, so this returns nil there.
+  ///
+  /// Intentionally not gated on iOS 26.4: the decode is pure JSON and stays testable on any OS.
+  /// Only the call site that assigns to the availability-gated `commitmentInfo` property is gated.
   func parseCommitmentInfo(from jsonRepresentation: Data) -> Qonversion.TransactionCommitmentInfo? {
-    // Decode straight from raw JSON bytes so that `price` is parsed as a Swift Decimal
-    // without round-tripping through Double, and so `billingPeriodNumber` /
-    // `totalBillingPeriods` survive whether Apple emits them as JSON ints or floats.
     guard let envelope = try? JSONDecoder().decode(TransactionEnvelope.self, from: jsonRepresentation),
           let info = envelope.commitmentInfo
     else { return nil }
 
+    let commitmentPrice = NSDecimalNumber(value: info.commitmentPrice).dividing(by: NSDecimalNumber(value: 1000))
+    let commitmentExpirationDate = Date(timeIntervalSince1970: info.commitmentExpiresDate / 1000.0)
+
     return Qonversion.TransactionCommitmentInfo(
       billingPeriodNumber: UInt(info.billingPeriodNumber),
       totalBillingPeriods: UInt(info.totalBillingPeriods),
-      pricePerBillingPeriod: NSDecimalNumber(decimal: info.price),
-      currentBillingPeriodExpirationDate: info.expirationDate
+      commitmentPrice: commitmentPrice,
+      commitmentExpirationDate: commitmentExpirationDate
     )
   }
 
-  @available(iOS 26.4, macOS 26.4, watchOS 26.4, tvOS 26.4, visionOS 26.4, *)
   private struct TransactionEnvelope: Decodable {
     let commitmentInfo: CommitmentInfoJSON?
   }
 
-  @available(iOS 26.4, macOS 26.4, watchOS 26.4, tvOS 26.4, visionOS 26.4, *)
+  /// Mirrors Apple's `TransactionCommitmentInfo` JSON (App Store Server API schema).
+  /// `commitmentPrice` is in milliunits of the currency; `commitmentExpiresDate` is epoch milliseconds.
   private struct CommitmentInfoJSON: Decodable {
-    let billingPeriodNumber: UInt64
-    let totalBillingPeriods: UInt64
-    let price: Decimal
-    let expirationDate: Date
-
-    enum CodingKeys: String, CodingKey {
-      case billingPeriodNumber
-      case totalBillingPeriods
-      case price
-      case expirationDate
-    }
-
-    init(from decoder: Decoder) throws {
-      let container = try decoder.container(keyedBy: CodingKeys.self)
-      billingPeriodNumber = try container.decode(UInt64.self, forKey: .billingPeriodNumber)
-      totalBillingPeriods = try container.decode(UInt64.self, forKey: .totalBillingPeriods)
-      price = try container.decode(Decimal.self, forKey: .price)
-      expirationDate = try Self.decodeExpirationDate(from: container)
-    }
-
-    // Apple has not yet published the JSON encoding of Transaction.CommitmentInfo.expirationDate
-    // in jsonRepresentation. Other Transaction date fields (purchaseDate, expiresDate,
-    // signedDate) are Unix milliseconds, so we expect a number, but accept ISO-8601 and
-    // numeric strings defensively. Swap to typed transaction.commitmentInfo?.expirationDate
-    // and delete these fallbacks once the iOS 26.4 SDK ships.
-    private static func decodeExpirationDate(
-      from container: KeyedDecodingContainer<CodingKeys>
-    ) throws -> Date {
-      if let millis = try? container.decode(Double.self, forKey: .expirationDate) {
-        return Date(timeIntervalSince1970: millis / 1000.0)
-      }
-
-      let raw = try container.decode(String.self, forKey: .expirationDate)
-      if let date = ISO8601DateFormatter().date(from: raw) {
-        return date
-      }
-      if let millis = Double(raw) {
-        return Date(timeIntervalSince1970: millis / 1000.0)
-      }
-
-      throw DecodingError.dataCorruptedError(
-        forKey: .expirationDate, in: container,
-        debugDescription: "Unrecognized expirationDate encoding: \(raw)"
-      )
-    }
+    let billingPeriodNumber: Int
+    let totalBillingPeriods: Int
+    let commitmentPrice: Int64
+    let commitmentExpiresDate: Double
   }
   
   private func convert(paymentMode: Product.SubscriptionOffer.PaymentMode) -> String {

--- a/Sources/Swift/PurchasesMapper.swift
+++ b/Sources/Swift/PurchasesMapper.swift
@@ -67,7 +67,36 @@ final class PurchasesMapper {
     
     purchaseInfo.storefrontCountryCode = await Storefront.current?.countryCode
 
+    if #available(iOS 26.4, macOS 26.4, watchOS 26.4, tvOS 26.4, visionOS 26.4, *) {
+      // Transitional: parse Transaction.CommitmentInfo from jsonRepresentation.
+      // Swap for direct typed access (transaction.commitmentInfo?.billingPeriodNumber)
+      // once Xcode ships with the iOS 26.4 SDK.
+      purchaseInfo.commitmentInfo = parseCommitmentInfo(from: transaction)
+    }
+
     return purchaseInfo
+  }
+
+  @available(iOS 26.4, macOS 26.4, watchOS 26.4, tvOS 26.4, visionOS 26.4, *)
+  private func parseCommitmentInfo(from transaction: Transaction) -> Qonversion.TransactionCommitmentInfo? {
+    guard let jsonDict = (try? JSONSerialization.jsonObject(with: transaction.jsonRepresentation)) as? [String: Any],
+          let raw = jsonDict["commitmentInfo"] as? [String: Any],
+          let billingPeriodNumber = raw["billingPeriodNumber"] as? UInt64,
+          let totalBillingPeriods = raw["totalBillingPeriods"] as? UInt64,
+          let priceValue = raw["price"],
+          let expirationDateString = raw["expirationDate"] as? String
+    else { return nil }
+
+    let priceDecimal = NSDecimalNumber(string: "\(priceValue)")
+    let formatter = ISO8601DateFormatter()
+    guard let expirationDate = formatter.date(from: expirationDateString) else { return nil }
+
+    return Qonversion.TransactionCommitmentInfo(
+      billingPeriodNumber: UInt(billingPeriodNumber),
+      totalBillingPeriods: UInt(totalBillingPeriods),
+      pricePerBillingPeriod: priceDecimal,
+      currentBillingPeriodExpirationDate: expirationDate
+    )
   }
   
   private func convert(paymentMode: Product.SubscriptionOffer.PaymentMode) -> String {


### PR DESCRIPTION
## Summary

- New public DTO `QONTransactionCommitmentInfo` (Swift name `Qonversion.TransactionCommitmentInfo`) exposed on `QONTransaction.commitmentInfo`, gated `API_AVAILABLE(ios(26.4), macosx(26.4), watchos(26.4), tvos(26.4), visionos(26.4))`. Fields: `billingPeriodNumber`, `totalBillingPeriods`, `pricePerBillingPeriod`, `currentBillingPeriodExpirationDate`. Consumers can compute "X of Y payments remaining" from `totalBillingPeriods - billingPeriodNumber`.
- Commitment data is parsed on-device from `Transaction.jsonRepresentation` in `PurchasesMapper.swift` (gated `@available(iOS 26.4, ...)`) and cached on `QNProductCenterManager` keyed by `transactionId`. The cache uses one-shot consume semantics: entries are removed once enrichment writes the value onto a matching `QONTransaction`.
- Enrichment is wired into every consumer-facing path that returns transactions: `launch:` (success and error-with-data), `handlePurchasedTransaction:` (SK1), and `prepareEntitlementsResultWithCompletion:` (cached-entitlements path used by `checkEntitlements`).

## Background

Apple shipped monthly subscriptions with a 12-month commitment in iOS 26.4 / 26.5 (May 2026). The commitment data lives on `Transaction.CommitmentInfo` (iOS 26.4+), a distinct sibling of `advancedCommerceInfo` (which targets the Advanced Commerce API and is unrelated). This PR exposes the commitment fields so apps can render progress in their UI.

The repo currently builds against Xcode 16.2 / iOS 18.2 SDK (pre-26.4), so the implementation reads JSON from `Transaction.jsonRepresentation` instead of typed property access. A code comment in `PurchasesMapper.swift` notes the transition: swap to `transaction.commitmentInfo?.expirationDate` etc. once the Xcode SDK supports iOS 26.4.

## Out of scope

- `RenewalInfo.CommitmentInfo` (next-renewal forecast) - separate ticket if needed.
- Cross-platform wrappers (Flutter / RN / Unity / Cordova / Capacitor) - follow-up after iOS lands.
- `purchaseman` / backend ingestion of commitment fields - follow-up if needed for analytics.
- Mintlify documentation update.

## Test plan

- [ ] `pod install` then `xcodebuild test` on `QonversionTests` to confirm new DTO tests pass:
  - `testQONTransactionCommitmentInfo_init_setsAllFields`
  - `testQONTransactionCommitmentInfo_NSCoding_roundtrip`
- [ ] Manual smoke on an iOS 26.4 device or simulator with a real commitment-product transaction to confirm `QONTransaction.commitmentInfo` is populated on `launch:`, `checkEntitlements:`, and the `purchase` callback path.
- [ ] Verify `commitmentInfo` is nil on iOS < 26.4 and that no availability warnings or runtime crashes appear.

## References

- Linear: https://linear.app/qonversion/issue/DEV-906
- Apple announcement: https://support.apple.com/en-us/126901
- `Transaction.CommitmentInfo`: https://developer.apple.com/documentation/storekit/transaction/commitmentinfo-swift.struct
