### PR TITLE
feat: [DEV-1168] Suppress native purchase spinner when web loader present

### DIFF
--- a/Sources/NoCodes/Entities/NoCodesAction.swift
+++ b/Sources/NoCodes/Entities/NoCodesAction.swift
@@ -50,6 +50,10 @@ public enum NoCodesActionType {
 
   /// Internal action for loading context data (device info, user info, entitlements)
   case getContext
+
+  /// Internal action: the web page announces it renders its own purchase loader,
+  /// so the native purchase spinner should be suppressed to avoid a double loader
+  case purchaseLoaderPresent
 }
 
 /// Action performed in the No-Codes

--- a/Sources/NoCodes/Mappers/NoCodesMapper.swift
+++ b/Sources/NoCodes/Mappers/NoCodesMapper.swift
@@ -26,7 +26,8 @@ final class NoCodesMapper: NoCodesMapperInterface {
       "showScreen": .showScreen,
       "redeemPromoCode": .redeemPromoCode,
       "screenAnalytics": .screenAnalytics,
-      "getContext": .getContext
+      "getContext": .getContext,
+      "purchaseLoaderPresent": .purchaseLoaderPresent
     ]
     
     let data: [String: Any] = rawAction["data"] as? [String: Any] ?? [:]

--- a/Sources/NoCodes/NoCodesViewController.swift
+++ b/Sources/NoCodes/NoCodesViewController.swift
@@ -61,6 +61,7 @@ final class NoCodesViewController: UIViewController {
   private var theme: NoCodesTheme!
   private var didTrackScreenShown = false
   private var didTrackScreenClosed = false
+  private var hasWebPurchaseLoader = false
   private var contextBuilder: NoCodesContextBuilderInterface!
   private var htmlInjector: NoCodesHTMLInjectorInterface!
 
@@ -249,7 +250,7 @@ extension NoCodesViewController: WKScriptMessageHandler {
       return
     }
     
-    if action.type != .loadProducts && action.type != .screenAnalytics && action.type != .getContext {
+    if action.type != .loadProducts && action.type != .screenAnalytics && action.type != .getContext && action.type != .purchaseLoaderPresent {
       delegate.noCodesStartsExecuting(action: action)
     }
     
@@ -276,6 +277,8 @@ extension NoCodesViewController: WKScriptMessageHandler {
       handle(screenAnalyticsAction: action)
     case .getContext:
       handle(getContextAction: action)
+    case .purchaseLoaderPresent:
+      hasWebPurchaseLoader = true
     default: break
     }
   }
@@ -537,7 +540,7 @@ extension NoCodesViewController {
   private func handle(purchaseAction: NoCodesAction) {
     guard let productId: String = purchaseAction.parameters?[Constants.productId.rawValue] as? String else { return }
 
-    activityIndicator.startAnimating()
+    if !hasWebPurchaseLoader { activityIndicator.startAnimating() }
     Task {
       do {
         let products = try await Qonversion.shared().products()
@@ -580,7 +583,7 @@ extension NoCodesViewController {
   }
   
   private func handle(restoreAction: NoCodesAction) {
-    activityIndicator.startAnimating()
+    if !hasWebPurchaseLoader { activityIndicator.startAnimating() }
     
     Task {
       do {


### PR DESCRIPTION
Issue: [DEV-1168](https://linear.app/qonversion/issue/DEV-1168)

Suppress the native purchase spinner when the No-Code screen renders its own web purchase loader (from dash-mono#547), so there's no double loader over the web overlay.

## Change
- New internal action `purchaseLoaderPresent` (`NoCodesActionType` + mapper). The web page sends it on load via the existing JS→native bridge (`{ data: { type: "purchaseLoaderPresent", parameters: {} } }`), only when a custom purchase loader is configured.
- On receipt, set `hasWebPurchaseLoader = true`; `handle(purchaseAction:)` / `handle(restoreAction:)` then skip `activityIndicator.startAnimating()`. `stopAnimating()` calls are unchanged (no-op when never started).
- Excluded from `noCodesStartsExecuting` like other internal actions.

Safe/no-op for the web (Stripe) flow (no native spinner) and older screens (never send the signal).

Requires dash-mono#547 (sends the signal). Android counterpart: qonversion/android-sdk#(same branch).

Part of [DEV-1168](https://linear.app/qonversion/issue/DEV-1168)