### PR TITLE
chore: release tooling for the Swift SDK

### DIFF
--- a/.github/workflows/manual_minor_prerelease.yml
+++ b/.github/workflows/manual_minor_prerelease.yml
@@ -8,6 +8,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Minor
         run: |
           fastlane minor

--- a/.github/workflows/manual_patch_prerelease.yml
+++ b/.github/workflows/manual_patch_prerelease.yml
@@ -8,6 +8,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Patch
         run: |
           fastlane patch

--- a/Qonversion.xcodeproj/project.pbxproj
+++ b/Qonversion.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		70CD93012BC6E22B0039D65C /* SendUserPropertiesResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70CD92A92BC6E22B0039D65C /* SendUserPropertiesResult.swift */; };
 		70CD93022BC6E22B0039D65C /* UserPropertiesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70CD92AA2BC6E22B0039D65C /* UserPropertiesManager.swift */; };
 		A300000000000000000000B1 /* PurchasesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A300000000000000000000A1 /* PurchasesManager.swift */; };
+		C600000000000000000000B1 /* SDKVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = C600000000000000000000A1 /* SDKVersion.swift */; };
 		C500000000000000000000B1 /* PurchaseAssociationsStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C500000000000000000000A1 /* PurchaseAssociationsStorage.swift */; };
 		C400000000000000000000B1 /* ListEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = C400000000000000000000A1 /* ListEnvelope.swift */; };
 		C100000000000000000000B1 /* AsyncMulticast.swift in Sources */ = {isa = PBXBuildFile; fileRef = C100000000000000000000A1 /* AsyncMulticast.swift */; };
@@ -187,6 +188,7 @@
 		A300000000000000000000A3 /* PurchasesService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PurchasesService.swift; sourceTree = "<group>"; };
 		A300000000000000000000A4 /* PurchasesServiceInterface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PurchasesServiceInterface.swift; sourceTree = "<group>"; };
 		A100000000000000000000A1 /* UserManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserManager.swift; sourceTree = "<group>"; };
+		C600000000000000000000A1 /* SDKVersion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SDKVersion.swift; sourceTree = "<group>"; };
 		C500000000000000000000A1 /* PurchaseAssociationsStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PurchaseAssociationsStorage.swift; sourceTree = "<group>"; };
 		C400000000000000000000A1 /* ListEnvelope.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListEnvelope.swift; sourceTree = "<group>"; };
 		C100000000000000000000A1 /* AsyncMulticast.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncMulticast.swift; sourceTree = "<group>"; };
@@ -688,6 +690,7 @@
 				70CD92E62BC6E22B0039D65C /* StoreKit */,
 				70CD92EB2BC6E22B0039D65C /* Utils */,
 				70CD92EC2BC6E22B0039D65C /* Configuration.swift */,
+				C600000000000000000000A1 /* SDKVersion.swift */,
 				70CD92ED2BC6E22B0039D65C /* InternalConfig.swift */,
 				70CD92EE2BC6E22B0039D65C /* LaunchMode.swift */,
 				70CD92EF2BC6E22B0039D65C /* PrivacyInfo.xcprivacy */,
@@ -916,6 +919,7 @@
 				A300000000000000000000B3 /* PurchasesService.swift in Sources */,
 				A300000000000000000000B4 /* PurchasesServiceInterface.swift in Sources */,
 				A100000000000000000000B1 /* UserManager.swift in Sources */,
+				C600000000000000000000B1 /* SDKVersion.swift in Sources */,
 				C500000000000000000000B1 /* PurchaseAssociationsStorage.swift in Sources */,
 				C400000000000000000000B1 /* ListEnvelope.swift in Sources */,
 				C100000000000000000000B1 /* AsyncMulticast.swift in Sources */,

--- a/Qonversion.xcodeproj/project.pbxproj
+++ b/Qonversion.xcodeproj/project.pbxproj
@@ -32,6 +32,8 @@
 		70CD93012BC6E22B0039D65C /* SendUserPropertiesResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70CD92A92BC6E22B0039D65C /* SendUserPropertiesResult.swift */; };
 		70CD93022BC6E22B0039D65C /* UserPropertiesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70CD92AA2BC6E22B0039D65C /* UserPropertiesManager.swift */; };
 		A300000000000000000000B1 /* PurchasesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A300000000000000000000A1 /* PurchasesManager.swift */; };
+		CA00000000000000000000B1 /* ReceiptFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA00000000000000000000A1 /* ReceiptFetcher.swift */; };
+		C900000000000000000000B1 /* RequestTrigger.swift in Sources */ = {isa = PBXBuildFile; fileRef = C900000000000000000000A1 /* RequestTrigger.swift */; };
 		C500000000000000000000B1 /* PurchaseAssociationsStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C500000000000000000000A1 /* PurchaseAssociationsStorage.swift */; };
 		C400000000000000000000B1 /* ListEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = C400000000000000000000A1 /* ListEnvelope.swift */; };
 		C100000000000000000000B1 /* AsyncMulticast.swift in Sources */ = {isa = PBXBuildFile; fileRef = C100000000000000000000A1 /* AsyncMulticast.swift */; };
@@ -187,6 +189,8 @@
 		A300000000000000000000A3 /* PurchasesService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PurchasesService.swift; sourceTree = "<group>"; };
 		A300000000000000000000A4 /* PurchasesServiceInterface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PurchasesServiceInterface.swift; sourceTree = "<group>"; };
 		A100000000000000000000A1 /* UserManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserManager.swift; sourceTree = "<group>"; };
+		CA00000000000000000000A1 /* ReceiptFetcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReceiptFetcher.swift; sourceTree = "<group>"; };
+		C900000000000000000000A1 /* RequestTrigger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestTrigger.swift; sourceTree = "<group>"; };
 		C500000000000000000000A1 /* PurchaseAssociationsStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PurchaseAssociationsStorage.swift; sourceTree = "<group>"; };
 		C400000000000000000000A1 /* ListEnvelope.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListEnvelope.swift; sourceTree = "<group>"; };
 		C100000000000000000000A1 /* AsyncMulticast.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncMulticast.swift; sourceTree = "<group>"; };
@@ -525,6 +529,7 @@
 			isa = PBXGroup;
 			children = (
 				70CD92BF2BC6E22B0039D65C /* Request.swift */,
+				C900000000000000000000A1 /* RequestTrigger.swift */,
 				70CD92C02BC6E22B0039D65C /* RequestType.swift */,
 			);
 			path = Request;
@@ -648,6 +653,7 @@
 			isa = PBXGroup;
 			children = (
 				70CD92DC2BC6E22B0039D65C /* StoreKitFacade.swift */,
+				CA00000000000000000000A1 /* ReceiptFetcher.swift */,
 				A200000000000000000000A1 /* StoreKitPurchaseOutcome.swift */,
 				70CD92DD2BC6E22B0039D65C /* StoreKitFacadeInterface.swift */,
 				70B4E96D2BD92B9C00EE808C /* StoreKitFacadeDelegate.swift */,
@@ -916,6 +922,8 @@
 				A300000000000000000000B3 /* PurchasesService.swift in Sources */,
 				A300000000000000000000B4 /* PurchasesServiceInterface.swift in Sources */,
 				A100000000000000000000B1 /* UserManager.swift in Sources */,
+				CA00000000000000000000B1 /* ReceiptFetcher.swift in Sources */,
+				C900000000000000000000B1 /* RequestTrigger.swift in Sources */,
 				C500000000000000000000B1 /* PurchaseAssociationsStorage.swift in Sources */,
 				C400000000000000000000B1 /* ListEnvelope.swift in Sources */,
 				C100000000000000000000B1 /* AsyncMulticast.swift in Sources */,

--- a/Qonversion.xcodeproj/project.pbxproj
+++ b/Qonversion.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		70CD93012BC6E22B0039D65C /* SendUserPropertiesResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70CD92A92BC6E22B0039D65C /* SendUserPropertiesResult.swift */; };
 		70CD93022BC6E22B0039D65C /* UserPropertiesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70CD92AA2BC6E22B0039D65C /* UserPropertiesManager.swift */; };
 		A300000000000000000000B1 /* PurchasesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A300000000000000000000A1 /* PurchasesManager.swift */; };
+		CB00000000000000000000B1 /* IntegrationsInfoCollector.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB00000000000000000000A1 /* IntegrationsInfoCollector.swift */; };
 		CA00000000000000000000B1 /* ReceiptFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA00000000000000000000A1 /* ReceiptFetcher.swift */; };
 		C900000000000000000000B1 /* RequestTrigger.swift in Sources */ = {isa = PBXBuildFile; fileRef = C900000000000000000000A1 /* RequestTrigger.swift */; };
 		C500000000000000000000B1 /* PurchaseAssociationsStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C500000000000000000000A1 /* PurchaseAssociationsStorage.swift */; };
@@ -189,6 +190,7 @@
 		A300000000000000000000A3 /* PurchasesService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PurchasesService.swift; sourceTree = "<group>"; };
 		A300000000000000000000A4 /* PurchasesServiceInterface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PurchasesServiceInterface.swift; sourceTree = "<group>"; };
 		A100000000000000000000A1 /* UserManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserManager.swift; sourceTree = "<group>"; };
+		CB00000000000000000000A1 /* IntegrationsInfoCollector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IntegrationsInfoCollector.swift; sourceTree = "<group>"; };
 		CA00000000000000000000A1 /* ReceiptFetcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReceiptFetcher.swift; sourceTree = "<group>"; };
 		C900000000000000000000A1 /* RequestTrigger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestTrigger.swift; sourceTree = "<group>"; };
 		C500000000000000000000A1 /* PurchaseAssociationsStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PurchaseAssociationsStorage.swift; sourceTree = "<group>"; };
@@ -611,6 +613,7 @@
 			isa = PBXGroup;
 			children = (
 				70CD92D32BC6E22B0039D65C /* DeviceInfoCollector.swift */,
+				CB00000000000000000000A1 /* IntegrationsInfoCollector.swift */,
 				70CD92D42BC6E22B0039D65C /* DeviceInfoCollectorInterface.swift */,
 				70CD92D52BC6E22B0039D65C /* DeviceService.swift */,
 				70CD92D62BC6E22B0039D65C /* DeviceServiceInterface.swift */,
@@ -922,6 +925,7 @@
 				A300000000000000000000B3 /* PurchasesService.swift in Sources */,
 				A300000000000000000000B4 /* PurchasesServiceInterface.swift in Sources */,
 				A100000000000000000000B1 /* UserManager.swift in Sources */,
+				CB00000000000000000000B1 /* IntegrationsInfoCollector.swift in Sources */,
 				CA00000000000000000000B1 /* ReceiptFetcher.swift in Sources */,
 				C900000000000000000000B1 /* RequestTrigger.swift in Sources */,
 				C500000000000000000000B1 /* PurchaseAssociationsStorage.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -22,31 +22,110 @@ Qonversion - In-app subscription monetization: implement subscriptions and grow 
 
 ## Getting Started
 
-The SDK is distributed via Swift Package Manager only:
+### Requirements
+
+- iOS 13.0+ / macOS 10.15+ / tvOS 13.0+ / watchOS 6.0+ / visionOS 1.0+
+- Purchases run on StoreKit 2 (iOS 15+) with an automatic StoreKit 1 fallback on older systems
+- The public API is async/await-first
+
+### Installation
+
+The SDK is distributed via Swift Package Manager only. In Xcode: **File → Add Package Dependencies…** and paste:
 
 ```
 https://github.com/qonversion/qonversion-ios-sdk
 ```
 
-Initialize the SDK on app launch:
+Or add it to your `Package.swift`:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/qonversion/qonversion-ios-sdk", from: "6.0.0")
+]
+```
+
+### Initialization
+
+Initialize the SDK once, as early as possible on app launch:
 
 ```swift
 import Qonversion
 
-let configuration = Qonversion.Configuration(apiKey: "YOUR_PROJECT_KEY", launchMode: .subscriptionManagement)
+let configuration = Qonversion.Configuration(
+    apiKey: "YOUR_PROJECT_KEY",          // Qonversion Dashboard → Settings
+    launchMode: .subscriptionManagement
+)
 Qonversion.initialize(with: configuration)
 ```
 
-Load products and make a purchase — the transaction is finished only after
-Qonversion confirms it; when the backend is unreachable, the purchase still
-succeeds with locally calculated entitlements:
+Pick the launch mode by who owns the purchase flow:
+
+| Mode | Who processes purchases | Who finishes transactions |
+|---|---|---|
+| `.subscriptionManagement` | The SDK (`purchase`, `restore`) | The SDK, strictly after Qonversion confirms the purchase |
+| `.analytics` | Your own StoreKit code | Your app — the SDK only tracks (`handlePurchases`) and never finishes anything |
+
+Optional configuration:
+
+```swift
+Qonversion.Configuration(
+    apiKey: "YOUR_PROJECT_KEY",
+    launchMode: .subscriptionManagement,
+    proxyURL: "your.proxy.domain",             // route API traffic through your server
+    entitlementsCacheLifetime: .month,         // how long cached entitlements power the offline fallback
+    logLevel: .warning                         // .verbose ... .disabled
+)
+```
+
+### User identity
+
+Every install gets an anonymous Qonversion user. Link it to your own user id after sign-in — if the id is already linked to another Qonversion user, the SDK switches to that user and invalidates every user-scoped cache:
+
+```swift
+try await Qonversion.shared.identify("your_user_id")
+
+await Qonversion.shared.logout()   // back to a fresh anonymous user; await it before the next identify
+
+let user = try await Qonversion.shared.userInfo()
+```
+
+Installs updated from the previous production SDK keep their user automatically — the stored uid is migrated on first launch.
+
+### Products and purchases
 
 ```swift
 let products = try await Qonversion.shared.products()
+
 let result = try await Qonversion.shared.purchase(products[0])
+// result.transaction — the verified store transaction
+// result.entitlements — the user's access after the purchase
 ```
 
-Check the user's access:
+The transaction is finished **only after Qonversion confirms the purchase**. If the backend is unreachable, the purchase still succeeds with locally calculated entitlements, and the report is retried automatically (offline queue + a sweep of unfinished transactions on the next launch).
+
+Attach context to a purchase — quantity, the remote config context and the screen that initiated it:
+
+```swift
+let options = Qonversion.PurchaseOptions(quantity: 1, contextKeys: ["main_paywall"], screenUid: "scr_42")
+try await Qonversion.shared.purchase(product, options: options)
+```
+
+Promotional offers are signed by Qonversion:
+
+```swift
+let offer = try await Qonversion.shared.getPromotionalOffer(for: product, discountId: "promo_id")
+try await Qonversion.shared.purchase(product, options: Qonversion.PurchaseOptions(promoOffer: offer))
+```
+
+Restore and history:
+
+```swift
+let entitlements = try await Qonversion.shared.restore()
+
+Qonversion.shared.syncHistoricalData()   // once per install; call it on the first launch of the integrated build
+```
+
+### Entitlements
 
 ```swift
 let entitlements = try await Qonversion.shared.checkEntitlements()
@@ -55,24 +134,53 @@ if entitlements["premium"]?.active == true {
 }
 ```
 
-Follow out-of-band updates (Ask to Buy approvals, renewals, purchases on
-other devices) and App Store promoted purchases — both are AsyncStreams in
-the style of StoreKit's `Transaction.updates`:
+When Qonversion is unreachable (5xx / connection issues), entitlements are calculated locally from StoreKit data with the production-grade rules and the persisted cache — purchases and restores never fail because of a temporary outage. For the very first launch without a network connection, bundle a fallback file `qonversion_ios_fallbacks.json` with your products and entitlement definitions.
+
+### Update streams
+
+Both streams follow the style of StoreKit's `Transaction.updates`: every access returns an independent stream, so subscribe from as many places as you need.
+
+Entitlements refreshed by out-of-band transactions — Ask to Buy approvals, renewals, purchases on other devices (subscription-management mode):
 
 ```swift
-for await entitlements in Qonversion.shared.entitlementsUpdates { /* ... */ }
+for await entitlements in Qonversion.shared.entitlementsUpdates {
+    // refresh the UI
+}
+```
 
+Purchases promoted in the App Store — call `purchase()` right away or keep the intent and trigger it when the app is ready (e.g. after onboarding); intents arriving before your subscription are buffered:
+
+```swift
 for await intent in Qonversion.shared.promoPurchaseIntents {
     try await intent.purchase()
 }
 ```
 
-In Analytics mode, report the purchases your own StoreKit 2 code makes:
+### Analytics mode
+
+Report the purchases your own StoreKit 2 code makes, so Qonversion can track them. The SDK never finishes these transactions — your app owns their lifecycle:
 
 ```swift
-await Qonversion.shared.handlePurchases([verificationResult])
+let result = try await product.purchase()
+if case .success(let verificationResult) = result {
+    await Qonversion.shared.handlePurchases([verificationResult])
+}
 ```
 
+### User properties and attribution
+
+```swift
+Qonversion.shared.setUserProperty("test@example.com", key: .email)
+Qonversion.shared.setCustomUserProperty("value", key: "my_key")
+let properties = try await Qonversion.shared.userProperties()
+
+Qonversion.shared.collectAppleSearchAdsAttribution()
+Qonversion.shared.collectAdvertisingId()   // after the ATT permission is granted
+```
+
+### Sample
+
+The `Sample` scheme in `Qonversion.xcodeproj` is a working demo of every flow above — set your project key in `AppDelegate` and run.
 
 ## In-App Subscription Implementation & Management
 

--- a/README.md
+++ b/README.md
@@ -27,26 +27,45 @@ Qonversion - In-app subscription monetization: implement subscriptions and grow 
 - iOS 13.0+ / macOS 10.15+ / tvOS 13.0+ / watchOS 6.0+ / visionOS 1.0+
 - Purchases run on StoreKit 2 (iOS 15+) with an automatic StoreKit 1 fallback on older systems
 - The public API is async/await-first
+- A Qonversion project: sign up at [qonversion.io](https://qonversion.io), create products and entitlements in the Dashboard, and grab the project key from **Settings**
+
+### Core concepts
+
+| Concept | What it is |
+|---|---|
+| **Product** | A Qonversion product linked to an App Store product. You operate Qonversion product ids in code, so changing the underlying store product doesn't require an app release. |
+| **Entitlement** | The access level a purchase unlocks (e.g. `premium`). One entitlement can be unlocked by many products across platforms — an Apple subscription and a Stripe payment can grant the same access. Check entitlements, not receipts. |
+| **Offering** | A group of products behind a paywall, in the display order configured in the Dashboard and personalized by A/B experiments. |
+| **User** | Every install gets an anonymous Qonversion user; link it to your own user id with `identify`. Entitlements follow the user across devices and platforms. |
+
+The flow: the app buys a store product → the SDK reports the purchase to Qonversion, which validates it with Apple → the user's entitlements update everywhere (device, other platforms, webhooks, integrations).
 
 ### Installation
 
-The SDK is distributed via Swift Package Manager only. In Xcode: **File → Add Package Dependencies…** and paste:
+The SDK is distributed via Swift Package Manager only.
+
+In Xcode: **File → Add Package Dependencies…**, paste the repository URL and add the `Qonversion` library to your app target:
 
 ```
 https://github.com/qonversion/qonversion-ios-sdk
 ```
 
-Or add it to your `Package.swift`:
+Or in `Package.swift`:
 
 ```swift
 dependencies: [
     .package(url: "https://github.com/qonversion/qonversion-ios-sdk", from: "6.0.0")
+],
+targets: [
+    .target(name: "YourApp", dependencies: [
+        .product(name: "Qonversion", package: "qonversion-ios-sdk")
+    ])
 ]
 ```
 
 ### Initialization
 
-Initialize the SDK once, as early as possible on app launch:
+Initialize the SDK once, as early as possible on app launch — `application(_:didFinishLaunchingWithOptions:)` or your `App` initializer:
 
 ```swift
 import Qonversion
@@ -58,125 +77,288 @@ let configuration = Qonversion.Configuration(
 Qonversion.initialize(with: configuration)
 ```
 
-Pick the launch mode by who owns the purchase flow:
+Initialization is synchronous and never blocks the launch. In the background it warms everything up: creates the backend user, refreshes the product → entitlements mapping, resumes purchase reports left unfinished by previous sessions, and starts observing out-of-band transactions (renewals, Ask to Buy approvals, purchases on other devices, offer code redemptions).
 
-| Mode | Who processes purchases | Who finishes transactions |
-|---|---|---|
-| `.subscriptionManagement` | The SDK (`purchase`, `restore`) | The SDK, strictly after Qonversion confirms the purchase |
-| `.analytics` | Your own StoreKit code | Your app — the SDK only tracks (`handlePurchases`) and never finishes anything |
-
-Optional configuration:
+All configuration options:
 
 ```swift
-Qonversion.Configuration(
+let configuration = Qonversion.Configuration(
     apiKey: "YOUR_PROJECT_KEY",
     launchMode: .subscriptionManagement,
-    proxyURL: "your.proxy.domain",             // route API traffic through your server
-    entitlementsCacheLifetime: .month,         // how long cached entitlements power the offline fallback
-    logLevel: .warning                         // .verbose ... .disabled
+    proxyURL: "your.proxy.domain",       // optional
+    entitlementsCacheLifetime: .month,   // default .month
+    logLevel: .warning                   // default .verbose
 )
 ```
 
-### User identity
+| Option | What it does |
+|---|---|
+| `proxyURL` | Routes all SDK traffic through your server — for regions where the API domain may be unreachable. Contact Qonversion before using it. |
+| `entitlementsCacheLifetime` | How long cached entitlements stay eligible for the offline fallback: `.week`, `.twoWeeks`, `.month`, `.twoMonths`, `.threeMonths`, `.sixMonths`, `.year`, `.unlimited`. |
+| `logLevel` | Minimal severity written to the unified log: `.verbose`, `.debug`, `.warning`, `.error`, `.critical`, or `.disabled`. |
 
-Every install gets an anonymous Qonversion user. Link it to your own user id after sign-in — if the id is already linked to another Qonversion user, the SDK switches to that user and invalidates every user-scoped cache:
+### Launch modes
+
+Pick the mode by who owns the purchase flow — it defines who finishes StoreKit transactions, and finishing them twice or never are both bugs:
+
+| | `.subscriptionManagement` | `.analytics` |
+|---|---|---|
+| Who calls StoreKit | The SDK (`purchase`, `restore`) | Your own code |
+| Who finishes transactions | The SDK — strictly after Qonversion confirms the purchase | Your app; the SDK never touches them |
+| How purchases reach Qonversion | Automatically | You pass them via `handlePurchases` |
+| Out-of-band transactions (renewals, Ask to Buy, other devices) | The SDK reports **and finishes** them, then emits fresh entitlements into `entitlementsUpdates` | The SDK only observes; reporting is up to you |
+| Entitlements | Calculated by Qonversion, with an on-device fallback | Available the same way |
+
+Use `.subscriptionManagement` for a full integration where Qonversion is the source of truth for access. Use `.analytics` when you keep your existing StoreKit code and want revenue analytics, integrations, and the subscribers CRM on top of it.
+
+### Users and identity
+
+Every install starts as an anonymous Qonversion user (`QON_...`). After your own sign-in, link it:
 
 ```swift
-try await Qonversion.shared.identify("your_user_id")
+let user = try await Qonversion.shared.identify("your_user_id")
+```
 
+Two outcomes, both handled for you:
+
+- the id is new → it links to the current anonymous user, purchases made before sign-in stay with the account;
+- the id is already linked to another Qonversion user (sign-in on a second device) → the SDK switches to that user and drops every user-scoped cache, so entitlements, offerings and remote configs are re-fetched for the right account.
+
+```swift
 await Qonversion.shared.logout()   // back to a fresh anonymous user; await it before the next identify
 
 let user = try await Qonversion.shared.userInfo()
+// user.id — the Qonversion user id (pass to support, find in the CRM)
+// user.identityId — your id if the user is identified
 ```
 
-Installs updated from the previous production SDK keep their user automatically — the stored uid is migrated on first launch.
+Installs updated from the previous production SDK keep their Qonversion user automatically — the stored uid is migrated on first launch, no code needed.
 
-### Products and purchases
+### Products
 
 ```swift
 let products = try await Qonversion.shared.products()
-
-let result = try await Qonversion.shared.purchase(products[0])
-// result.transaction — the verified store transaction
-// result.entitlements — the user's access after the purchase
 ```
 
-The transaction is finished **only after Qonversion confirms the purchase**. If the backend is unreachable, the purchase still succeeds with locally calculated entitlements, and the report is retried automatically (offline queue + a sweep of unfinished transactions on the next launch).
-
-Attach context to a purchase — quantity, the remote config context and the screen that initiated it:
+Products come enriched with App Store data, ready for a paywall:
 
 ```swift
-let options = Qonversion.PurchaseOptions(quantity: 1, contextKeys: ["main_paywall"], screenUid: "scr_42")
-try await Qonversion.shared.purchase(product, options: options)
+for product in products {
+    // Identity
+    product.qonversionId       // "pro_monthly" — the id you operate in code
+    product.storeId            // "com.app.pro.monthly" — the App Store product id
+
+    // Display (localized by the store)
+    product.displayName        // "Pro Monthly"
+    product.displayPrice       // "$9.99"
+    product.price              // Decimal(9.99)
+
+    // Subscription details (nil for non-subscriptions)
+    product.subscription?.subscriptionPeriod     // 1 month
+    product.subscription?.introductoryOffer      // trial / intro price, if configured
+    product.subscription?.promotionalOffers      // promo offers configured in App Store Connect
+
+    // The raw store product, when you need the full StoreKit API
+    product.storeProduct       // StoreKit.Product (iOS 15+)
+    product.skProduct          // SKProduct (older systems)
+}
 ```
 
-Promotional offers are signed by Qonversion:
+### Offerings
+
+Offerings are the recommended way to build paywalls: the set and order of products is controlled from the Dashboard and personalized by A/B experiments — no app release needed to change a paywall.
+
+```swift
+let offerings = try await Qonversion.shared.offerings()
+
+if let main = offerings.main {                      // the offering marked as main
+    show(products: main.products)                   // already in the paywall order
+}
+let onboarding = offerings.offering(for: "onboarding_paywall")
+```
+
+### Trial and intro eligibility
+
+Show "Start your free trial" only to users who will actually get one. The check runs on the device via StoreKit 2 (subscription group history), no network round-trip:
+
+```swift
+let eligibility = try await Qonversion.shared.checkTrialIntroEligibility(["pro_monthly", "pro_annual"])
+
+switch eligibility["pro_monthly"] {
+case .eligible:                 break // show the trial CTA
+case .ineligible:               break // trial already consumed — show the regular price
+case .nonIntroOrTrialProduct:   break // no intro offer configured
+case .unknown, .none:           break // store can't answer (e.g. iOS < 15)
+}
+```
+
+### Making purchases
+
+```swift
+let products = try await Qonversion.shared.products()
+let result = try await Qonversion.shared.purchase(products[0])
+
+result.transaction                            // the verified store transaction
+result.entitlements["premium"]?.active        // access right after the purchase
+```
+
+The transaction is finished **only after Qonversion confirms the purchase** — an unreported purchase is never lost. A user cancellation and a pending purchase (Ask to Buy, SCA) surface as errors; a pending purchase completes later through the out-of-band flow and arrives via `entitlementsUpdates`.
+
+Attach context to a purchase:
+
+```swift
+let options = Qonversion.PurchaseOptions(
+    quantity: 1,                       // consumables
+    contextKeys: ["main_paywall"],     // ties the purchase to remote config contexts
+    screenUid: "scr_42"                // the screen that initiated the purchase
+)
+let result = try await Qonversion.shared.purchase(product, options: options)
+```
+
+`contextKeys` and `screenUid` survive the whole purchase lifecycle — including Ask to Buy approvals that arrive days later and app restarts in between.
+
+Promotional offers (win-back discounts for existing subscribers) are signed by Qonversion — no server code on your side:
 
 ```swift
 let offer = try await Qonversion.shared.getPromotionalOffer(for: product, discountId: "promo_id")
-try await Qonversion.shared.purchase(product, options: Qonversion.PurchaseOptions(promoOffer: offer))
+let options = Qonversion.PurchaseOptions(promoOffer: offer)
+let result = try await Qonversion.shared.purchase(product, options: options)
 ```
 
-Restore and history:
+**If Qonversion is unreachable at purchase time**, the purchase still succeeds: entitlements are calculated on the device, the report is queued and re-sent on the next launch, and the transaction stays unfinished until the backend confirms it. You never lose a sale to a network hiccup.
 
-```swift
-let entitlements = try await Qonversion.shared.restore()
-
-Qonversion.shared.syncHistoricalData()   // once per install; call it on the first launch of the integrated build
-```
-
-### Entitlements
+### Checking access
 
 ```swift
 let entitlements = try await Qonversion.shared.checkEntitlements()
-if entitlements["premium"]?.active == true {
+
+if let premium = entitlements["premium"], premium.active {
     // unlock the feature
 }
 ```
 
-When Qonversion is unreachable (5xx / connection issues), entitlements are calculated locally from StoreKit data with the production-grade rules and the persisted cache — purchases and restores never fail because of a temporary outage. For the very first launch without a network connection, bundle a fallback file `qonversion_ios_fallbacks.json` with your products and entitlement definitions.
+| Field | Meaning |
+|---|---|
+| `active` | Whether the access is currently granted. The only field you need for gating. |
+| `source` | Where the purchase came from: `.appStore`, `.playStore`, `.stripe`, `.manual`. |
+| `renewState` | `.willRenew`, `.canceled` (active until expiration), `.billingIssue` (grace period — worth a payment-update prompt). |
+| `startedDate` / `expirationDate` | Period bounds; `expirationDate == nil` means lifetime access. |
+| `productId` | The Qonversion product that granted the access. |
 
-### Update streams
+**Offline behavior.** When Qonversion is unreachable (5xx / connection issues), entitlements are calculated locally from StoreKit data, the persisted cache (see `entitlementsCacheLifetime`) and the product → entitlements mapping — access checks keep working through outages. For the very first launch without a network connection, bundle a `qonversion_ios_fallbacks.json` file into the app:
 
-Both streams follow the style of StoreKit's `Transaction.updates`: every access returns an independent stream, so subscribe from as many places as you need.
-
-Entitlements refreshed by out-of-band transactions — Ask to Buy approvals, renewals, purchases on other devices (subscription-management mode):
-
-```swift
-for await entitlements in Qonversion.shared.entitlementsUpdates {
-    // refresh the UI
+```json
+{
+    "products": [
+        {"id": "pro_monthly", "apple_product_id": "com.app.pro.monthly"}
+    ],
+    "products_permissions": {
+        "pro_monthly": ["premium"]
+    }
 }
 ```
 
-Purchases promoted in the App Store — call `purchase()` right away or keep the intent and trigger it when the app is ready (e.g. after onboarding); intents arriving before your subscription are buffered:
+### Listening for updates
+
+Both streams follow the style of StoreKit's `Transaction.updates`: every access returns an independent stream, so subscribe from as many places as you need. Start the listeners once, right after initialization:
 
 ```swift
-for await intent in Qonversion.shared.promoPurchaseIntents {
-    try await intent.purchase()
+Task {
+    for await entitlements in Qonversion.shared.entitlementsUpdates {
+        // fired after the SDK processes an out-of-band transaction:
+        // renewals, Ask to Buy approvals, purchases on other devices,
+        // offer code redemptions
+        refreshUI(with: entitlements)
+    }
+}
+
+Task {
+    for await intent in Qonversion.shared.promoPurchaseIntents {
+        // a purchase started from the App Store product page;
+        // call purchase() now, or keep the intent and trigger it
+        // when the app is ready (e.g. after onboarding)
+        let result = try await intent.purchase()
+    }
 }
 ```
+
+Promo purchase intents arriving before your subscription are buffered — subscribing late (after onboarding) is safe.
+
+### Restore and historical data
+
+```swift
+let entitlements = try await Qonversion.shared.restore()
+```
+
+Restore syncs the user's App Store purchases with Qonversion and returns the resulting entitlements. If the purchases turn out to belong to another Qonversion user, the SDK switches to that user — the same account ends up with the access on every device. If the App Store is unreachable but Qonversion knows the user's entitlements, they are returned instead of an error.
+
+```swift
+Qonversion.shared.syncHistoricalData()
+```
+
+Call it once after the first launch of the app version that integrates the SDK — it reports the user's past transactions so existing subscribers appear in the analytics with their real history. The SDK guarantees it runs at most once per install.
 
 ### Analytics mode
 
-Report the purchases your own StoreKit 2 code makes, so Qonversion can track them. The SDK never finishes these transactions — your app owns their lifecycle:
+Keep your own StoreKit 2 purchase code and feed the results to Qonversion:
 
 ```swift
-let result = try await product.purchase()
+// your purchase flow
+let result = try await storeProduct.purchase()
 if case .success(let verificationResult) = result {
     await Qonversion.shared.handlePurchases([verificationResult])
 }
+
+// and your transaction updates listener
+for await update in StoreKit.Transaction.updates {
+    await Qonversion.shared.handlePurchases([update])
+}
 ```
 
-### User properties and attribution
+The SDK reports these purchases for analytics and never finishes the transactions — your app owns their lifecycle. Repeated reports of the same transaction are deduplicated, so passing both the purchase result and the updates stream is safe.
+
+### User properties
+
+Properties power segmentation in analytics and are passed to integrations (AppsFlyer, Adjust, Firebase, etc.). They are batched and sent with a small delay:
 
 ```swift
 Qonversion.shared.setUserProperty("test@example.com", key: .email)
-Qonversion.shared.setCustomUserProperty("value", key: "my_key")
-let properties = try await Qonversion.shared.userProperties()
+Qonversion.shared.setUserProperty("af_id_123", key: .appsFlyerUserId)
+Qonversion.shared.setCustomUserProperty("gold", key: "tier")
 
-Qonversion.shared.collectAppleSearchAdsAttribution()
-Qonversion.shared.collectAdvertisingId()   // after the ATT permission is granted
+let properties = try await Qonversion.shared.userProperties()
 ```
+
+Defined keys: `.email`, `.name`, `.userId`, `.advertisingId`, `.appsFlyerUserId`, `.adjustAdId`, `.kochavaDeviceId`, `.firebaseAppInstanceId`, `.appMetricaDeviceId`, `.appMetricaUserProfileId`, `.pushWooshUserId`, `.pushWooshHwId`.
+
+### Attribution
+
+```swift
+// Apple Search Ads (iOS 14.3+): call on launch, the SDK fetches and
+// reports the attribution token by itself
+Qonversion.shared.collectAppleSearchAdsAttribution()
+
+// IDFA: call after the user grants the App Tracking Transparency permission
+Qonversion.shared.collectAdvertisingId()
+```
+
+### Remote config
+
+Remote config delivers JSON payloads controlled from the Dashboard and powers A/B experiments — paywall copy, feature flags, pricing tests:
+
+```swift
+let remoteConfig = try await Qonversion.shared.remoteConfig()
+let paywallTitle = remoteConfig.payload["paywall_title"] as? String
+
+// scoped by context key, e.g. per screen
+let onboardingConfig = try await Qonversion.shared.remoteConfig(contextKey: "onboarding")
+
+// experiment info, when the user is in one
+remoteConfig.experiment?.name
+remoteConfig.experiment?.group.type   // .control / .treatment
+```
+
+Link purchases to the experiment that drove them by passing the same context keys to `PurchaseOptions(contextKeys:)`.
 
 ### Sample
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,60 @@ Qonversion - In-app subscription monetization: implement subscriptions and grow 
 
 [![SPM Compatible](https://img.shields.io/badge/SPM-compatible-green.svg?style=flat)](https://documentation.qonversion.io/docs/ios-sdk-setup)
 [![Release](https://img.shields.io/github/v/release/qonversion/qonversion-ios-sdk?style=flat)](https://github.com/qonversion/qonversion-ios-sdk/releases)
-[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://documentation.qonversion.io/docs/ios-sdk-setup#install-via-carthage)
-[![SwiftPM compatible](https://img.shields.io/badge/SwiftPM-compatible-4BC51D.svg?style=flat)](https://documentation.qonversion.io/docs/ios-sdk-setup#install-via-swift-package-manager)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat)](https://qonversion.io)
+
+## Getting Started
+
+The SDK is distributed via Swift Package Manager only:
+
+```
+https://github.com/qonversion/qonversion-ios-sdk
+```
+
+Initialize the SDK on app launch:
+
+```swift
+import Qonversion
+
+let configuration = Qonversion.Configuration(apiKey: "YOUR_PROJECT_KEY", launchMode: .subscriptionManagement)
+Qonversion.initialize(with: configuration)
+```
+
+Load products and make a purchase — the transaction is finished only after
+Qonversion confirms it; when the backend is unreachable, the purchase still
+succeeds with locally calculated entitlements:
+
+```swift
+let products = try await Qonversion.shared.products()
+let result = try await Qonversion.shared.purchase(products[0])
+```
+
+Check the user's access:
+
+```swift
+let entitlements = try await Qonversion.shared.checkEntitlements()
+if entitlements["premium"]?.active == true {
+    // unlock the feature
+}
+```
+
+Follow out-of-band updates (Ask to Buy approvals, renewals, purchases on
+other devices) and App Store promoted purchases — both are AsyncStreams in
+the style of StoreKit's `Transaction.updates`:
+
+```swift
+for await entitlements in Qonversion.shared.entitlementsUpdates { /* ... */ }
+
+for await intent in Qonversion.shared.promoPurchaseIntents {
+    try await intent.purchase()
+}
+```
+
+In Analytics mode, report the purchases your own StoreKit 2 code makes:
+
+```swift
+await Qonversion.shared.handlePurchases([verificationResult])
+```
 
 
 ## In-App Subscription Implementation & Management

--- a/README.md
+++ b/README.md
@@ -188,7 +188,19 @@ result.transaction                            // the verified store transaction
 result.entitlements["premium"]?.active        // access right after the purchase
 ```
 
-The transaction is finished **only after Qonversion confirms the purchase** — an unreported purchase is never lost. A user cancellation and a pending purchase (Ask to Buy, SCA) surface as errors; a pending purchase completes later through the out-of-band flow and arrives via `entitlementsUpdates`.
+The transaction is finished **only after Qonversion confirms the purchase** — an unreported purchase is never lost. A user cancellation and a pending purchase (Ask to Buy, SCA) surface as typed errors — react precisely instead of showing a generic failure:
+
+```swift
+do {
+    let result = try await Qonversion.shared.purchase(product)
+} catch let error as QonversionError {
+    switch error.type {
+    case .purchaseCancelled: break     // the user changed their mind — not a failure
+    case .purchasePending: break       // completes later via entitlementsUpdates
+    default: showError(error.message)  // error.error carries the underlying failure
+    }
+}
+```
 
 Attach context to a purchase:
 
@@ -240,9 +252,17 @@ if let premium = entitlements["premium"], premium.active {
     ],
     "products_permissions": {
         "pro_monthly": ["premium"]
-    }
+    },
+    "remote_config_list": [
+        {
+            "payload": {"paywall_title": "Go Pro"},
+            "source": {"uid": "src_1", "name": "main", "type": "remote_configuration", "assignment_type": "auto", "context_key": null}
+        }
+    ]
 }
 ```
+
+The same file also answers `remoteConfig()` calls when the API is unreachable — bundle the configs your launch screens depend on.
 
 ### Listening for updates
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ Qonversion - In-app subscription monetization: implement subscriptions and grow 
 |---|---|
 | **Product** | A Qonversion product linked to an App Store product. You operate Qonversion product ids in code, so changing the underlying store product doesn't require an app release. |
 | **Entitlement** | The access level a purchase unlocks (e.g. `premium`). One entitlement can be unlocked by many products across platforms — an Apple subscription and a Stripe payment can grant the same access. Check entitlements, not receipts. |
-| **Offering** | A group of products behind a paywall, in the display order configured in the Dashboard and personalized by A/B experiments. |
 | **User** | Every install gets an anonymous Qonversion user; link it to your own user id with `identify`. Entitlements follow the user across devices and platforms. |
 
 The flow: the app buys a store product → the SDK reports the purchase to Qonversion, which validates it with Apple → the user's entitlements update everywhere (device, other platforms, webhooks, integrations).
@@ -122,7 +121,7 @@ let user = try await Qonversion.shared.identify("your_user_id")
 Two outcomes, both handled for you:
 
 - the id is new → it links to the current anonymous user, purchases made before sign-in stay with the account;
-- the id is already linked to another Qonversion user (sign-in on a second device) → the SDK switches to that user and drops every user-scoped cache, so entitlements, offerings and remote configs are re-fetched for the right account.
+- the id is already linked to another Qonversion user (sign-in on a second device) → the SDK switches to that user and drops every user-scoped cache, so entitlements and remote configs are re-fetched for the right account.
 
 ```swift
 await Qonversion.shared.logout()   // back to a fresh anonymous user; await it before the next identify
@@ -162,19 +161,6 @@ for product in products {
     product.storeProduct       // StoreKit.Product (iOS 15+)
     product.skProduct          // SKProduct (older systems)
 }
-```
-
-### Offerings
-
-Offerings are the recommended way to build paywalls: the set and order of products is controlled from the Dashboard and personalized by A/B experiments — no app release needed to change a paywall.
-
-```swift
-let offerings = try await Qonversion.shared.offerings()
-
-if let main = offerings.main {                      // the offering marked as main
-    show(products: main.products)                   // already in the paywall order
-}
-let onboarding = offerings.offering(for: "onboarding_paywall")
 ```
 
 ### Trial and intro eligibility

--- a/Sources/Assemblies/MiscAssembly.swift
+++ b/Sources/Assemblies/MiscAssembly.swift
@@ -9,10 +9,6 @@ import Foundation
 import OSLog
 import StoreKit
 
-fileprivate enum SDKLevelConstants: String {
-    case version = "1.0"
-}
-
 fileprivate enum IntConstants: UInt {
     case maxRequestsPerSecond = 5
 }
@@ -129,7 +125,7 @@ final class MiscAssembly {
     
     func headersBuilder() -> HeadersBuilderInterface {
         let deviceInfoCollector: DeviceInfoCollectorInterface = servicesAssembly.deviceInfoCollector()
-        let headersBuilder = HeadersBuilder(apiKey: apiKey, sdkVersion: SDKLevelConstants.version.rawValue, deviceInfoCollector: deviceInfoCollector, userDefaults: userDefaults)
+        let headersBuilder = HeadersBuilder(apiKey: apiKey, sdkVersion: SDKVersion.current, deviceInfoCollector: deviceInfoCollector, userDefaults: userDefaults)
         
         return headersBuilder
     }

--- a/Sources/Assemblies/QonversionAssembly.swift
+++ b/Sources/Assemblies/QonversionAssembly.swift
@@ -73,7 +73,9 @@ final class QonversionAssembly {
         let propertiesStorage: PropertiesStorage = miscAssembly.userPropertiesStorage()
         let logger: LoggerWrapper = miscAssembly.loggerWrapper()
         let userManager: UserManagerInterface = userManager()
-        let userPropertiesManager = UserPropertiesManager(requestProcessor: requestProcessor, propertiesStorage: propertiesStorage, delayCalculator: delayCalculator, userIdProvider: miscAssembly.internalConfig, userManager: userManager, logger: logger)
+        let deviceInfoCollector: DeviceInfoCollectorInterface = servicesAssembly.deviceInfoCollector()
+        let integrationsInfoCollector = IntegrationsInfoCollector(deviceInfoCollector: deviceInfoCollector)
+        let userPropertiesManager = UserPropertiesManager(requestProcessor: requestProcessor, propertiesStorage: propertiesStorage, delayCalculator: delayCalculator, userIdProvider: miscAssembly.internalConfig, userManager: userManager, integrationsInfoCollector: integrationsInfoCollector, logger: logger)
         userPropertiesManagerInstance = userPropertiesManager
 
         return userPropertiesManager

--- a/Sources/Assemblies/QonversionAssembly.swift
+++ b/Sources/Assemblies/QonversionAssembly.swift
@@ -28,6 +28,10 @@ final class QonversionAssembly {
     // Holds the transaction reports dedup gate and the update streams —
     // stateful, one instance SDK-wide.
     private var purchasesManagerInstance: PurchasesManager?
+
+    // Owns the shared pending-properties storage: the remote config manager
+    // flushes the same batch the facade fills — one instance SDK-wide.
+    private var userPropertiesManagerInstance: UserPropertiesManagerInterface?
     
     required init(apiKey: String, userDefaults: UserDefaults?, launchMode: Qonversion.LaunchMode = .analytics, baseURL: String? = nil, entitlementsCacheLifetime: Qonversion.EntitlementsCacheLifetime = .month, logLevel: Qonversion.LogLevel = .verbose) {
         let userDefaults: UserDefaults = userDefaults ?? UserDefaults.standard
@@ -60,13 +64,18 @@ final class QonversionAssembly {
     }
 
     func userPropertiesManager() -> UserPropertiesManagerInterface {
+        if let userPropertiesManagerInstance {
+            return userPropertiesManagerInstance
+        }
+
         let requestProcessor: RequestProcessorInterface = servicesAssembly.requestProcessor()
         let delayCalculator: IncrementalDelayCalculator = miscAssembly.delayCalculator()
         let propertiesStorage: PropertiesStorage = miscAssembly.userPropertiesStorage()
         let logger: LoggerWrapper = miscAssembly.loggerWrapper()
         let userManager: UserManagerInterface = userManager()
         let userPropertiesManager = UserPropertiesManager(requestProcessor: requestProcessor, propertiesStorage: propertiesStorage, delayCalculator: delayCalculator, userIdProvider: miscAssembly.internalConfig, userManager: userManager, logger: logger)
-        
+        userPropertiesManagerInstance = userPropertiesManager
+
         return userPropertiesManager
     }
     
@@ -166,7 +175,9 @@ final class QonversionAssembly {
 
         let remoteConfigService: RemoteConfigServiceInterface = servicesAssembly.remoteConfigService()
         let logger: LoggerWrapper = miscAssembly.loggerWrapper()
-        let remoteConfigManager = RemoteConfigManager(remoteConfigService: remoteConfigService, logger: logger)
+        let userManager: UserManagerInterface = userManager()
+        let userPropertiesManager: UserPropertiesManagerInterface = userPropertiesManager()
+        let remoteConfigManager = RemoteConfigManager(remoteConfigService: remoteConfigService, userManager: userManager, userPropertiesManager: userPropertiesManager, logger: logger)
 
         let userChangesNotifier: UserChangesNotifier = miscAssembly.userChangesNotifier()
 

--- a/Sources/Assemblies/ServicesAssembly.swift
+++ b/Sources/Assemblies/ServicesAssembly.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 fileprivate enum StringConstants: String {
-    case baseURL = "https://api.qonversion.io/"
+    case baseURL = "https://api2.qonversion.io/"
 }
 
 final class ServicesAssembly {
@@ -113,7 +113,8 @@ final class ServicesAssembly {
     func purchasesService() -> PurchasesServiceInterface {
         let requestProcessor: RequestProcessorInterface = requestProcessor()
         let appBundleId: String = Bundle.main.bundleIdentifier ?? ""
-        let purchasesService = PurchasesService(requestProcessor: requestProcessor, appBundleId: appBundleId)
+        let receiptFetcher = ReceiptFetcher()
+        let purchasesService = PurchasesService(requestProcessor: requestProcessor, appBundleId: appBundleId, receiptFetcher: receiptFetcher)
 
         return purchasesService
     }

--- a/Sources/Entities/UserPropertyKey.swift
+++ b/Sources/Entities/UserPropertyKey.swift
@@ -55,6 +55,9 @@ extension Qonversion {
         
         /// AppMetrica user profile ID
         case appMetricaUserProfileId = "_q_appmetrica_user_profile_id"
+
+        /// Tenjin analytics installation ID.
+        case tenjinAnalyticsInstallationId = "_q_tenjin_aiid"
         
         /// Value for custom user property
         /// - Important: Do not pass this value directly. Use ``Qonversion/Qonversion/setCustomUserProperty(_:key:)`` instead.

--- a/Sources/Managers/ProductsManager/ProductsManager.swift
+++ b/Sources/Managers/ProductsManager/ProductsManager.swift
@@ -52,6 +52,10 @@ final class ProductsManager: ProductsManagerInterface, ProductsDataSource, @unch
         return loadedProducts
     }
 
+    func isFallbackFileAccessible() -> Bool {
+        return fallbackService.obtainFallbackData() != nil
+    }
+
     func loadProductPermissions() async {
         do {
             let mapping: [String: [String]] = try await productsService.productPermissions()

--- a/Sources/Managers/ProductsManager/ProductsManagerInterface.swift
+++ b/Sources/Managers/ProductsManager/ProductsManagerInterface.swift
@@ -14,4 +14,7 @@ protocol ProductsManagerInterface {
     /// Fetches the product → permissions mapping and refreshes the persistent
     /// cache on every success; on failure the previously cached mapping stays.
     func loadProductPermissions() async
+
+    /// Whether the bundled fallback file is present and parses.
+    func isFallbackFileAccessible() -> Bool
 }

--- a/Sources/Managers/PurchasesManager/PurchasesManager.swift
+++ b/Sources/Managers/PurchasesManager/PurchasesManager.swift
@@ -23,6 +23,10 @@ final class PurchasesManager: PurchasesManagerInterface, @unchecked Sendable {
     private let localStorage: LocalStorageInterface
     private let logger: LoggerWrapper
 
+    // Joined by concurrent restore() calls; guarded by restoreTaskLock.
+    private let restoreTaskLock = NSLock()
+    private var restoreTask: Task<[String: Qonversion.Entitlement], Error>?
+
     private let reportsGate = TransactionReportsGate()
 
     /// Emits fresh entitlements after the SDK processes an observed
@@ -65,6 +69,10 @@ final class PurchasesManager: PurchasesManagerInterface, @unchecked Sendable {
 
     @discardableResult
     func purchase(_ product: Qonversion.Product, options: Qonversion.PurchaseOptions?) async throws -> Qonversion.PurchaseResult {
+        if launchModeProvider.launchMode == .analytics {
+            logger.warning("Making purchases via Qonversion in the Analytics mode can lead to an inconsistent state in the store. Consider switching to the Subscription management mode.")
+        }
+
         // The backend user must exist before the purchase is reported. The
         // uid is captured HERE: a logout during the payment sheet must not
         // reroute the report to the next anonymous user.
@@ -95,7 +103,7 @@ final class PurchasesManager: PurchasesManagerInterface, @unchecked Sendable {
         }
 
         do {
-            try await purchasesService.send(transaction, userId: userId, options: options)
+            try await purchasesService.send(transaction, userId: userId, options: options, trigger: .purchase)
             purchaseAssociationsStorage.remove(for: product.storeId)
         } catch {
             // Production fault tolerance: when the backend is unreachable the
@@ -129,6 +137,40 @@ final class PurchasesManager: PurchasesManagerInterface, @unchecked Sendable {
 
     @discardableResult
     func restore() async throws -> [String: Qonversion.Entitlement] {
+        // Production parity: concurrent restore() calls join one in-flight
+        // run instead of syncing with the store twice.
+        let task: Task<[String: Qonversion.Entitlement], Error> = joinedRestoreTask()
+        defer { clearRestoreTask(task) }
+
+        return try await task.value
+    }
+
+    private func joinedRestoreTask() -> Task<[String: Qonversion.Entitlement], Error> {
+        restoreTaskLock.lock()
+        defer { restoreTaskLock.unlock() }
+
+        if let inFlight: Task<[String: Qonversion.Entitlement], Error> = restoreTask {
+            return inFlight
+        }
+
+        let task = Task { [weak self] () throws -> [String: Qonversion.Entitlement] in
+            guard let self else { return [:] }
+            return try await self.performRestore()
+        }
+        restoreTask = task
+
+        return task
+    }
+
+    private func clearRestoreTask(_ task: Task<[String: Qonversion.Entitlement], Error>) {
+        restoreTaskLock.lock()
+        defer { restoreTaskLock.unlock() }
+        if restoreTask == task {
+            restoreTask = nil
+        }
+    }
+
+    private func performRestore() async throws -> [String: Qonversion.Entitlement] {
         _ = try await userManager.obtainUser()
         let userId: String = userIdProvider.getUserId()
 
@@ -156,7 +198,7 @@ final class PurchasesManager: PurchasesManagerInterface, @unchecked Sendable {
                     guard await reportsGate.tryTake(id) else { continue }
                 }
                 do {
-                    let ownerUserId: String? = try await purchasesService.send(transaction, userId: userId)
+                    let ownerUserId: String? = try await purchasesService.send(transaction, userId: userId, trigger: .restore)
                     if let ownerUserId, ownerUserId != userId {
                         resolvedOwnerUserId = ownerUserId
                     }
@@ -239,7 +281,7 @@ final class PurchasesManager: PurchasesManagerInterface, @unchecked Sendable {
                 guard await reportsGate.tryTake(id) else { continue }
             }
             do {
-                try await purchasesService.send(transaction, userId: userId)
+                try await purchasesService.send(transaction, userId: userId, trigger: .handleStoreKit2Transactions)
             } catch {
                 if let id: String = transaction.id {
                     await reportsGate.release(id)
@@ -282,7 +324,7 @@ final class PurchasesManager: PurchasesManagerInterface, @unchecked Sendable {
                 guard await reportsGate.tryTake(id) else { continue }
             }
             do {
-                let ownerUserId: String? = try await purchasesService.send(transaction, userId: userId)
+                let ownerUserId: String? = try await purchasesService.send(transaction, userId: userId, trigger: .syncHistoricalData)
                 if let ownerUserId, ownerUserId != userId {
                     resolvedOwnerUserId = ownerUserId
                 }
@@ -323,7 +365,7 @@ final class PurchasesManager: PurchasesManagerInterface, @unchecked Sendable {
                 guard await reportsGate.tryTake(id) else { continue }
             }
             do {
-                try await purchasesService.send(transaction, userId: userId, options: reportOptions(for: transaction))
+                try await purchasesService.send(transaction, userId: userId, options: reportOptions(for: transaction), trigger: .initialization)
                 purchaseAssociationsStorage.remove(for: transaction.productId)
                 await storeKitFacade.finish(transaction)
             } catch {
@@ -375,7 +417,7 @@ extension PurchasesManager: StoreKitFacadeDelegate {
             do {
                 _ = try await self.userManager.obtainUser()
                 let userId: String = self.userIdProvider.getUserId()
-                try await self.purchasesService.send(transaction, userId: userId, options: self.reportOptions(for: transaction))
+                try await self.purchasesService.send(transaction, userId: userId, options: self.reportOptions(for: transaction), trigger: .purchase)
                 self.purchaseAssociationsStorage.remove(for: transaction.productId)
             } catch {
                 if let id: String = transaction.id {

--- a/Sources/Managers/RemoteConfig/RemoteConfigManager.swift
+++ b/Sources/Managers/RemoteConfig/RemoteConfigManager.swift
@@ -15,6 +15,8 @@ fileprivate enum Constants: String {
 final class RemoteConfigManager: RemoteConfigManagerInterface, @unchecked Sendable {
 
     private let remoteConfigService: RemoteConfigServiceInterface
+    private let userManager: UserManagerInterface
+    private let userPropertiesManager: UserPropertiesManagerInterface
     private let logger: LoggerWrapper
 
     // The cache is read/written from concurrent loads and cleared from the
@@ -26,9 +28,20 @@ final class RemoteConfigManager: RemoteConfigManagerInterface, @unchecked Sendab
     /// must not cache its (stale) response for the new one.
     private var cacheGeneration = 0
 
-    init(remoteConfigService: RemoteConfigServiceInterface, logger: LoggerWrapper) {
+    init(remoteConfigService: RemoteConfigServiceInterface, userManager: UserManagerInterface, userPropertiesManager: UserPropertiesManagerInterface, logger: LoggerWrapper) {
         self.remoteConfigService = remoteConfigService
+        self.userManager = userManager
+        self.userPropertiesManager = userPropertiesManager
         self.logger = logger
+    }
+
+    /// Remote configs are computed per user from fresh segmentation data: the
+    /// user must be settled (identify in flight would change the uid) and the
+    /// pending properties batch must reach the backend first. A flush failure
+    /// is not fatal — properties retry on their own schedule.
+    private func prepareUserForRemoteConfig() async throws {
+        _ = try await userManager.obtainUser()
+        try? await userPropertiesManager.sendProperties()
     }
 
     func loadRemoteConfig(contextKey: String?) async throws -> Qonversion.RemoteConfig {
@@ -37,6 +50,8 @@ final class RemoteConfigManager: RemoteConfigManagerInterface, @unchecked Sendab
         if let cached {
             return cached
         }
+
+        try await prepareUserForRemoteConfig()
 
         let remoteConfig: Qonversion.RemoteConfig = try await remoteConfigService.loadRemoteConfig(contextKey: contextKey)
         cacheConfig(remoteConfig, for: finalKey, ifGenerationIs: generation)
@@ -58,6 +73,8 @@ final class RemoteConfigManager: RemoteConfigManagerInterface, @unchecked Sendab
     }
 
     func loadRemoteConfigList() async throws -> Qonversion.RemoteConfigList {
+        try await prepareUserForRemoteConfig()
+
         let generation: Int = currentGeneration()
         let remoteConfigList: Qonversion.RemoteConfigList = try await remoteConfigService.loadRemoteConfigList()
         handleLoadedRemoteConfigList(remoteConfigList, generation: generation)
@@ -69,24 +86,30 @@ final class RemoteConfigManager: RemoteConfigManagerInterface, @unchecked Sendab
         if (cachedConfigs.count == contextKeys.count) {
             return Qonversion.RemoteConfigList(remoteConfigs: cachedConfigs)
         }
+        try await prepareUserForRemoteConfig()
+
         let remoteConfigList: Qonversion.RemoteConfigList = try await remoteConfigService.loadRemoteConfigList(contextKeys: contextKeys, includeEmptyContextKey: includeEmptyContextKey)
         handleLoadedRemoteConfigList(remoteConfigList, generation: generation)
         return remoteConfigList
     }
 
     func attachUserToRemoteConfig(id: String) async throws {
+        _ = try await userManager.obtainUser()
         try await remoteConfigService.attachUserToRemoteConfig(id: id)
     }
 
     func detachUserFromRemoteConfig(id: String) async throws {
+        _ = try await userManager.obtainUser()
         try await remoteConfigService.detachUserFromRemoteConfig(id: id)
     }
 
     func attachUserToExperiment(id: String, groupId: String) async throws {
+        _ = try await userManager.obtainUser()
         try await remoteConfigService.attachUserToExperiment(id: id, groupId: groupId)
     }
 
     func detachUserFromExperiment(id: String) async throws {
+        _ = try await userManager.obtainUser()
         try await remoteConfigService.detachUserFromExperiment(id: id)
     }
     

--- a/Sources/Managers/UserProperties/UserPropertiesManager.swift
+++ b/Sources/Managers/UserProperties/UserPropertiesManager.swift
@@ -25,6 +25,7 @@ final class UserPropertiesManager : UserPropertiesManagerInterface, @unchecked S
     private let delayCalculator: IncrementalDelayCalculator
     private let userIdProvider: UserIdProvider
     private let userManager: UserManagerInterface
+    private let integrationsInfoCollector: IntegrationsInfoCollectorInterface
     private let logger: LoggerWrapper
 
     // Mutated from the caller's thread (setProperty) and from the scheduled
@@ -41,6 +42,7 @@ final class UserPropertiesManager : UserPropertiesManagerInterface, @unchecked S
         delayCalculator: IncrementalDelayCalculator,
         userIdProvider: UserIdProvider,
         userManager: UserManagerInterface,
+        integrationsInfoCollector: IntegrationsInfoCollectorInterface,
         logger: LoggerWrapper
     ) {
         self.requestProcessor = requestProcessor
@@ -48,7 +50,27 @@ final class UserPropertiesManager : UserPropertiesManagerInterface, @unchecked S
         self.delayCalculator = delayCalculator
         self.userIdProvider = userIdProvider
         self.userManager = userManager
+        self.integrationsInfoCollector = integrationsInfoCollector
         self.logger = logger
+    }
+
+    func collectIntegrationsData() {
+        // Watch and vision apps do not ship attribution SDKs — same platform
+        // gate as production.
+        #if !os(watchOS) && !os(visionOS)
+        integrationsInfoCollector.adjustUserId { [weak self] adjustUserId in
+            guard let self, let adjustUserId, !adjustUserId.isEmpty else { return }
+            self.setUserProperty(key: .adjustAdId, value: adjustUserId)
+        }
+        if let appsFlyerUserId: String = integrationsInfoCollector.appsFlyerUserId(), !appsFlyerUserId.isEmpty {
+            setUserProperty(key: .appsFlyerUserId, value: appsFlyerUserId)
+        }
+        if let facebookAnonymousId: String = integrationsInfoCollector.facebookAnonymousId(), !facebookAnonymousId.isEmpty {
+            // The key is intentionally not part of the public UserPropertyKey
+            // enum — mirrors the production contract.
+            setCustomUserProperty(key: "_q_fb_anon_id", value: facebookAnonymousId)
+        }
+        #endif
     }
     
     func collectAppleSearchAdsAttribution() {

--- a/Sources/Managers/UserProperties/UserPropertiesManagerInterface.swift
+++ b/Sources/Managers/UserProperties/UserPropertiesManagerInterface.swift
@@ -20,4 +20,8 @@ protocol UserPropertiesManagerInterface {
     func clearDelayedProperties()
     
     func collectAppleSearchAdsAttribution()
+
+    /// Collects attribution ids of integrated third-party SDKs (Adjust,
+    /// AppsFlyer, Facebook) as user properties.
+    func collectIntegrationsData()
 }

--- a/Sources/NetworkLayer/Request/RequestTrigger.swift
+++ b/Sources/NetworkLayer/Request/RequestTrigger.swift
@@ -1,0 +1,22 @@
+//
+//  RequestTrigger.swift
+//  Qonversion
+//
+
+import Foundation
+
+/// The SDK flow that produced a request; travels in the `Trigger` header on
+/// user and purchase requests so the backend can tell the entry points apart.
+/// Values mirror the production SDK contract.
+enum RequestTrigger: String {
+    case initialization = "Init"
+    case purchase = "Purchase"
+    case products = "Products"
+    case restore = "Restore"
+    case syncHistoricalData = "SyncHistoricalData"
+    case actualizePermissions = "ActualizePermissions"
+    case identify = "Identify"
+    case logout = "Logout"
+    case userProperties = "UserProperties"
+    case handleStoreKit2Transactions = "HandleStoreKit2Transactions"
+}

--- a/Sources/NetworkLayer/RequestProcessor/RequestProcessor.swift
+++ b/Sources/NetworkLayer/RequestProcessor/RequestProcessor.swift
@@ -68,6 +68,10 @@ class RequestProcessor: RequestProcessorInterface, @unchecked Sendable {
                 urlRequest.httpMethod = stored.method
                 urlRequest.httpBody = stored.body
                 self.headersBuilder.addHeaders(to: &urlRequest)
+                urlRequest.addValue("\(stored.attempt + 1)", forHTTPHeaderField: Self.attemptHeader)
+                if let trigger: String = stored.trigger {
+                    urlRequest.addValue(trigger, forHTTPHeaderField: Self.triggerHeader)
+                }
 
                 do {
                     let (data, urlResponse) = try await self.networkProvider.send(request: urlRequest)
@@ -76,7 +80,9 @@ class RequestProcessor: RequestProcessorInterface, @unchecked Sendable {
                     // keep it queued. Everything else counts as delivered
                     // (resending would duplicate) or permanently rejected.
                     let statusCode = (urlResponse as? HTTPURLResponse)?.statusCode ?? 0
-                    if !Self.isRetriableStatusCode(statusCode) {
+                    if Self.isRetriableStatusCode(statusCode) {
+                        self.bumpAttempt(of: stored)
+                    } else {
                         self.requestsStorage.remove(stored)
                     }
 
@@ -86,6 +92,7 @@ class RequestProcessor: RequestProcessorInterface, @unchecked Sendable {
                     }
                 } catch {
                     // Kept in the queue for the next session.
+                    self.bumpAttempt(of: stored)
                 }
             }
         }
@@ -95,7 +102,25 @@ class RequestProcessor: RequestProcessorInterface, @unchecked Sendable {
         return statusCode >= 500 || statusCode == 429
     }
 
-    func process<T>(request: Request, responseType: T.Type) async throws -> T where T : Decodable {
+    static let attemptHeader: String = "Attempt"
+    static let triggerHeader: String = "Trigger"
+
+    /// Records one more failed send of a queued request, so the next replay
+    /// reports the true attempt number.
+    private func bumpAttempt(of stored: StoredRequest) {
+        requestsStorage.remove(stored)
+        let updated = StoredRequest(
+            url: stored.url,
+            method: stored.method,
+            body: stored.body,
+            dedupKey: stored.dedupKey,
+            trigger: stored.trigger,
+            attempt: stored.attempt + 1
+        )
+        requestsStorage.append(updated)
+    }
+
+    func process<T>(request: Request, responseType: T.Type, trigger: RequestTrigger?) async throws -> T where T : Decodable {
         if let error = criticalError {
             throw error
         }
@@ -108,6 +133,10 @@ class RequestProcessor: RequestProcessorInterface, @unchecked Sendable {
             throw QonversionError(type: .invalidRequest)
         }
         headersBuilder.addHeaders(to: &urlRequest)
+        urlRequest.addValue("1", forHTTPHeaderField: Self.attemptHeader)
+        if let trigger {
+            urlRequest.addValue(trigger.rawValue, forHTTPHeaderField: Self.triggerHeader)
+        }
 
         let responseBody: Data
         let error: QonversionError?
@@ -125,7 +154,8 @@ class RequestProcessor: RequestProcessorInterface, @unchecked Sendable {
                     url: urlRequest.url?.absoluteString ?? "",
                     method: urlRequest.httpMethod ?? "POST",
                     body: urlRequest.httpBody,
-                    dedupKey: request.replayDedupKey
+                    dedupKey: request.replayDedupKey,
+                    trigger: trigger?.rawValue
                 ))
             }
             throw QonversionError(type: .invalidResponse, error: error)
@@ -143,7 +173,8 @@ class RequestProcessor: RequestProcessorInterface, @unchecked Sendable {
                     url: urlRequest.url?.absoluteString ?? "",
                     method: urlRequest.httpMethod ?? "POST",
                     body: urlRequest.httpBody,
-                    dedupKey: request.replayDedupKey
+                    dedupKey: request.replayDedupKey,
+                    trigger: trigger?.rawValue
                 ))
             }
 

--- a/Sources/NetworkLayer/RequestProcessor/RequestProcessorInterface.swift
+++ b/Sources/NetworkLayer/RequestProcessor/RequestProcessorInterface.swift
@@ -7,8 +7,16 @@
 
 protocol RequestProcessorInterface {
     @discardableResult
-    func process<T>(request: Request, responseType: T.Type) async throws -> T where T : Decodable
+    func process<T>(request: Request, responseType: T.Type, trigger: RequestTrigger?) async throws -> T where T : Decodable
 
     /// Resends requests that failed on transport in previous sessions.
     func processStoredRequests()
+}
+
+extension RequestProcessorInterface {
+
+    @discardableResult
+    func process<T>(request: Request, responseType: T.Type) async throws -> T where T : Decodable {
+        try await process(request: request, responseType: responseType, trigger: nil)
+    }
 }

--- a/Sources/NetworkLayer/RequestsStorage/StoredRequest.swift
+++ b/Sources/NetworkLayer/RequestsStorage/StoredRequest.swift
@@ -16,4 +16,40 @@ struct StoredRequest: Codable, Equatable {
     /// Identifies the payload (e.g. by transaction id) so the same failed
     /// request never queues twice. Nil disables deduplication.
     let dedupKey: String?
+
+    /// The original flow that produced the request — replayed in the Trigger
+    /// header on resend.
+    let trigger: String?
+
+    /// How many times the request has been sent so far.
+    let attempt: Int
+
+    init(url: String, method: String, body: Data?, dedupKey: String?, trigger: String? = nil, attempt: Int = 1) {
+        self.url = url
+        self.method = method
+        self.body = body
+        self.dedupKey = dedupKey
+        self.trigger = trigger
+        self.attempt = attempt
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        url = try container.decode(String.self, forKey: .url)
+        method = try container.decode(String.self, forKey: .method)
+        body = try container.decodeIfPresent(Data.self, forKey: .body)
+        dedupKey = try container.decodeIfPresent(String.self, forKey: .dedupKey)
+        // Entries queued by older SDK builds carry neither field.
+        trigger = try container.decodeIfPresent(String.self, forKey: .trigger)
+        attempt = try container.decodeIfPresent(Int.self, forKey: .attempt) ?? 1
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case url
+        case method
+        case body
+        case dedupKey
+        case trigger
+        case attempt
+    }
 }

--- a/Sources/Qonversion.swift
+++ b/Sources/Qonversion.swift
@@ -189,6 +189,24 @@ public final class Qonversion: @unchecked Sendable {
         return try await entitlementsManager.entitlements()
     }
 
+    /// Sends all the properties set since the last batch right away, without
+    /// waiting for the batching delay. Delivery failures are retried by the
+    /// SDK automatically.
+    public func forceSendProperties() async {
+        guard let userPropertiesManager else { return }
+
+        try? await userPropertiesManager.sendProperties()
+    }
+
+    /// Whether the bundled fallback file (`qonversion_ios_fallbacks.json`) is
+    /// present in the app bundle and parses. Use in debug builds to verify the
+    /// offline fallback setup.
+    public func isFallbackFileAccessible() -> Bool {
+        guard let productsManager else { return false }
+
+        return productsManager.isFallbackFileAccessible()
+    }
+
     /// Collects Apple Search Ads Attribution data
     /// Available only for iOS 14.3+
     /// See details in the [Apple official documentation](https://developer.apple.com/documentation/iad/setting-up-apple-search-ads-attribution)

--- a/Sources/Qonversion.swift
+++ b/Sources/Qonversion.swift
@@ -54,6 +54,14 @@ public final class Qonversion: @unchecked Sendable {
             }
         }
 
+        // Attribution ids of integrated SDKs (Adjust, AppsFlyer, Facebook)
+        // become available after those SDKs initialize — collect with the
+        // same delay production uses.
+        Task {
+            try? await Task.sleep(nanoseconds: 5_000_000_000)
+            Qonversion.shared.userPropertiesManager?.collectIntegrationsData()
+        }
+
         // Warm up the user gate: create the backend user early so the first
         // data-sending call doesn't pay for it. Failure is fine — the gate
         // retries on the next demand.

--- a/Sources/SDKVersion.swift
+++ b/Sources/SDKVersion.swift
@@ -1,0 +1,13 @@
+//
+//  SDKVersion.swift
+//  Qonversion
+//
+
+import Foundation
+
+/// The SDK version sent to the backend in request headers.
+/// SPM provides no runtime version metadata, so the version lives in this
+/// constant; the release tooling (fastlane bump) rewrites it on every release.
+enum SDKVersion {
+    static let current: String = "1.0"
+}

--- a/Sources/Services/Device/IntegrationsInfoCollector.swift
+++ b/Sources/Services/Device/IntegrationsInfoCollector.swift
@@ -1,0 +1,99 @@
+//
+//  IntegrationsInfoCollector.swift
+//  Qonversion
+//
+
+import Foundation
+
+protocol IntegrationsInfoCollectorInterface: Sendable {
+
+    /// The Adjust adid, when the Adjust SDK is integrated into the host app.
+    /// Async because Adjust 5 exposes the id through a completion handler.
+    func adjustUserId(completion: @escaping @Sendable (String?) -> Void)
+
+    /// The AppsFlyer UID, when the AppsFlyer SDK is integrated.
+    func appsFlyerUserId() -> String?
+
+    /// The Facebook anonymous id — only meaningful without an IDFA, when it
+    /// is the sole way to attribute the install.
+    func facebookAnonymousId() -> String?
+}
+
+/// Reads attribution ids of third-party SDKs the host app may have integrated.
+/// The SDKs are not linked — the ids are resolved through the Objective-C
+/// runtime by class name, exactly like the production SDK does; an absent SDK
+/// resolves to nil.
+final class IntegrationsInfoCollector: IntegrationsInfoCollectorInterface {
+
+    private let deviceInfoCollector: DeviceInfoCollectorInterface
+
+    init(deviceInfoCollector: DeviceInfoCollectorInterface) {
+        self.deviceInfoCollector = deviceInfoCollector
+    }
+
+    func adjustUserId(completion: @escaping @Sendable (String?) -> Void) {
+        guard let adjustClass: AnyClass = NSClassFromString("Adjust") else {
+            return completion(nil)
+        }
+        let adjust: AnyObject = adjustClass as AnyObject
+
+        // Adjust 4 answers synchronously, Adjust 5 only through a completion.
+        let syncSelector: Selector = NSSelectorFromString("adid")
+        let asyncSelector: Selector = NSSelectorFromString("adidWithCompletionHandler:")
+        if adjust.responds(to: syncSelector) {
+            let adid: String? = adjust.perform(syncSelector)?.takeUnretainedValue() as? String
+            completion(adid)
+        } else if adjust.responds(to: asyncSelector) {
+            let handler: @convention(block) @Sendable (String?) -> Void = { adid in
+                completion(adid)
+            }
+            _ = adjust.perform(asyncSelector, with: handler)
+        } else {
+            completion(nil)
+        }
+    }
+
+    func appsFlyerUserId() -> String? {
+        // AppsFlyer 5 / AppsFlyer 6 entry points.
+        let entryPoints: [(className: String, sharedSelector: String)] = [
+            ("AppsFlyerTracker", "sharedTracker"),
+            ("AppsFlyerLib", "shared"),
+        ]
+        let uidSelector: Selector = NSSelectorFromString("getAppsFlyerUID")
+
+        for entryPoint in entryPoints {
+            guard let trackerClass: AnyClass = NSClassFromString(entryPoint.className) else { continue }
+            let tracker: AnyObject = trackerClass as AnyObject
+            let sharedSelector: Selector = NSSelectorFromString(entryPoint.sharedSelector)
+            guard tracker.responds(to: sharedSelector),
+                  let shared: AnyObject = tracker.perform(sharedSelector)?.takeUnretainedValue() else { continue }
+            guard shared.responds(to: uidSelector),
+                  let uid: String = shared.perform(uidSelector)?.takeUnretainedValue() as? String else { continue }
+
+            return uid
+        }
+
+        return nil
+    }
+
+    func facebookAnonymousId() -> String? {
+        // With a real IDFA available Facebook attributes by it — the
+        // anonymous id only matters when tracking is denied.
+        let zeroedIdfa = "00000000-0000-0000-0000-000000000000"
+        if let advertisingId: String = deviceInfoCollector.advertisingId(), advertisingId != zeroedIdfa {
+            return nil
+        }
+
+        let anonymousIdSelector: Selector = NSSelectorFromString("anonymousID")
+        for className in ["FBSDKAppEvents", "FBSDKBasicUtility"] {
+            guard let fbClass: AnyClass = NSClassFromString(className) else { continue }
+            let fb: AnyObject = fbClass as AnyObject
+            guard fb.responds(to: anonymousIdSelector),
+                  let anonymousId: String = fb.perform(anonymousIdSelector)?.takeUnretainedValue() as? String else { continue }
+
+            return anonymousId
+        }
+
+        return nil
+    }
+}

--- a/Sources/Services/PurchasesService/PurchasesService.swift
+++ b/Sources/Services/PurchasesService/PurchasesService.swift
@@ -61,23 +61,32 @@ final class PurchasesService: PurchasesServiceInterface {
 
     private let requestProcessor: RequestProcessorInterface
     private let appBundleId: String
+    private let receiptFetcher: ReceiptFetcherInterface
 
-    init(requestProcessor: RequestProcessorInterface, appBundleId: String) {
+    init(requestProcessor: RequestProcessorInterface, appBundleId: String, receiptFetcher: ReceiptFetcherInterface) {
         self.requestProcessor = requestProcessor
         self.appBundleId = appBundleId
+        self.receiptFetcher = receiptFetcher
     }
 
 
     @discardableResult
-    func send(_ transaction: Qonversion.Transaction, userId: String, options: Qonversion.PurchaseOptions?) async throws -> String? {
+    func send(_ transaction: Qonversion.Transaction, userId: String, options: Qonversion.PurchaseOptions?, trigger: RequestTrigger) async throws -> String? {
         // The v4 store_data shape for the app_store platform; the signed
         // transaction (jws) travels in the receipt slot, the ids next to it
-        // let the backend resolve and dedupe before verification.
+        // let the backend resolve and dedupe before verification. StoreKit 1
+        // transactions have no jws — the base64 app receipt is their proof.
+        let proof: String
+        if let jws: String = transaction.jws {
+            proof = jws
+        } else {
+            proof = receiptFetcher.appStoreReceipt() ?? ""
+        }
         let storeData: RequestBodyDict = [
             "transaction_id": transaction.id ?? "",
             "original_transaction_id": transaction.originalId ?? "",
             "product_id": transaction.productId,
-            "receipt": transaction.jws ?? "",
+            "receipt": proof,
         ]
         var body: RequestBodyDict = [
             "platform": "app_store",
@@ -101,7 +110,7 @@ final class PurchasesService: PurchasesServiceInterface {
 
         let request = Request.createPurchase(userId: userId, body: body)
         do {
-            let response: PurchaseReportResponse = try await requestProcessor.process(request: request, responseType: PurchaseReportResponse.self)
+            let response: PurchaseReportResponse = try await requestProcessor.process(request: request, responseType: PurchaseReportResponse.self, trigger: trigger)
 
             return response.userId
         } catch {

--- a/Sources/Services/PurchasesService/PurchasesServiceInterface.swift
+++ b/Sources/Services/PurchasesService/PurchasesServiceInterface.swift
@@ -12,7 +12,7 @@ protocol PurchasesServiceInterface {
     /// screenUid), when given, are attached to the report. Returns the
     /// resolved owner of the transaction when the backend provides one.
     @discardableResult
-    func send(_ transaction: Qonversion.Transaction, userId: String, options: Qonversion.PurchaseOptions?) async throws -> String?
+    func send(_ transaction: Qonversion.Transaction, userId: String, options: Qonversion.PurchaseOptions?, trigger: RequestTrigger) async throws -> String?
 
     /// Requests a backend-signed promotional offer for the store product.
     func promotionalOffer(userId: String, offerId: String, productStoreId: String) async throws -> Qonversion.PromotionalOffer
@@ -21,7 +21,17 @@ protocol PurchasesServiceInterface {
 extension PurchasesServiceInterface {
 
     @discardableResult
+    func send(_ transaction: Qonversion.Transaction, userId: String, trigger: RequestTrigger) async throws -> String? {
+        try await send(transaction, userId: userId, options: nil, trigger: trigger)
+    }
+
+    @discardableResult
+    func send(_ transaction: Qonversion.Transaction, userId: String, options: Qonversion.PurchaseOptions?) async throws -> String? {
+        try await send(transaction, userId: userId, options: options, trigger: .purchase)
+    }
+
+    @discardableResult
     func send(_ transaction: Qonversion.Transaction, userId: String) async throws -> String? {
-        try await send(transaction, userId: userId, options: nil)
+        try await send(transaction, userId: userId, options: nil, trigger: .purchase)
     }
 }

--- a/Sources/Services/UserService/UserService.swift
+++ b/Sources/Services/UserService/UserService.swift
@@ -50,7 +50,7 @@ final class UserService: UserServiceInterface, @unchecked Sendable {
             // The contract requires the environment field; sandbox/prod
             // separation is not a client-side concern.
             let request = Request.createUser(body: ["id": userId, "environment": "prod"])
-            let user: Qonversion.User = try await requestProcessor.process(request: request, responseType: Qonversion.User.self)
+            let user: Qonversion.User = try await requestProcessor.process(request: request, responseType: Qonversion.User.self, trigger: RequestTrigger.initialization)
             
             return user
         } catch {
@@ -87,7 +87,7 @@ final class UserService: UserServiceInterface, @unchecked Sendable {
     func user() async throws -> Qonversion.User {
         let request = Request.getUser(id: internalConfig.userId)
         do {
-            let user: Qonversion.User = try await requestProcessor.process(request: request, responseType: Qonversion.User.self)
+            let user: Qonversion.User = try await requestProcessor.process(request: request, responseType: Qonversion.User.self, trigger: RequestTrigger.initialization)
             
             return user
         } catch {

--- a/Sources/StoreKit/ReceiptFetcher.swift
+++ b/Sources/StoreKit/ReceiptFetcher.swift
@@ -1,0 +1,25 @@
+//
+//  ReceiptFetcher.swift
+//  Qonversion
+//
+
+import Foundation
+
+protocol ReceiptFetcherInterface: Sendable {
+
+    /// The base64-encoded App Store receipt of the app, if present. The only
+    /// proof of purchase available on the StoreKit 1 path.
+    func appStoreReceipt() -> String?
+}
+
+final class ReceiptFetcher: ReceiptFetcherInterface {
+
+    func appStoreReceipt() -> String? {
+        guard let url: URL = Bundle.main.appStoreReceiptURL,
+              let data: Data = try? Data(contentsOf: url) else {
+            return nil
+        }
+
+        return data.base64EncodedString()
+    }
+}

--- a/Tests/QonversionUnitTests/ConfigurationTests.swift
+++ b/Tests/QonversionUnitTests/ConfigurationTests.swift
@@ -55,6 +55,6 @@ final class ConfigurationTests: XCTestCase {
 
         let processor = servicesAssembly.requestProcessor() as? RequestProcessor
 
-        XCTAssertEqual(processor?.baseURL, "https://api.qonversion.io/")
+        XCTAssertEqual(processor?.baseURL, "https://api2.qonversion.io/")
     }
 }

--- a/Tests/QonversionUnitTests/IntegrationsInfoCollectorTests.swift
+++ b/Tests/QonversionUnitTests/IntegrationsInfoCollectorTests.swift
@@ -1,0 +1,83 @@
+//
+//  IntegrationsInfoCollectorTests.swift
+//  QonversionUnitTests
+//
+//  The collector resolves third-party SDK ids through the Objective-C runtime
+//  by class name. The fake @objc classes below register under the production
+//  class names, so the reflection path is exercised end to end.
+//
+
+import XCTest
+@testable import Qonversion
+
+@objc(Adjust)
+private final class FakeAdjust: NSObject {
+    @objc static func adid() -> String { "adjust-from-runtime" }
+}
+
+@objc(AppsFlyerLib)
+private final class FakeAppsFlyerLib: NSObject {
+    @objc static func shared() -> AnyObject { sharedInstance }
+    private static let sharedInstance = FakeAppsFlyerLib()
+    @objc func getAppsFlyerUID() -> String { "af-from-runtime" }
+}
+
+@objc(FBSDKAppEvents)
+private final class FakeFBSDKAppEvents: NSObject {
+    @objc static func anonymousID() -> String { "fb-from-runtime" }
+}
+
+final class IntegrationsInfoCollectorTests: XCTestCase {
+
+    private var deviceInfoCollector: MockDeviceInfoCollector!
+    private var collector: IntegrationsInfoCollector!
+
+    override func setUp() {
+        super.setUp()
+        deviceInfoCollector = MockDeviceInfoCollector()
+        collector = IntegrationsInfoCollector(deviceInfoCollector: deviceInfoCollector)
+    }
+
+    override func tearDown() {
+        collector = nil
+        deviceInfoCollector = nil
+        super.tearDown()
+    }
+
+    func testAdjustIdIsResolvedThroughTheRuntime() {
+        let expectation = expectation(description: "adjust id resolved")
+        nonisolated(unsafe) var resolved: String?
+
+        collector.adjustUserId { adid in
+            resolved = adid
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1)
+        XCTAssertEqual(resolved, "adjust-from-runtime")
+    }
+
+    func testAppsFlyerUidIsResolvedThroughTheRuntime() {
+        XCTAssertEqual(collector.appsFlyerUserId(), "af-from-runtime")
+    }
+
+    func testFacebookAnonymousIdIsResolvedWhenIdfaIsUnavailable() {
+        deviceInfoCollector.advertisingIdValue = nil
+
+        XCTAssertEqual(collector.facebookAnonymousId(), "fb-from-runtime")
+    }
+
+    func testFacebookAnonymousIdIsSkippedWithARealIdfa() {
+        // With a live IDFA Facebook attributes by it — the anonymous id must
+        // not be collected even though the SDK is present.
+        deviceInfoCollector.advertisingIdValue = "6D92078A-8246-4BA4-AE85-1BC6C137E623"
+
+        XCTAssertNil(collector.facebookAnonymousId())
+    }
+
+    func testFacebookAnonymousIdIsResolvedWithAZeroedIdfa() {
+        deviceInfoCollector.advertisingIdValue = "00000000-0000-0000-0000-000000000000"
+
+        XCTAssertEqual(collector.facebookAnonymousId(), "fb-from-runtime")
+    }
+}

--- a/Tests/QonversionUnitTests/Mocks.swift
+++ b/Tests/QonversionUnitTests/Mocks.swift
@@ -38,9 +38,11 @@ final class MockRequestProcessor: RequestProcessorInterface {
     var error: Error?
     var onProcess: (() async -> Void)?
     private(set) var processedRequests: [Request] = []
+    private(set) var processedTriggers: [RequestTrigger?] = []
 
-    func process<T>(request: Request, responseType: T.Type) async throws -> T where T: Decodable {
+    func process<T>(request: Request, responseType: T.Type, trigger: RequestTrigger?) async throws -> T where T: Decodable {
         processedRequests.append(request)
+        processedTriggers.append(trigger)
         await onProcess?()
         if let error { throw error }
         guard !results.isEmpty else { throw MockError.noStub }
@@ -67,6 +69,45 @@ final class MockNetworkProvider: NetworkProviderInterface {
         if let error { throw error }
         return (responseData, response)
     }
+}
+
+final class MockReceiptFetcher: ReceiptFetcherInterface {
+
+    var receipt: String?
+    private(set) var fetchCallsCount = 0
+
+    func appStoreReceipt() -> String? {
+        fetchCallsCount += 1
+        return receipt
+    }
+}
+
+final class MockUserPropertiesManager: UserPropertiesManagerInterface {
+
+    var userPropertiesResult: Qonversion.UserProperties?
+    var error: Error?
+    private(set) var sendPropertiesCallsCount = 0
+    var onSendProperties: (() async -> Void)?
+
+    func userProperties() async throws -> Qonversion.UserProperties {
+        if let error { throw error }
+        guard let userPropertiesResult else { throw MockError.noStub }
+        return userPropertiesResult
+    }
+
+    func setUserProperty(key: Qonversion.UserPropertyKey, value: String) { }
+
+    func setCustomUserProperty(key: String, value: String) { }
+
+    func sendProperties() async throws {
+        sendPropertiesCallsCount += 1
+        await onSendProperties?()
+        if let error { throw error }
+    }
+
+    func clearDelayedProperties() { }
+
+    func collectAppleSearchAdsAttribution() { }
 }
 
 final class MockHeadersBuilder: HeadersBuilderInterface {
@@ -234,7 +275,12 @@ final class MockStoreKitFacade: StoreKitFacadeInterface {
 
     func currentEntitlements() async -> [Qonversion.Transaction] { currentEntitlementsResult }
 
+    private(set) var facadeRestoreCallsCount = 0
+    var onRestore: (() async -> Void)?
+
     func restore() async throws -> [Qonversion.Transaction] {
+        facadeRestoreCallsCount += 1
+        await onRestore?()
         if let restoreError { throw restoreError }
         return restoreResult
     }
@@ -584,6 +630,7 @@ final class MockPurchasesService: PurchasesServiceInterface {
     var error: Error?
     var onSend: (() async -> Void)?
     private(set) var sentTransactions: [(transaction: Qonversion.Transaction, userId: String, options: Qonversion.PurchaseOptions?)] = []
+    private(set) var sentTriggers: [RequestTrigger] = []
 
     var promotionalOfferResult: Qonversion.PromotionalOffer?
     private(set) var promotionalOfferCalls: [(userId: String, offerId: String, productStoreId: String)] = []
@@ -591,8 +638,9 @@ final class MockPurchasesService: PurchasesServiceInterface {
     var reportedOwnerUserId: String?
 
     @discardableResult
-    func send(_ transaction: Qonversion.Transaction, userId: String, options: Qonversion.PurchaseOptions?) async throws -> String? {
+    func send(_ transaction: Qonversion.Transaction, userId: String, options: Qonversion.PurchaseOptions?, trigger: RequestTrigger) async throws -> String? {
         sentTransactions.append((transaction, userId, options))
+        sentTriggers.append(trigger)
         await onSend?()
         if let error { throw error }
         return reportedOwnerUserId

--- a/Tests/QonversionUnitTests/Mocks.swift
+++ b/Tests/QonversionUnitTests/Mocks.swift
@@ -71,6 +71,21 @@ final class MockNetworkProvider: NetworkProviderInterface {
     }
 }
 
+final class MockIntegrationsInfoCollector: IntegrationsInfoCollectorInterface {
+
+    var adjustUserIdResult: String?
+    var appsFlyerUserIdResult: String?
+    var facebookAnonymousIdResult: String?
+
+    func adjustUserId(completion: @escaping @Sendable (String?) -> Void) {
+        completion(adjustUserIdResult)
+    }
+
+    func appsFlyerUserId() -> String? { appsFlyerUserIdResult }
+
+    func facebookAnonymousId() -> String? { facebookAnonymousIdResult }
+}
+
 final class MockReceiptFetcher: ReceiptFetcherInterface {
 
     var receipt: String?
@@ -108,6 +123,12 @@ final class MockUserPropertiesManager: UserPropertiesManagerInterface {
     func clearDelayedProperties() { }
 
     func collectAppleSearchAdsAttribution() { }
+
+    private(set) var collectIntegrationsDataCallsCount = 0
+
+    func collectIntegrationsData() {
+        collectIntegrationsDataCallsCount += 1
+    }
 }
 
 final class MockHeadersBuilder: HeadersBuilderInterface {

--- a/Tests/QonversionUnitTests/Mocks.swift
+++ b/Tests/QonversionUnitTests/Mocks.swift
@@ -636,6 +636,10 @@ final class MockProductsManager: ProductsManagerInterface, ProductsDataSource {
         loadPermissionsCallsCount += 1
     }
 
+    var fallbackFileAccessible = false
+
+    func isFallbackFileAccessible() -> Bool { fallbackFileAccessible }
+
     func cachedProductPermissions() -> [String: [String]]? { cachedMapping }
 
     func cachedProducts() -> [Qonversion.Product] { cachedProductsResult }

--- a/Tests/QonversionUnitTests/ProductsManagerTests.swift
+++ b/Tests/QonversionUnitTests/ProductsManagerTests.swift
@@ -51,6 +51,20 @@ final class ProductsManagerTests: XCTestCase {
         return Qonversion.Product(qonversionId: qonversionId, storeId: storeId, offeringId: nil)
     }
 
+    // MARK: - Fallback file accessibility
+
+    func testFallbackFileAccessibleWhenBundledDataParses() {
+        fallbackService.fallbackData = FallbackData(products: nil, productsPermissions: ["pro": ["premium"]])
+
+        XCTAssertTrue(manager.isFallbackFileAccessible())
+    }
+
+    func testFallbackFileNotAccessibleWithoutBundledData() {
+        fallbackService.fallbackData = nil
+
+        XCTAssertFalse(manager.isFallbackFileAccessible())
+    }
+
     // MARK: - In-memory cache
 
     func testProductsReturnsInMemoryCacheWithoutServiceCall() async throws {

--- a/Tests/QonversionUnitTests/PurchasesManagerTests.swift
+++ b/Tests/QonversionUnitTests/PurchasesManagerTests.swift
@@ -237,6 +237,32 @@ final class PurchasesManagerTests: XCTestCase {
         XCTAssertTrue(facade.finishedTransactions.isEmpty)
     }
 
+    // MARK: - restore single-flight
+
+    func testConcurrentRestoresShareOneStoreRun() async throws {
+        let gate = PurchasesAsyncGate()
+        facade.onRestore = { await gate.wait() }
+        entitlementsManager.entitlementsResult = [:]
+
+        async let first: [String: Qonversion.Entitlement] = manager.restore()
+        async let second: [String: Qonversion.Entitlement] = manager.restore()
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        await gate.open()
+        _ = try await first
+        _ = try await second
+
+        XCTAssertEqual(facade.facadeRestoreCallsCount, 1, "concurrent restore() calls must join the in-flight run")
+    }
+
+    func testRestoreRunsAgainAfterTheFirstOneFinishes() async throws {
+        entitlementsManager.entitlementsResult = [:]
+
+        _ = try await manager.restore()
+        _ = try await manager.restore()
+
+        XCTAssertEqual(facade.facadeRestoreCallsCount, 2)
+    }
+
     // MARK: - restore
 
     func testRestoreReportsLatestTransactionPerProductAndReturnsEntitlements() async throws {
@@ -827,4 +853,29 @@ private actor StreamCollector<Element> {
     private func append(_ element: Element) {
         received.append(element)
     }
+}
+
+/// A reusable async gate: wait() suspends until open() is called.
+private actor PurchasesGateStorage {
+    var isOpen = false
+    var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func open() {
+        isOpen = true
+        waiters.forEach { $0.resume() }
+        waiters.removeAll()
+    }
+
+    func wait() async {
+        if isOpen { return }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+}
+
+private final class PurchasesAsyncGate: @unchecked Sendable {
+    private let storage = PurchasesGateStorage()
+    func open() async { await storage.open() }
+    func wait() async { await storage.wait() }
 }

--- a/Tests/QonversionUnitTests/PurchasesManagerTests.swift
+++ b/Tests/QonversionUnitTests/PurchasesManagerTests.swift
@@ -93,6 +93,36 @@ final class PurchasesManagerTests: XCTestCase {
 
     // MARK: - purchase happy path
 
+    func testEachFlowReportsWithItsOwnTrigger() async throws {
+        // purchase
+        facade.purchaseResult = makeTransaction(id: "trig-1")
+        entitlementsManager.entitlementsResult = [:]
+        _ = try await manager.purchase(makeProduct(), options: nil)
+        XCTAssertEqual(service.sentTriggers, [.purchase])
+
+        // restore
+        facade.restoreResult = [makeTransaction(id: "trig-2")]
+        _ = try await manager.restore()
+        XCTAssertEqual(service.sentTriggers.last, .restore)
+
+        // analytics ingestion
+        await manager.handle(transactions: [makeTransaction(id: "trig-3")])
+        XCTAssertEqual(service.sentTriggers.last, .handleStoreKit2Transactions)
+    }
+
+    func testSyncAndSweepReportWithTheirOwnTriggers() async throws {
+        // historical data sync
+        facade.historicalDataResult = [makeTransaction(id: "trig-4")]
+        await manager.syncHistoricalData()
+        XCTAssertEqual(service.sentTriggers.last, .syncHistoricalData)
+
+        // unfinished transactions sweep
+        manager = makeManager(launchMode: .subscriptionManagement)
+        facade.unfinishedTransactionsResult = [makeTransaction(id: "trig-5")]
+        await manager.processUnfinishedTransactions()
+        XCTAssertEqual(service.sentTriggers.last, .initialization)
+    }
+
     func testPurchaseGoesGateStorePurchaseReportFinishAndReturnsEntitlements() async throws {
         facade.purchaseResult = makeTransaction(id: "t1")
         entitlementsManager.entitlementsResult = ["premium": entitlement(id: "premium")]

--- a/Tests/QonversionUnitTests/PurchasesServiceTests.swift
+++ b/Tests/QonversionUnitTests/PurchasesServiceTests.swift
@@ -10,10 +10,60 @@
 import XCTest
 @testable import Qonversion
 
+
 final class PurchasesServiceTests: XCTestCase {
 
+    private var receiptFetcher: MockReceiptFetcher!
+
+    override func setUp() {
+        super.setUp()
+        receiptFetcher = MockReceiptFetcher()
+    }
+
+    override func tearDown() {
+        receiptFetcher = nil
+        super.tearDown()
+    }
+
+    // MARK: - StoreKit 1 proof of purchase
+
+    func testStoreKitOneReportCarriesTheAppReceipt() async throws {
+        // An SK1 transaction has no jws — the base64 app receipt is the only
+        // proof of purchase the backend can verify.
+        let processor = MockRequestProcessor()
+        processor.results = [PurchaseReportResponse(userId: nil)]
+        let service = PurchasesService(requestProcessor: processor, appBundleId: "com.test.app", receiptFetcher: receiptFetcher)
+        receiptFetcher.receipt = "base64-app-receipt"
+        let transaction = Qonversion.Transaction(id: "t1", originalId: "t1", productId: "com.app.pro", jws: nil)
+
+        try await service.send(transaction, userId: "user_abc", options: nil, trigger: .purchase)
+
+        guard case let .createPurchase(_, _, body, _) = processor.processedRequests[0] else {
+            return XCTFail("Expected a .createPurchase request")
+        }
+        let storeData = body["store_data"] as? RequestBodyDict
+        XCTAssertEqual(storeData?["receipt"] as? String, "base64-app-receipt")
+    }
+
+    func testStoreKitTwoReportPrefersJwsAndSkipsReceiptFetch() async throws {
+        let processor = MockRequestProcessor()
+        processor.results = [PurchaseReportResponse(userId: nil)]
+        let service = PurchasesService(requestProcessor: processor, appBundleId: "com.test.app", receiptFetcher: receiptFetcher)
+        receiptFetcher.receipt = "base64-app-receipt"
+        let transaction = Qonversion.Transaction(id: "t1", originalId: "t1", productId: "com.app.pro", jws: "signed-jws")
+
+        try await service.send(transaction, userId: "user_abc", options: nil, trigger: .purchase)
+
+        guard case let .createPurchase(_, _, body, _) = processor.processedRequests[0] else {
+            return XCTFail("Expected a .createPurchase request")
+        }
+        let storeData = body["store_data"] as? RequestBodyDict
+        XCTAssertEqual(storeData?["receipt"] as? String, "signed-jws")
+        XCTAssertEqual(receiptFetcher.fetchCallsCount, 0)
+    }
+
     private func makeService(_ processor: MockRequestProcessor) -> PurchasesService {
-        PurchasesService(requestProcessor: processor, appBundleId: "com.test.app")
+        PurchasesService(requestProcessor: processor, appBundleId: "com.test.app", receiptFetcher: receiptFetcher)
     }
 
     private func makeTransaction(
@@ -130,7 +180,7 @@ final class PurchasesServiceTests: XCTestCase {
             nonce: nonce.uuidString,
             timestamp: "1700000000000"
         )]
-        let service = PurchasesService(requestProcessor: processor, appBundleId: "com.test.app")
+        let service = PurchasesService(requestProcessor: processor, appBundleId: "com.test.app", receiptFetcher: receiptFetcher)
 
         let offer = try await service.promotionalOffer(userId: "QON_buyer", offerId: "offer1", productStoreId: "com.app.pro")
 
@@ -155,7 +205,7 @@ final class PurchasesServiceTests: XCTestCase {
     func testPromotionalOfferWithMalformedSignatureThrows() async {
         let processor = MockRequestProcessor()
         processor.results = [PromoOfferSignatureResponse(keyIdentifier: "KEY123", signature: "%%%", nonce: "not-a-uuid", timestamp: "soon")]
-        let service = PurchasesService(requestProcessor: processor, appBundleId: "com.test.app")
+        let service = PurchasesService(requestProcessor: processor, appBundleId: "com.test.app", receiptFetcher: receiptFetcher)
 
         do {
             _ = try await service.promotionalOffer(userId: "u", offerId: "o", productStoreId: "p")
@@ -170,7 +220,7 @@ final class PurchasesServiceTests: XCTestCase {
     func testPromotionalOfferWrapsProcessorErrors() async {
         let processor = MockRequestProcessor()
         processor.error = MockError.stubbed
-        let service = PurchasesService(requestProcessor: processor, appBundleId: "com.test.app")
+        let service = PurchasesService(requestProcessor: processor, appBundleId: "com.test.app", receiptFetcher: receiptFetcher)
 
         do {
             _ = try await service.promotionalOffer(userId: "u", offerId: "o", productStoreId: "p")

--- a/Tests/QonversionUnitTests/QonversionFacadeTests.swift
+++ b/Tests/QonversionUnitTests/QonversionFacadeTests.swift
@@ -34,6 +34,16 @@ final class QonversionFacadeTests: XCTestCase {
         }
     }
 
+    // MARK: - Silent no-ops when uninitialized
+
+    func testForceSendPropertiesIsANoOpWhenUninitialized() async {
+        await Qonversion.shared.forceSendProperties()
+    }
+
+    func testIsFallbackFileAccessibleIsFalseWhenUninitialized() {
+        XCTAssertFalse(Qonversion.shared.isFallbackFileAccessible())
+    }
+
     // MARK: - Async methods throw initialization error when uninitialized
 
     func testUserPropertiesThrowsInitializationError() async {

--- a/Tests/QonversionUnitTests/RemoteConfigManagerTests.swift
+++ b/Tests/QonversionUnitTests/RemoteConfigManagerTests.swift
@@ -11,16 +11,28 @@ import XCTest
 final class RemoteConfigManagerTests: XCTestCase {
 
     private var remoteConfigService: MockRemoteConfigService!
+    private var userManager: MockUserManager!
+    private var userPropertiesManager: MockUserPropertiesManager!
     private var manager: RemoteConfigManager!
 
     override func setUp() {
         super.setUp()
         remoteConfigService = MockRemoteConfigService()
-        manager = RemoteConfigManager(remoteConfigService: remoteConfigService, logger: LoggerWrapper())
+        userManager = MockUserManager()
+        userManager.user = Qonversion.User(id: "user_abc")
+        userPropertiesManager = MockUserPropertiesManager()
+        manager = RemoteConfigManager(
+            remoteConfigService: remoteConfigService,
+            userManager: userManager,
+            userPropertiesManager: userPropertiesManager,
+            logger: LoggerWrapper()
+        )
     }
 
     override func tearDown() {
         manager = nil
+        userPropertiesManager = nil
+        userManager = nil
         remoteConfigService = nil
         super.tearDown()
     }
@@ -36,6 +48,58 @@ final class RemoteConfigManagerTests: XCTestCase {
             contextKey: contextKey
         )
         return Qonversion.RemoteConfig(payload: ["flag": "on"], experiment: nil, source: source)
+    }
+
+    // MARK: - user gate and properties flush (production parity)
+
+    func testLoadWaitsForTheUserGateAndFlushesPropertiesFirst() async throws {
+        remoteConfigService.remoteConfigResult = makeRemoteConfig(contextKey: "main")
+
+        _ = try await manager.loadRemoteConfig(contextKey: "main")
+
+        XCTAssertEqual(userManager.obtainUserCallsCount, 1)
+        XCTAssertEqual(userPropertiesManager.sendPropertiesCallsCount, 1,
+                       "pending properties must reach the backend before the config is computed")
+    }
+
+    func testLoadListFlushesPropertiesFirst() async throws {
+        remoteConfigService.remoteConfigListResult = Qonversion.RemoteConfigList(remoteConfigs: [])
+
+        _ = try await manager.loadRemoteConfigList()
+
+        XCTAssertEqual(userManager.obtainUserCallsCount, 1)
+        XCTAssertEqual(userPropertiesManager.sendPropertiesCallsCount, 1)
+    }
+
+    func testUserGateErrorFailsTheLoadWithoutServiceCall() async {
+        userManager.error = MockError.stubbed
+
+        do {
+            _ = try await manager.loadRemoteConfig(contextKey: "main")
+            XCTFail("Expected the user gate error to propagate")
+        } catch {
+            XCTAssertEqual(error as? MockError, .stubbed)
+        }
+        XCTAssertTrue(remoteConfigService.loadRemoteConfigContextKeys.isEmpty)
+    }
+
+    func testPropertiesFlushFailureDoesNotBlockTheLoad() async throws {
+        userPropertiesManager.error = MockError.stubbed
+        remoteConfigService.remoteConfigResult = makeRemoteConfig(contextKey: "main")
+
+        let config = try await manager.loadRemoteConfig(contextKey: "main")
+
+        XCTAssertEqual(config.source.contextKey, "main")
+    }
+
+    func testCachedLoadSkipsTheGateAndTheFlush() async throws {
+        remoteConfigService.remoteConfigResult = makeRemoteConfig(contextKey: "main")
+        _ = try await manager.loadRemoteConfig(contextKey: "main")
+
+        _ = try await manager.loadRemoteConfig(contextKey: "main")
+
+        XCTAssertEqual(userManager.obtainUserCallsCount, 1)
+        XCTAssertEqual(userPropertiesManager.sendPropertiesCallsCount, 1)
     }
 
     // MARK: - loadRemoteConfig caching

--- a/Tests/QonversionUnitTests/RemoteConfigManagerTests.swift
+++ b/Tests/QonversionUnitTests/RemoteConfigManagerTests.swift
@@ -102,6 +102,52 @@ final class RemoteConfigManagerTests: XCTestCase {
         XCTAssertEqual(userPropertiesManager.sendPropertiesCallsCount, 1)
     }
 
+    func testPropertiesFlushHappensStrictlyBeforeTheConfigRequest() async throws {
+        let order = OrderRecorder()
+        userPropertiesManager.onSendProperties = { await order.record("flush") }
+        remoteConfigService.onLoadRemoteConfig = { await order.record("load") }
+        remoteConfigService.remoteConfigResult = makeRemoteConfig(contextKey: "main")
+
+        _ = try await manager.loadRemoteConfig(contextKey: "main")
+
+        let events: [String] = await order.events
+        XCTAssertEqual(events, ["flush", "load"])
+    }
+
+    func testLoadListWithContextKeysFlushesPropertiesFirst() async throws {
+        remoteConfigService.remoteConfigListResult = Qonversion.RemoteConfigList(remoteConfigs: [
+            makeRemoteConfig(contextKey: "a"),
+        ])
+
+        _ = try await manager.loadRemoteConfigList(contextKeys: ["a"], includeEmptyContextKey: false)
+
+        XCTAssertEqual(userManager.obtainUserCallsCount, 1)
+        XCTAssertEqual(userPropertiesManager.sendPropertiesCallsCount, 1)
+    }
+
+    func testAttachAndDetachWaitForTheUserGate() async {
+        userManager.error = MockError.stubbed
+
+        let operations: [() async throws -> Void] = [
+            { try await self.manager.attachUserToRemoteConfig(id: "rc") },
+            { try await self.manager.detachUserFromRemoteConfig(id: "rc") },
+            { try await self.manager.attachUserToExperiment(id: "exp", groupId: "g") },
+            { try await self.manager.detachUserFromExperiment(id: "exp") },
+        ]
+        for operation in operations {
+            do {
+                try await operation()
+                XCTFail("Expected the user gate error to propagate")
+            } catch {
+                XCTAssertEqual(error as? MockError, .stubbed)
+            }
+        }
+        XCTAssertTrue(remoteConfigService.attachedRemoteConfigIds.isEmpty)
+        XCTAssertTrue(remoteConfigService.detachedRemoteConfigIds.isEmpty)
+        XCTAssertTrue(remoteConfigService.attachedExperiments.isEmpty)
+        XCTAssertTrue(remoteConfigService.detachedExperimentIds.isEmpty)
+    }
+
     // MARK: - loadRemoteConfig caching
 
     func testLoadRemoteConfigCachesResultByContextKey() async throws {
@@ -316,4 +362,10 @@ private final class ManagerAsyncGate: @unchecked Sendable {
     private let storage = ManagerGateStorage()
     func open() async { await storage.open() }
     func wait() async { await storage.wait() }
+}
+
+/// Records event ordering across concurrent async hooks.
+private actor OrderRecorder {
+    var events: [String] = []
+    func record(_ event: String) { events.append(event) }
 }

--- a/Tests/QonversionUnitTests/RequestProcessorTests.swift
+++ b/Tests/QonversionUnitTests/RequestProcessorTests.swift
@@ -100,6 +100,38 @@ final class RequestProcessorTests: XCTestCase {
         XCTAssertEqual(sent.value(forHTTPHeaderField: "Trigger"), "Purchase")
     }
 
+    func testFailedReplayBumpsThePersistedAttempt() async throws {
+        let stored = StoredRequest(
+            url: baseURL + "v4/users/u1/purchases",
+            method: "POST",
+            body: nil,
+            dedupKey: nil,
+            trigger: "Purchase",
+            attempt: 1
+        )
+        requestsStorage.append(stored)
+        let processor = makeProcessor()
+        networkProvider.response = makeHTTPResponse(statusCode: 500)
+
+        processor.processStoredRequests()
+        await waitUntil { self.requestsStorage.storedRequests.first?.attempt == 2 }
+
+        XCTAssertEqual(requestsStorage.storedRequests.count, 1)
+        XCTAssertEqual(requestsStorage.storedRequests.first?.attempt, 2, "the next replay must report the true attempt number")
+        XCTAssertEqual(requestsStorage.storedRequests.first?.trigger, "Purchase")
+    }
+
+    func testRejectedRetriableRequestStoresItsTrigger() async {
+        let processor = makeProcessor(retriableRequestKinds: [.createPurchase])
+        networkProvider.response = makeHTTPResponse(statusCode: 503)
+        errorHandler.errorToReturn = QonversionError(type: .internal)
+        let request = Request.createPurchase(userId: "u1", body: ["price": "1"])
+
+        _ = try? await processor.process(request: request, responseType: EmptyApiResponse.self, trigger: .restore)
+
+        XCTAssertEqual(requestsStorage.storedRequests.first?.trigger, "Restore", "the replay must repeat the original flow's trigger")
+    }
+
     func testLegacyStoredRequestDecodesWithAttemptOne() throws {
         let legacyJson = #"{"url": "https://api2.qonversion.io/v4/users/u1/purchases", "method": "POST"}"#
 

--- a/Tests/QonversionUnitTests/RequestProcessorTests.swift
+++ b/Tests/QonversionUnitTests/RequestProcessorTests.swift
@@ -56,6 +56,59 @@ final class RequestProcessorTests: XCTestCase {
         )
     }
 
+    // MARK: - Attempt and Trigger headers (production parity)
+
+    func testLiveRequestCarriesAttemptOneAndNoTriggerByDefault() async throws {
+        let processor = makeProcessor()
+        networkProvider.responseData = Data("{}".utf8)
+
+        _ = try? await processor.process(request: Request.getProducts(), responseType: EmptyApiResponse.self)
+
+        let sent = try XCTUnwrap(networkProvider.sentRequests.first)
+        XCTAssertEqual(sent.value(forHTTPHeaderField: "Attempt"), "1")
+        XCTAssertNil(sent.value(forHTTPHeaderField: "Trigger"))
+    }
+
+    func testExplicitTriggerTravelsInTheHeader() async throws {
+        let processor = makeProcessor()
+        networkProvider.responseData = Data("{}".utf8)
+
+        _ = try? await processor.process(request: Request.getProducts(), responseType: EmptyApiResponse.self, trigger: .restore)
+
+        let sent = try XCTUnwrap(networkProvider.sentRequests.first)
+        XCTAssertEqual(sent.value(forHTTPHeaderField: "Trigger"), "Restore")
+    }
+
+    func testReplayedRequestCarriesIncrementedAttemptAndOriginalTrigger() async throws {
+        let stored = StoredRequest(
+            url: baseURL + "v4/users/u1/purchases",
+            method: "POST",
+            body: nil,
+            dedupKey: nil,
+            trigger: "Purchase",
+            attempt: 1
+        )
+        requestsStorage.append(stored)
+        let processor = makeProcessor()
+        networkProvider.response = makeHTTPResponse(statusCode: 200)
+
+        processor.processStoredRequests()
+        await waitUntil { !self.networkProvider.sentRequests.isEmpty }
+
+        let sent = try XCTUnwrap(networkProvider.sentRequests.first)
+        XCTAssertEqual(sent.value(forHTTPHeaderField: "Attempt"), "2")
+        XCTAssertEqual(sent.value(forHTTPHeaderField: "Trigger"), "Purchase")
+    }
+
+    func testLegacyStoredRequestDecodesWithAttemptOne() throws {
+        let legacyJson = #"{"url": "https://api2.qonversion.io/v4/users/u1/purchases", "method": "POST"}"#
+
+        let stored: StoredRequest = try JSONDecoder().decode(StoredRequest.self, from: Data(legacyJson.utf8))
+
+        XCTAssertEqual(stored.attempt, 1)
+        XCTAssertNil(stored.trigger)
+    }
+
     private func waitUntil(timeout: TimeInterval = 3.0, _ condition: @escaping () -> Bool) async {
         let deadline = Date().addingTimeInterval(timeout)
         while !condition() && Date() < deadline {

--- a/Tests/QonversionUnitTests/UserPropertiesManagerTests.swift
+++ b/Tests/QonversionUnitTests/UserPropertiesManagerTests.swift
@@ -24,6 +24,7 @@ final class UserPropertiesManagerTests: XCTestCase {
 
     private var requestProcessor: MockRequestProcessor!
     private var propertiesStorage: UserPropertiesStorage!
+    private var integrationsCollector: MockIntegrationsInfoCollector!
     private var userManager: MockUserManager!
     private var manager: UserPropertiesManager!
 
@@ -33,12 +34,14 @@ final class UserPropertiesManagerTests: XCTestCase {
         propertiesStorage = UserPropertiesStorage()
         userManager = MockUserManager()
         userManager.user = try? JSONDecoder.qonversionTest.decode(Qonversion.User.self, from: Data(#"{"id": "test-user-id", "created_at": "2023-11-14T22:13:20Z", "environment": "sandbox"}"#.utf8))
+        integrationsCollector = MockIntegrationsInfoCollector()
         manager = UserPropertiesManager(
             requestProcessor: requestProcessor,
             propertiesStorage: propertiesStorage,
             delayCalculator: IncrementalDelayCalculator(),
             userIdProvider: InternalConfig(userId: "test-user-id"),
             userManager: userManager,
+            integrationsInfoCollector: integrationsCollector,
             logger: LoggerWrapper()
         )
     }
@@ -81,6 +84,31 @@ final class UserPropertiesManagerTests: XCTestCase {
         manager.setCustomUserProperty(key: "my_key", value: "my_value")
 
         XCTAssertEqual(propertiesStorage.all(), [Qonversion.UserProperty(key: "my_key", value: "my_value")])
+    }
+
+    // MARK: - integrations data auto-collection (production parity)
+
+    func testCollectIntegrationsDataStoresAvailableIntegrationIds() {
+        integrationsCollector.adjustUserIdResult = "adjust-123"
+        integrationsCollector.appsFlyerUserIdResult = "af-456"
+        integrationsCollector.facebookAnonymousIdResult = "fb-789"
+
+        manager.collectIntegrationsData()
+
+        let stored: [String: String] = Dictionary(propertiesStorage.all().map { ($0.key, $0.value) }, uniquingKeysWith: { first, _ in first })
+        XCTAssertEqual(stored["_q_adjust_adid"], "adjust-123")
+        XCTAssertEqual(stored["_q_appsflyer_user_id"], "af-456")
+        XCTAssertEqual(stored["_q_fb_anon_id"], "fb-789")
+    }
+
+    func testCollectIntegrationsDataSkipsMissingIntegrations() {
+        integrationsCollector.adjustUserIdResult = nil
+        integrationsCollector.appsFlyerUserIdResult = nil
+        integrationsCollector.facebookAnonymousIdResult = nil
+
+        manager.collectIntegrationsData()
+
+        XCTAssertTrue(propertiesStorage.all().isEmpty)
     }
 
     // MARK: - defined property keys

--- a/Tests/QonversionUnitTests/UserPropertiesManagerTests.swift
+++ b/Tests/QonversionUnitTests/UserPropertiesManagerTests.swift
@@ -83,6 +83,12 @@ final class UserPropertiesManagerTests: XCTestCase {
         XCTAssertEqual(propertiesStorage.all(), [Qonversion.UserProperty(key: "my_key", value: "my_value")])
     }
 
+    // MARK: - defined property keys
+
+    func testTenjinKeyMatchesTheCrossPlatformContract() {
+        XCTAssertEqual(Qonversion.UserPropertyKey.tenjinAnalyticsInstallationId.rawValue, "_q_tenjin_aiid")
+    }
+
     // MARK: - sendProperties
 
     func testSendPropertiesSuccessClearsStorageAndSendsRequest() async throws {

--- a/Tests/QonversionUnitTests/UserServiceTests.swift
+++ b/Tests/QonversionUnitTests/UserServiceTests.swift
@@ -118,6 +118,16 @@ final class UserServiceTests: XCTestCase {
 
     // MARK: - createUser
 
+    func testUserRequestsCarryTheInitTrigger() async throws {
+        let processor = MockRequestProcessor()
+        let service = UserService(requestProcessor: processor, localStorage: makeStorage(), internalConfig: InternalConfig(userId: "initial"))
+        processor.results = [try decodeUserStub()]
+
+        _ = try await service.createUser()
+
+        XCTAssertEqual(processor.processedTriggers, [.initialization])
+    }
+
     func testCreateUserUsesCurrentUidAndSendsCreateUserRequest() async throws {
         let processor = MockRequestProcessor()
         let storage = makeStorage()

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,8 +21,8 @@ lane :bump do |options|
   new_version = options[:version]
 
   # The SDK version lives in a single Swift constant (sent in request headers).
-  file_path = Dir['../Sources/Assemblies/MiscAssembly.swift'].first
-  update_file(file_path, /case version = ".*"/, "case version = \"#{new_version}\"")
+  file_path = Dir['../Sources/SDKVersion.swift'].first
+  update_file(file_path, /static let current: String = ".*"/, "static let current: String = \"#{new_version}\"")
 end
 
 def get_tag

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -20,15 +20,9 @@ end
 lane :bump do |options|
   new_version = options[:version]
 
-  update_plist(
-    plist_path: "Framework/Info.plist",
-    block: proc do |plist|
-      plist[:CFBundleShortVersionString] = new_version
-    end
-  )
-
-  file_path = Dir['../**/QONConfiguration.m'].first
-  update_file(file_path, /NSString \*const kSDKVersion = @".*";/, "NSString *const kSDKVersion = @\"#{new_version}\";")
+  # The SDK version lives in a single Swift constant (sent in request headers).
+  file_path = Dir['../Sources/Assemblies/MiscAssembly.swift'].first
+  update_file(file_path, /case version = ".*"/, "case version = \"#{new_version}\"")
 end
 
 def get_tag


### PR DESCRIPTION
The bump lane rewrites the Swift version constant instead of the removed ObjC files; the manual prerelease workflows check the repo out (they need the tags); the README drops Carthage and documents the Swift API getting-started path.