### PR TITLE
fix(nocodes): drop IDFA collection and ship No Codes in NoIdfa subspec

### DIFF
--- a/Qonversion.podspec
+++ b/Qonversion.podspec
@@ -44,7 +44,7 @@ Pod::Spec.new do |s|
   end
 
   s.subspec 'NoIdfa' do |sss|
-    sss.source_files              = ['Sources/Qonversion/**/*.{h,m}', 'Sources/Swift/**/*.swift']
+    sss.source_files              = ['Sources/Qonversion/**/*.{h,m}', 'Sources/Swift/**/*.swift', 'Sources/NoCodes/**/*.swift']
     sss.osx.exclude_files         = excluded_files + idfa_exclude_files
     sss.tvos.exclude_files        = excluded_files + idfa_exclude_files
     sss.watchos.exclude_files     = excluded_files + idfa_exclude_files

--- a/Qonversion.podspec
+++ b/Qonversion.podspec
@@ -1,4 +1,5 @@
 Pod::Spec.new do |s|
+  all_sources = ['Sources/Qonversion/**/*.{h,m}', 'Sources/Swift/**/*.swift', 'Sources/NoCodes/**/*.swift']
   excluded_files = ['Sources/NoCodes/**/*.swift']
   idfa_exclude_files = ['Sources/Qonversion/IDFA']
   s.name         = 'Qonversion'
@@ -36,7 +37,7 @@ Pod::Spec.new do |s|
   s.default_subspecs = 'Main'
   
   s.subspec 'Main' do |ss|
-    ss.source_files              = ['Sources/Qonversion/**/*.{h,m}', 'Sources/Swift/**/*.swift', 'Sources/NoCodes/**/*.swift']
+    ss.source_files              = all_sources
     ss.osx.exclude_files         = excluded_files
     ss.tvos.exclude_files        = excluded_files
     ss.watchos.exclude_files     = excluded_files
@@ -44,7 +45,7 @@ Pod::Spec.new do |s|
   end
 
   s.subspec 'NoIdfa' do |sss|
-    sss.source_files              = ['Sources/Qonversion/**/*.{h,m}', 'Sources/Swift/**/*.swift', 'Sources/NoCodes/**/*.swift']
+    sss.source_files              = all_sources
     sss.osx.exclude_files         = excluded_files + idfa_exclude_files
     sss.tvos.exclude_files        = excluded_files + idfa_exclude_files
     sss.watchos.exclude_files     = excluded_files + idfa_exclude_files

--- a/Sources/NoCodes/Device/DeviceInfoCollector.swift
+++ b/Sources/NoCodes/Device/DeviceInfoCollector.swift
@@ -8,10 +8,6 @@
 
 import Foundation
 
-#if canImport(AdSupport)
-import AdSupport
-#endif
-
 #if os(iOS)
 import UIKit
 #elseif os(macOS)
@@ -50,7 +46,6 @@ final class DeviceInfoCollector: DeviceInfoCollectorInterface {
         let country: String? = country()
         let language: String? = language()
         let timezone: String = TimeZone.current.identifier
-        let advertisingId: String? = advertisingId()
         let vendorId: String? = vendorId()
 
         let deviceInfo = Device(
@@ -62,28 +57,12 @@ final class DeviceInfoCollector: DeviceInfoCollectorInterface {
             country: country,
             language: language,
             timezone: timezone,
-            advertisingId: advertisingId,
             vendorId: vendorId,
             installDate: installDate
         )
 
         lastPreparedDevice = deviceInfo
         return deviceInfo
-    }
-    
-    func advertisingId() -> String? {
-        var result: String? = nil
-
-        #if canImport(AdSupport)
-        let advertisingId: UUID = ASIdentifierManager.shared().advertisingIdentifier
-        result = advertisingId.uuidString
-
-        if result == "00000000-0000-0000-0000-000000000000" {
-            result = nil
-        }
-        #endif
-
-        return result
     }
 
     private func osVersion() -> String {

--- a/Sources/NoCodes/Device/DeviceInfoCollectorInterface.swift
+++ b/Sources/NoCodes/Device/DeviceInfoCollectorInterface.swift
@@ -10,10 +10,8 @@ import Foundation
 #if os(iOS)
 
 protocol DeviceInfoCollectorInterface {
-    
+
     func deviceInfo() -> Device
-    
-    func advertisingId() -> String?
 }
 
 #endif

--- a/Sources/NoCodes/Entities/Device.swift
+++ b/Sources/NoCodes/Entities/Device.swift
@@ -18,7 +18,6 @@ struct Device: Comparable, Codable {
     let country: String?
     let language: String?
     let timezone: String?
-    let advertisingId: String?
     let vendorId: String?
     let installDate: TimeInterval
 
@@ -31,7 +30,6 @@ struct Device: Comparable, Codable {
         country: String?,
         language: String?,
         timezone: String,
-        advertisingId: String?,
         vendorId: String?,
         installDate: TimeInterval
     ) {
@@ -43,7 +41,6 @@ struct Device: Comparable, Codable {
         self.country = country
         self.language = language
         self.timezone = timezone
-        self.advertisingId = advertisingId
         self.vendorId = vendorId
         self.installDate = installDate
     }
@@ -57,7 +54,6 @@ struct Device: Comparable, Codable {
         && lhs.country == rhs.country
         && lhs.language == rhs.language
         && lhs.timezone == rhs.timezone
-        && lhs.advertisingId == rhs.advertisingId
         && lhs.vendorId == rhs.vendorId
         && lhs.installDate == rhs.installDate
         


### PR DESCRIPTION
## Context

Kids-mode clients use the `Qonversion/NoIdfa` CocoaPods subspec, which excludes `Sources/Qonversion/IDFA` so the binary contains no `ASIdentifierManager` references. No Codes was incompatible with that setup for two independent reasons:

1. The `NoIdfa` subspec did not include `Sources/NoCodes/**/*.swift` at all — the No Codes API was simply absent for those clients.
2. No Codes hard-imported `AdSupport` and called `ASIdentifierManager.shared().advertisingIdentifier` directly in `DeviceInfoCollector` — a direct symbol reference that fails Kids Category review.

## Changes

- Removed `AdSupport` import and all `advertisingId` collection from No Codes (`DeviceInfoCollector.swift`, `DeviceInfoCollectorInterface.swift`, `Entities/Device.swift`). The collected value was dead weight: never sent anywhere (`HeadersBuilder` only reads appVersion/country/language/os fields), zeroed without an ATT prompt on iOS 14.5+, and contradicting the privacy manifest (`NSPrivacyTracking = false`).
- Added `Sources/NoCodes/**/*.swift` to the `NoIdfa` subspec — kids-mode clients now get the No Codes API. The per-platform exclude lists already present in the subspec now apply, same as in `Main`.
- Side effect: SPM builds (the `NoCodes` target is always part of the product) also stop referencing AdSupport.

## Verification

- `Qonversion-iOS` scheme builds.
- `pod lib lint --subspec=NoIdfa --platforms=ios` passes.
- Built NoIdfa binary: `strings` shows **0** `ASIdentifierManager` occurrences, `otool -L` shows no AdSupport linkage, and NoCodes symbols are present (No Codes is actually compiled in).

Linear: DEV-1164

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7PZguLWJT2jFF3Dsy2Sjd