### PR TITLE
Pass original client error through NoCodesError.fromClientError

### DIFF
--- a/Sources/NoCodes/Entities/NoCodesError.swift
+++ b/Sources/NoCodes/Entities/NoCodesError.swift
@@ -36,11 +36,7 @@ public struct NoCodesError: Error {
   }
   
   static func fromClientError(_ error: Error?) -> NoCodesError {
-    let errorMessage = error?.localizedDescription ?? (error.map { String(describing: $0) }) ?? "Unknown error"
-    return NoCodesError(
-      type: .clientError,
-      message: errorMessage
-    )
+    return NoCodesError(type: .clientError, error: error)
   }
 }
 


### PR DESCRIPTION
## Problem

When a custom `NoCodesPurchaseDelegate` throws from `purchase(product:)` or `restore()`, the SDK wraps the error via `NoCodesError.fromClientError(_:)` before forwarding it to `noCodesFailedToExecute(action:error:)`. Only `localizedDescription` was copied into `message` — the original `Error` object was dropped, even though `NoCodesError` has a public `error: Error?` field for exactly this.

## Fix

`fromClientError` now passes the original error into the initializer, which already composes the message as the `.clientError` default text + the error's `localizedDescription` (passing `message:` too would duplicate it). The unreachable `String(describing:)` fallback is removed (`localizedDescription` is non-optional).

Clients can access the original error via `(err as? NoCodesError)?.error`. No signature changes — backward compatible.

Covers both purchase and restore paths (`NoCodesViewController.handle(purchaseAction:)` / `handle(restoreAction:)`).

Verified: `swift build` of the package for iOS simulator (arm64-apple-ios13.0-simulator) passes.

[DEV-1171](https://linear.app/qonversion/issue/DEV-1171/no-codes-ios-original-client-error-is-lost-when-wrapping-into)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015zCom8YGU7znenFE52cWoP