### PR TITLE
fix: synchronize -[QNDevice advertiserID] to fix IDFA race crash

### DIFF
--- a/Sources/Qonversion/Qonversion/Utils/QNDevice/QNDevice.m
+++ b/Sources/Qonversion/Qonversion/Utils/QNDevice/QNDevice.m
@@ -215,21 +215,23 @@ static NSString * const kUserDefaultsSuiteName = @"qonversion.device.suite";
 }
 
 - (NSString *)advertiserID {
-  if (!_advertiserID && !self.idfaProhibited) {
+  @synchronized (self) {
+    if (!_advertiserID && !self.idfaProhibited) {
 #if TARGET_OS_WATCH || TARGET_OS_VISION
-    self.idfaProhibited = YES;
-    _advertiserID = nil;
-#else
-    SEL selector = NSSelectorFromString(@"obtainAdvertisingID");
-    if ([[QNDevice current] respondsToSelector:selector]) {
-      _advertiserID = ((NSString * (*)(id, SEL))[[QNDevice current] methodForSelector:selector])([QNDevice current], selector);
-    } else {
       self.idfaProhibited = YES;
-    }
+      _advertiserID = nil;
+#else
+      SEL selector = NSSelectorFromString(@"obtainAdvertisingID");
+      if ([[QNDevice current] respondsToSelector:selector]) {
+        _advertiserID = ((NSString * (*)(id, SEL))[[QNDevice current] methodForSelector:selector])([QNDevice current], selector);
+      } else {
+        self.idfaProhibited = YES;
+      }
 #endif
+    }
+
+    return _advertiserID;
   }
-  
-  return _advertiserID;
 }
 
 #if TARGET_OS_WATCH || TARGET_OS_VISION


### PR DESCRIPTION
## Summary

- Wraps `-[QNDevice advertiserID]` (`Sources/Qonversion/Qonversion/Utils/QNDevice/QNDevice.m`) in `@synchronized(self)` so the lazy check-then-store on `_advertiserID` is serialized across threads.
- Closes a long-standing race that surfaces as `EXC_BAD_ACCESS` in `objc_retain` along the IDFA collection path.
- One file, +13 / -11; only indentation changes outside the new lock keyword. No public API change.

## Background

Investing.com (com.investing.app, SDK 6.9.0) reports a spike since early April in crashes traced to three signatures, all `EXC_BAD_ACCESS` at `objc_retain_x0 + 16` (90-day Crashlytics counts):

- `-[Qonversion collectAdvertisingId]` - 180
- `-[Qonversion setUserProperty:value:]` - 125
- `-[QNDevice fbAnonID]` - 6

Two SDK-driven paths reach the unsynchronized lazy initializer concurrently:

1. **Main thread, ~5s post-init** - `QNUserPropertiesManager.collectIntegrationsData` does `dispatch_async(main, performSelector(collectIntegrationsDataInBackground) afterDelay:5)`. That method reads `self.device.fbAnonID`, which calls `self.advertiserID` twice on one line (`QNDevice.m:292`).
2. **Background QoS thread** - the customer's `ATTrackingManager.requestTrackingAuthorization` completion calls `Qonversion.shared().collectAdvertisingId()`, which reads `[QNDevice current].advertiserID`.

The concurrent `objc_storeStrong` on the strong `_advertiserID` ivar can either tear the pointer slot or over-release the prior value. Either way the next reader hands a bad pointer to `objc_retain`. The lazy branch re-runs on every call until ATT is granted, keeping the race window wide open.

Code unchanged since 2021; same signature present on 6.0.0.

## Fix

A single `@synchronized(self)` around the getter body. The lock is recursive, so the (non-existent) re-entry through `respondsToSelector:` / `methodForSelector:` / the IMP-cast call to `obtainAdvertisingID` would be safe anyway. No external code uses `@synchronized([QNDevice current])`, so there is no risk of cross-object contention.

Why not the alternatives:

- `atomic` on the property only guards individual loads/stores, not the compound check-init-return, so two threads can still race the lookup and double-store.
- `dispatch_once` cannot be re-armed; the existing behavior re-attempts the IDFA load on every call until either `_advertiserID` is set or `idfaProhibited` flips.
- A dedicated `dispatch_queue_t` / `os_unfair_lock` ivar adds new state for a single getter on a cold path.
- Marshaling at call sites leaves the underlying race in place and any future caller re-introduces the crash class.

## Test plan

- [ ] Customer ships hotfix with no app-side change (only SDK bump) and confirms the three signatures drop in Crashlytics over the next release cycle. That drop is the empirical confirmation - this race is hard to repro locally without TSan + a tight loop.
- [ ] Optional: run the existing test target under Xcode's Thread Sanitizer to confirm no warnings on the new lock.
- [ ] Manual smoke: launch sample app on iOS 18 / iOS 26 device, accept ATT, confirm IDFA propagates to a `setUserProperty` round-trip.

## Linear

[SUP3-137](https://linear.app/qonversion/issue/SUP3-137/investingcom-ios-objc-retain-crashes-in-qonversion-idfa-collection)