### PR TITLE
feat(web2app): wire redemption Universal Link into iOS sample app

### DIFF
--- a/Sample/Sample.entitlements
+++ b/Sample/Sample.entitlements
@@ -8,5 +8,9 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:screens.qonversion.io</string>
+	</array>
 </dict>
 </plist>

--- a/Sample/SampleApp.swift
+++ b/Sample/SampleApp.swift
@@ -21,6 +21,37 @@ struct SampleApp: App {
         WindowGroup {
             ContentView()
                 .environmentObject(appState)
+                // Web2App redemption (DEV-847): the redemption email opens a
+                // Universal Link https://screens.qonversion.io/r/{project_uid}/{token}.
+                // iOS delivers it as a browsing-web user activity. Forward the URL
+                // to the SDK, which validates host + path internally (grant-first:
+                // on success the backend already granted the entitlement, the SDK
+                // just refreshes — no identify).
+                .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { activity in
+                    guard let url = activity.webpageURL else { return }
+                    handleRedemption(url)
+                }
+        }
+    }
+
+    private func handleRedemption(_ url: URL) {
+        Qonversion.shared().handleRedemptionLink(url: url) { result in
+            switch result {
+            case .success:
+                print("✅ Redemption succeeded — entitlements refreshed")
+            case .tokenExpired:
+                print("⏰ Redemption token expired — offer reissue")
+            case .alreadyConsumed:
+                print("♻️ Redemption token already consumed")
+            case .invalidToken:
+                print("❌ Invalid redemption token")
+            case .networkError:
+                print("📡 Network error during redemption")
+            case .retryable:
+                print("🔁 Retryable error during redemption — try again")
+            @unknown default:
+                print("Redemption result: \(result.rawValue)")
+            }
         }
     }
     


### PR DESCRIPTION
Brings the **iOS sample** to parity with the Android sample for Web2App redemption testing.

## Changes (sample-only — NO SDK release needed)
- `Sample/Sample.entitlements`: add `com.apple.developer.associated-domains` → `applinks:screens.qonversion.io`.
- `Sample/SampleApp.swift`: `.onContinueUserActivity(NSUserActivityTypeBrowsingWeb)` → forwards the redemption Universal Link to `Qonversion.shared().handleRedemptionLink(url:)`; logs each `QONRedemptionResult` case.

The redemption SDK API (`handleRedemptionLink`, from #669) is already on develop, so the sample compiles against it. **This does not modify `Sources/Qonversion`** (the published CocoaPods/SPM artifact) — it's purely the demo app, so it ships without an SDK release.

## To test on iOS (prerequisites)
- The sample app's **bundle id + Team id** must be in the AASA at `screens.qonversion.io/.well-known/apple-app-site-association` (DEV-1101 AASA population) for the Universal Link to open the app.
- Domain `screens.qonversion.io` must be live (DEV-1101).
- Grant-first: on `Success` the backend already granted the entitlement; the SDK refreshes (no identify).

Note: not buildable in the agent sandbox (no Xcode) — relies on CI / local Xcode build. Related: DEV-847, DEV-1102.