### PR TITLE
feat: restore parity with the production SDK

### DIFF
--- a/Sources/Managers/PurchasesManager/PurchasesManager.swift
+++ b/Sources/Managers/PurchasesManager/PurchasesManager.swift
@@ -132,10 +132,22 @@ final class PurchasesManager: PurchasesManagerInterface, @unchecked Sendable {
         _ = try await userManager.obtainUser()
         let userId: String = userIdProvider.getUserId()
 
-        let restored: [Qonversion.Transaction] = try await storeKitFacade.restore()
+        let restored: [Qonversion.Transaction]
+        do {
+            restored = try await storeKitFacade.restore()
+        } catch {
+            // A store failure (e.g. a Stripe-only user without an Apple
+            // receipt) must not discard the entitlements the backend knows.
+            if let fetched: [String: Qonversion.Entitlement] = try? await entitlementsManager.entitlements(), !fetched.isEmpty {
+                logger.warning("Store restore failed, returning backend entitlements: " + error.message)
+                return fetched
+            }
+            throw error
+        }
         // Production rule: only the latest transaction per product participates.
         let latest = EntitlementsCalculator.latestTransactionsPerProduct(restored)
 
+        var resolvedOwnerUserId: String?
         do {
             for transaction in latest {
                 // Skip transactions already reported this session (sweep,
@@ -144,7 +156,10 @@ final class PurchasesManager: PurchasesManagerInterface, @unchecked Sendable {
                     guard await reportsGate.tryTake(id) else { continue }
                 }
                 do {
-                    try await purchasesService.send(transaction, userId: userId)
+                    let ownerUserId: String? = try await purchasesService.send(transaction, userId: userId)
+                    if let ownerUserId, ownerUserId != userId {
+                        resolvedOwnerUserId = ownerUserId
+                    }
                 } catch {
                     if let id: String = transaction.id {
                         await reportsGate.release(id)
@@ -159,10 +174,24 @@ final class PurchasesManager: PurchasesManagerInterface, @unchecked Sendable {
             throw QonversionError(type: .restoreFailed, message: nil, error: error)
         }
 
+        await switchToOwnerIfNeeded(resolvedOwnerUserId)
+
         if let fetched: [String: Qonversion.Entitlement] = try? await entitlementsManager.entitlements() {
             return fetched
         }
         return await entitlementsManager.localFallbackEntitlements(for: latest)
+    }
+
+    /// The restored transactions may belong to another Qonversion user — the
+    /// backend resolves the owner and the SDK follows (production parity).
+    private func switchToOwnerIfNeeded(_ ownerUserId: String?) async {
+        guard let ownerUserId else { return }
+
+        do {
+            try await userManager.switchToUser(with: ownerUserId)
+        } catch {
+            logger.error("Failed to switch to the transactions owner: " + error.message)
+        }
     }
 
     func promotionalOffer(for product: Qonversion.Product, discountId: String) async throws -> Qonversion.PromotionalOffer {
@@ -247,12 +276,16 @@ final class PurchasesManager: PurchasesManagerInterface, @unchecked Sendable {
         let latest: [Qonversion.Transaction] = EntitlementsCalculator.latestTransactionsPerProduct(history)
 
         var hadFailures = false
+        var resolvedOwnerUserId: String?
         for transaction in latest {
             if let id: String = transaction.id {
                 guard await reportsGate.tryTake(id) else { continue }
             }
             do {
-                try await purchasesService.send(transaction, userId: userId)
+                let ownerUserId: String? = try await purchasesService.send(transaction, userId: userId)
+                if let ownerUserId, ownerUserId != userId {
+                    resolvedOwnerUserId = ownerUserId
+                }
             } catch {
                 if let id: String = transaction.id {
                     await reportsGate.release(id)
@@ -261,6 +294,8 @@ final class PurchasesManager: PurchasesManagerInterface, @unchecked Sendable {
                 logger.error("Failed to report a historical transaction: " + error.message)
             }
         }
+
+        await switchToOwnerIfNeeded(resolvedOwnerUserId)
 
         if !hadFailures {
             localStorage.set(bool: true, forKey: Constants.historicalDataSyncedKey.rawValue)

--- a/Sources/Managers/UserManager/UserManager.swift
+++ b/Sources/Managers/UserManager/UserManager.swift
@@ -112,6 +112,12 @@ actor UserManager: UserManagerInterface {
         userChangesNotifier.notifyUserChanged()
     }
 
+    func switchToUser(with uid: String) async throws {
+        guard uid != internalConfig.userId else { return }
+
+        try await switchUser(to: uid)
+    }
+
     func userInfo() async throws -> Qonversion.User {
         try await obtainUser()
 

--- a/Sources/Managers/UserManager/UserManagerInterface.swift
+++ b/Sources/Managers/UserManager/UserManagerInterface.swift
@@ -30,6 +30,10 @@ protocol UserManagerInterface {
     /// Unlinks the current identity and resets to a fresh anonymous user.
     func logout() async
 
+    /// Switches the SDK to another Qonversion user (e.g. the resolved owner
+    /// of restored transactions) and invalidates the user-scoped caches.
+    func switchToUser(with uid: String) async throws
+
     /// Returns up-to-date info about the current user from the backend.
     func userInfo() async throws -> Qonversion.User
 }

--- a/Sources/Services/PurchasesService/PurchasesService.swift
+++ b/Sources/Services/PurchasesService/PurchasesService.swift
@@ -5,6 +5,27 @@
 
 import Foundation
 
+/// Wire shape of the created purchase; only the fields the SDK consumes.
+struct PurchaseReportResponse: Decodable {
+
+    /// The resolved owner of the transaction — may differ from the reporting
+    /// user when the store account belongs to another Qonversion user.
+    let userId: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case userId = "user_id"
+    }
+
+    init(userId: String?) {
+        self.userId = userId
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        userId = try container.decodeIfPresent(String.self, forKey: .userId)
+    }
+}
+
 /// Wire shape of the backend-signed promotional offer.
 struct PromoOfferSignatureResponse: Decodable {
 
@@ -47,7 +68,8 @@ final class PurchasesService: PurchasesServiceInterface {
     }
 
 
-    func send(_ transaction: Qonversion.Transaction, userId: String, options: Qonversion.PurchaseOptions?) async throws {
+    @discardableResult
+    func send(_ transaction: Qonversion.Transaction, userId: String, options: Qonversion.PurchaseOptions?) async throws -> String? {
         // The v4 store_data shape for the app_store platform; the signed
         // transaction (jws) travels in the receipt slot, the ids next to it
         // let the backend resolve and dedupe before verification.
@@ -79,7 +101,9 @@ final class PurchasesService: PurchasesServiceInterface {
 
         let request = Request.createPurchase(userId: userId, body: body)
         do {
-            _ = try await requestProcessor.process(request: request, responseType: EmptyApiResponse.self)
+            let response: PurchaseReportResponse = try await requestProcessor.process(request: request, responseType: PurchaseReportResponse.self)
+
+            return response.userId
         } catch {
             throw QonversionError(type: .purchaseReportingFailed, message: nil, error: error)
         }

--- a/Sources/Services/PurchasesService/PurchasesServiceInterface.swift
+++ b/Sources/Services/PurchasesService/PurchasesServiceInterface.swift
@@ -9,8 +9,10 @@ protocol PurchasesServiceInterface {
 
     /// Reports the purchase to the backend; the transaction's jws proof is
     /// included as part of the payload. Association options (contextKeys,
-    /// screenUid), when given, are attached to the report.
-    func send(_ transaction: Qonversion.Transaction, userId: String, options: Qonversion.PurchaseOptions?) async throws
+    /// screenUid), when given, are attached to the report. Returns the
+    /// resolved owner of the transaction when the backend provides one.
+    @discardableResult
+    func send(_ transaction: Qonversion.Transaction, userId: String, options: Qonversion.PurchaseOptions?) async throws -> String?
 
     /// Requests a backend-signed promotional offer for the store product.
     func promotionalOffer(userId: String, offerId: String, productStoreId: String) async throws -> Qonversion.PromotionalOffer
@@ -18,7 +20,8 @@ protocol PurchasesServiceInterface {
 
 extension PurchasesServiceInterface {
 
-    func send(_ transaction: Qonversion.Transaction, userId: String) async throws {
+    @discardableResult
+    func send(_ transaction: Qonversion.Transaction, userId: String) async throws -> String? {
         try await send(transaction, userId: userId, options: nil)
     }
 }

--- a/Tests/QonversionUnitTests/Mocks.swift
+++ b/Tests/QonversionUnitTests/Mocks.swift
@@ -553,6 +553,13 @@ final class MockUserManager: UserManagerInterface {
         logoutCallsCount += 1
     }
 
+    private(set) var switchedToUserIds: [String] = []
+
+    func switchToUser(with uid: String) async throws {
+        switchedToUserIds.append(uid)
+        if let error { throw error }
+    }
+
     func userInfo() async throws -> Qonversion.User {
         userInfoCallsCount += 1
         if let error { throw error }
@@ -581,10 +588,14 @@ final class MockPurchasesService: PurchasesServiceInterface {
     var promotionalOfferResult: Qonversion.PromotionalOffer?
     private(set) var promotionalOfferCalls: [(userId: String, offerId: String, productStoreId: String)] = []
 
-    func send(_ transaction: Qonversion.Transaction, userId: String, options: Qonversion.PurchaseOptions?) async throws {
+    var reportedOwnerUserId: String?
+
+    @discardableResult
+    func send(_ transaction: Qonversion.Transaction, userId: String, options: Qonversion.PurchaseOptions?) async throws -> String? {
         sentTransactions.append((transaction, userId, options))
         await onSend?()
         if let error { throw error }
+        return reportedOwnerUserId
     }
 
     func promotionalOffer(userId: String, offerId: String, productStoreId: String) async throws -> Qonversion.PromotionalOffer {

--- a/Tests/QonversionUnitTests/PurchasesManagerTests.swift
+++ b/Tests/QonversionUnitTests/PurchasesManagerTests.swift
@@ -528,6 +528,66 @@ final class PurchasesManagerTests: XCTestCase {
         XCTAssertTrue(service.sentTransactions.isEmpty)
     }
 
+    // MARK: - restore user switching
+
+    func testRestoreSwitchesToTheTransactionsOwner() async throws {
+        // The backend resolves the reported transaction to ANOTHER user.
+        facade.restoreResult = [makeTransaction(id: "t1")]
+        service.reportedOwnerUserId = "QON_owner"
+        entitlementsManager.entitlementsResult = ["premium": entitlement(id: "premium")]
+
+        _ = try await manager.restore()
+
+        XCTAssertEqual(userManager.switchedToUserIds, ["QON_owner"])
+    }
+
+    func testRestoreDoesNotSwitchWhenTheOwnerMatches() async throws {
+        facade.restoreResult = [makeTransaction(id: "t1")]
+        service.reportedOwnerUserId = uid
+        entitlementsManager.entitlementsResult = [:]
+
+        _ = try await manager.restore()
+
+        XCTAssertTrue(userManager.switchedToUserIds.isEmpty)
+    }
+
+    func testSyncHistoricalDataSwitchesToTheTransactionsOwner() async {
+        facade.historicalDataResult = [makeTransaction(id: "t1")]
+        service.reportedOwnerUserId = "QON_owner"
+
+        await manager.syncHistoricalData()
+
+        XCTAssertEqual(userManager.switchedToUserIds, ["QON_owner"])
+    }
+
+    // MARK: - backend entitlements survive a store failure on restore
+
+    func testRestoreReturnsBackendEntitlementsWhenTheStoreFails() async throws {
+        // A Stripe-only user on iOS: the store sync fails (no Apple receipt /
+        // cancelled sign-in), but the backend knows the entitlements.
+        facade.restoreError = QonversionError(type: .purchaseFailed)
+        entitlementsManager.entitlementsResult = ["stripe_premium": entitlement(id: "stripe_premium")]
+
+        let entitlements = try await manager.restore()
+
+        XCTAssertEqual(entitlements.keys.sorted(), ["stripe_premium"])
+        XCTAssertTrue(service.sentTransactions.isEmpty)
+    }
+
+    func testRestoreRethrowsTheStoreErrorWhenTheBackendHasNothing() async {
+        facade.restoreError = QonversionError(type: .purchaseFailed)
+        entitlementsManager.entitlementsResult = [:]
+
+        do {
+            _ = try await manager.restore()
+            XCTFail("Expected the store error")
+        } catch let error as QonversionError {
+            XCTAssertEqual(error.type, .purchaseFailed)
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
     // MARK: - historical data sync
 
     func testSyncHistoricalDataReportsLatestTransactionPerProductWithoutFinishing() async {

--- a/Tests/QonversionUnitTests/PurchasesServiceTests.swift
+++ b/Tests/QonversionUnitTests/PurchasesServiceTests.swift
@@ -38,7 +38,7 @@ final class PurchasesServiceTests: XCTestCase {
 
     func testSendPostsPurchaseWithV4StoreDataAndJwsProof() async throws {
         let processor = MockRequestProcessor()
-        processor.results = [EmptyApiResponse()]
+        processor.results = [PurchaseReportResponse(userId: nil)]
         let service = makeService(processor)
 
         try await service.send(makeTransaction(), userId: "QON_buyer")
@@ -65,7 +65,7 @@ final class PurchasesServiceTests: XCTestCase {
 
     func testSendWithoutPurchaseDateOmitsPurchasedAt() async throws {
         let processor = MockRequestProcessor()
-        processor.results = [EmptyApiResponse()]
+        processor.results = [PurchaseReportResponse(userId: nil)]
         let service = makeService(processor)
 
         try await service.send(makeTransaction(purchaseDate: nil), userId: "QON_buyer")
@@ -78,7 +78,7 @@ final class PurchasesServiceTests: XCTestCase {
 
     func testSendWithOptionsIncludesContextKeysAndScreenUid() async throws {
         let processor = MockRequestProcessor()
-        processor.results = [EmptyApiResponse()]
+        processor.results = [PurchaseReportResponse(userId: nil)]
         let service = makeService(processor)
         let options = Qonversion.PurchaseOptions(contextKeys: ["main", "onboarding"], screenUid: "screen_1")
 
@@ -93,7 +93,7 @@ final class PurchasesServiceTests: XCTestCase {
 
     func testSendWithoutOptionsOmitsAssociationFields() async throws {
         let processor = MockRequestProcessor()
-        processor.results = [EmptyApiResponse()]
+        processor.results = [PurchaseReportResponse(userId: nil)]
         let service = makeService(processor)
 
         try await service.send(makeTransaction(), userId: "QON_buyer")
@@ -107,7 +107,7 @@ final class PurchasesServiceTests: XCTestCase {
 
     func testSendWithoutJwsSendsEmptyReceipt() async throws {
         let processor = MockRequestProcessor()
-        processor.results = [EmptyApiResponse()]
+        processor.results = [PurchaseReportResponse(userId: nil)]
         let service = makeService(processor)
 
         try await service.send(makeTransaction(jws: nil), userId: "QON_buyer")


### PR DESCRIPTION
- restore and syncHistoricalData follow the backend-resolved transactions owner (the purchase report response carries user_id) and switch the user with cache invalidation
- a store failure on restore no longer discards the entitlements the backend knows (Stripe-only users on iOS)