### PR TITLE
fix(ios): report StoreKit 2 introductory/trial price, not full price

### DIFF
--- a/QonversionTests/QRequestSerializerTests.m
+++ b/QonversionTests/QRequestSerializerTests.m
@@ -1,17 +1,18 @@
 #import <XCTest/XCTest.h>
 #import "QNRequestSerializer.h"
+#import "QONStoreKit2PurchaseModel.h"
 
 @interface QNRequestSerializerTests : XCTestCase
 
 @property (nonatomic, strong) QNRequestSerializer *serializer;
 
 @end
-  
+
 @implementation QNRequestSerializerTests
 
 - (void)setUp {
     [super setUp];
-    
+
     self.serializer = [[QNRequestSerializer alloc] init];
 }
 
@@ -19,6 +20,58 @@
     id launchData = self.serializer.launchData;
     XCTAssertTrue([launchData isKindOfClass:[NSDictionary class]]);
     XCTAssertNotNil(launchData);
+}
+
+- (QONStoreKit2PurchaseModel *)baseStoreKit2Model {
+    QONStoreKit2PurchaseModel *model = [QONStoreKit2PurchaseModel new];
+    model.productId = @"com.qonversion.test.monthly";
+    model.price = @"9.99";
+    model.currency = @"USD";
+    model.transactionId = @"1000000000000001";
+    model.originalTransactionId = @"1000000000000001";
+    model.subscriptionPeriodUnit = @"2";
+    model.subscriptionPeriodNumberOfUnits = @"1";
+
+    return model;
+}
+
+- (void)testThatStoreKit2PaidIntroReportsIntroductoryPrice {
+    QONStoreKit2PurchaseModel *model = [self baseStoreKit2Model];
+    model.introductoryPrice = @"1.99";
+    model.introductoryNumberOfPeriods = @"1";
+    model.introductoryPeriodNumberOfUnits = @"1";
+    model.introductoryPeriodUnit = @"2";
+    model.introductoryPaymentMode = @"1";
+
+    NSDictionary *data = [self.serializer purchaseInfo:model receipt:nil];
+    NSDictionary *introOffer = data[@"introductory_offer"];
+
+    XCTAssertNotNil(introOffer);
+    XCTAssertEqualObjects(introOffer[@"value"], @"1.99");
+    XCTAssertNotEqualObjects(introOffer[@"value"], model.price);
+}
+
+- (void)testThatStoreKit2FreeTrialReportsZeroIntroductoryPrice {
+    QONStoreKit2PurchaseModel *model = [self baseStoreKit2Model];
+    model.introductoryPrice = @"0";
+    model.introductoryNumberOfPeriods = @"1";
+    model.introductoryPeriodNumberOfUnits = @"7";
+    model.introductoryPeriodUnit = @"0";
+    model.introductoryPaymentMode = @"2";
+
+    NSDictionary *data = [self.serializer purchaseInfo:model receipt:nil];
+    NSDictionary *introOffer = data[@"introductory_offer"];
+
+    XCTAssertNotNil(introOffer);
+    XCTAssertEqualObjects(introOffer[@"value"], @"0");
+}
+
+- (void)testThatStoreKit2NoIntroOmitsIntroductoryOffer {
+    QONStoreKit2PurchaseModel *model = [self baseStoreKit2Model];
+
+    NSDictionary *data = [self.serializer purchaseInfo:model receipt:nil];
+
+    XCTAssertNil(data[@"introductory_offer"]);
 }
 
 @end

--- a/QonversionTests/QRequestSerializerTests.m
+++ b/QonversionTests/QRequestSerializerTests.m
@@ -49,6 +49,10 @@
     XCTAssertNotNil(introOffer);
     XCTAssertEqualObjects(introOffer[@"value"], @"1.99");
     XCTAssertNotEqualObjects(introOffer[@"value"], model.price);
+    XCTAssertEqualObjects(introOffer[@"number_of_periods"], @"1");
+    XCTAssertEqualObjects(introOffer[@"period_number_of_units"], @"1");
+    XCTAssertEqualObjects(introOffer[@"period_unit"], @"2");
+    XCTAssertEqualObjects(introOffer[@"payment_mode"], @"1");
 }
 
 - (void)testThatStoreKit2FreeTrialReportsZeroIntroductoryPrice {
@@ -72,6 +76,35 @@
     NSDictionary *data = [self.serializer purchaseInfo:model receipt:nil];
 
     XCTAssertNil(data[@"introductory_offer"]);
+}
+
+- (void)testThatStoreKit2PromoOfferReportsValues {
+    QONStoreKit2PurchaseModel *model = [self baseStoreKit2Model];
+    model.promoOfferId = @"promo_winback";
+    model.promoOfferPrice = @"4.99";
+    model.promoOfferNumberOfPeriods = @"1";
+    model.promoOfferPeriodNumberOfUnits = @"1";
+    model.promoOfferPeriodUnit = @"2";
+    model.promoOfferPaymentMode = @"1";
+
+    NSDictionary *data = [self.serializer purchaseInfo:model receipt:nil];
+    NSDictionary *promoOffer = data[@"promo_offer"];
+
+    XCTAssertNotNil(promoOffer);
+    XCTAssertEqualObjects(promoOffer[@"id"], @"promo_winback");
+    XCTAssertEqualObjects(promoOffer[@"value"], @"4.99");
+    XCTAssertEqualObjects(promoOffer[@"number_of_periods"], @"1");
+    XCTAssertEqualObjects(promoOffer[@"period_number_of_units"], @"1");
+    XCTAssertEqualObjects(promoOffer[@"period_unit"], @"2");
+    XCTAssertEqualObjects(promoOffer[@"payment_mode"], @"1");
+}
+
+- (void)testThatStoreKit2NoPromoOmitsPromoOffer {
+    QONStoreKit2PurchaseModel *model = [self baseStoreKit2Model];
+
+    NSDictionary *data = [self.serializer purchaseInfo:model receipt:nil];
+
+    XCTAssertNil(data[@"promo_offer"]);
 }
 
 @end

--- a/Sources/Qonversion/Qonversion/Core/QNRequestSerializer/QNRequestSerializer.m
+++ b/Sources/Qonversion/Qonversion/Core/QNRequestSerializer/QNRequestSerializer.m
@@ -148,15 +148,17 @@ NS_ASSUME_NONNULL_BEGIN
     result[@"introductory_offer"] = introOffer;
   }
   
-  NSMutableDictionary *promoOffer = [[NSMutableDictionary alloc] init];
-  promoOffer[@"id"] = purchaseModel.promoOfferId;
-  promoOffer[@"value"] = purchaseModel.promoOfferPrice;
-  promoOffer[@"number_of_periods"] = purchaseModel.promoOfferNumberOfPeriods;
-  promoOffer[@"period_number_of_units"] = purchaseModel.promoOfferPeriodNumberOfUnits;
-  promoOffer[@"period_unit"] = purchaseModel.promoOfferPeriodUnit;
-  promoOffer[@"payment_mode"] = purchaseModel.promoOfferPaymentMode;
+  if (purchaseModel.promoOfferId != nil) {
+    NSMutableDictionary *promoOffer = [[NSMutableDictionary alloc] init];
+    promoOffer[@"id"] = purchaseModel.promoOfferId;
+    promoOffer[@"value"] = purchaseModel.promoOfferPrice;
+    promoOffer[@"number_of_periods"] = purchaseModel.promoOfferNumberOfPeriods;
+    promoOffer[@"period_number_of_units"] = purchaseModel.promoOfferPeriodNumberOfUnits;
+    promoOffer[@"period_unit"] = purchaseModel.promoOfferPeriodUnit;
+    promoOffer[@"payment_mode"] = purchaseModel.promoOfferPaymentMode;
 
-  result[@"promo_offer"] = [promoOffer copy];
+    result[@"promo_offer"] = [promoOffer copy];
+  }
   
   purchaseDict[@"country"] = purchaseModel.storefrontCountryCode;
   

--- a/Sources/Qonversion/Qonversion/Core/QNRequestSerializer/QNRequestSerializer.m
+++ b/Sources/Qonversion/Qonversion/Core/QNRequestSerializer/QNRequestSerializer.m
@@ -136,15 +136,17 @@ NS_ASSUME_NONNULL_BEGIN
   purchaseDict[@"period_unit"] = purchaseModel.subscriptionPeriodUnit;
   purchaseDict[@"period_number_of_units"] = purchaseModel.subscriptionPeriodNumberOfUnits;
     
-  NSMutableDictionary *introOffer = [[NSMutableDictionary alloc] init];
-  
-  introOffer[@"value"] = purchaseModel.price;
-  introOffer[@"number_of_periods"] = purchaseModel.introductoryNumberOfPeriods;
-  introOffer[@"period_number_of_units"] = purchaseModel.introductoryPeriodNumberOfUnits;
-  introOffer[@"period_unit"] = purchaseModel.introductoryPeriodUnit;
-  introOffer[@"payment_mode"] = purchaseModel.introductoryPaymentMode;
-  
-  result[@"introductory_offer"] = introOffer.count > 0 ? introOffer : nil;
+  if (purchaseModel.introductoryPrice != nil) {
+    NSMutableDictionary *introOffer = [[NSMutableDictionary alloc] init];
+
+    introOffer[@"value"] = purchaseModel.introductoryPrice;
+    introOffer[@"number_of_periods"] = purchaseModel.introductoryNumberOfPeriods;
+    introOffer[@"period_number_of_units"] = purchaseModel.introductoryPeriodNumberOfUnits;
+    introOffer[@"period_unit"] = purchaseModel.introductoryPeriodUnit;
+    introOffer[@"payment_mode"] = purchaseModel.introductoryPaymentMode;
+
+    result[@"introductory_offer"] = introOffer;
+  }
   
   NSMutableDictionary *promoOffer = [[NSMutableDictionary alloc] init];
   promoOffer[@"id"] = purchaseModel.promoOfferId;


### PR DESCRIPTION
## Summary

Fixes SUP3-154. On iOS, the StoreKit 2 purchase flow reported the introductory/trial price as the full subscription price, overstating first-period revenue. StoreKit 1 was unaffected.

`QNRequestSerializer.purchaseInfo:receipt:` (the SK2 path) set `introductory_offer.value = purchaseModel.price` (the standard price) instead of `purchaseModel.introductoryPrice`. The model already carried the correct value from `PurchasesMapper` (StoreKit's `introductoryOffer.price`); the serializer simply read the wrong field.

While fixing this, the sibling `promo_offer` block in the same method turned out to have the same spurious-block defect, so it is corrected in a follow-up commit.

## Fix

### Introductory offer

Guard the `introductory_offer` block on `introductoryPrice != nil` and read `introductoryPrice` for the value. One change fixes two defects:

- Wrong value: the intro/trial price is now reported correctly (free trial -> "0", paid intro -> discounted price).
- Spurious block: the old `introOffer.count > 0` guard was always true because `price` is `nonnull`, so an `introductory_offer` was emitted even for purchases with no offer. The new guard omits it.

### Promotional offer

The SK2 `promo_offer` block was built and attached unconditionally, so an empty `promo_offer {}` was emitted on every purchase that had no promotional offer - the same spurious-block pattern. Guard it on `promoOfferId != nil`.

Both fixes mirror the existing SK1 path (`purchaseData:...`, which guards `introductory_offer` on `product.introductoryPrice != nil` and `promo_offer` on the purchased offer id) and `PurchasesMapper` (which populates the `introductory_*` / `promoOffer_*` fields only when an offer exists). SK1 and SK2 send to the same purchase endpoint, which already tolerates an absent `introductory_offer` / `promo_offer` because the SK1 path omits them - so real offer purchases are unchanged on the wire and only the empty/phantom blocks are dropped.

## Tests

Adds regression coverage for the previously-untested SK2 `purchaseInfo:receipt:` path in `QRequestSerializerTests.m`:

- paid intro: every `introductory_offer` field is asserted; `value` equals the discounted price and not the full price
- free trial: `value` equals "0" (not dropped)
- no offer: `introductory_offer` is omitted
- promo present: every `promo_offer` field is reported
- no promo: `promo_offer` is omitted

Verified with `xcodebuild test -only-testing:QonversionTests/QNRequestSerializerTests` (6/6 passing).

## Notes

- Analytics/reporting only; entitlements and Apple billing are unaffected.
- Historical SK2 rows remain wrong and would need an App Store Server API backfill (the original payloads carry the wrong value) - out of scope here.
