### PR TITLE
feat: [DEV-1174] Support custom builder actions delivered via NoCodesDelegate

### DIFF
--- a/Sources/NoCodes/Delegate.swift
+++ b/Sources/NoCodes/Delegate.swift
@@ -62,7 +62,8 @@ public protocol NoCodesDelegate {
   /// The No-Codes SDK does not execute anything itself — handle the value in your app code.
   /// The screen stays open; close it using `NoCodes.shared.close()` if needed.
   /// - Parameters:
-  ///   - value: the string value configured for the custom action in the builder
+  ///   - value: the string value configured for the custom action in the builder,
+  ///   or an empty string if no value was configured
   func noCodesReceivedCustomAction(value: String)
 
   /// Called when No-Codes flow is finished and the No-Codes screen is closed

--- a/Sources/NoCodes/Delegate.swift
+++ b/Sources/NoCodes/Delegate.swift
@@ -57,7 +57,14 @@ public protocol NoCodesDelegate {
   ///   - action: ``NoCodesAction``
   /// For example, if the user made a purchase then action.type == .purchase
   func noCodesFinishedExecuting(action: NoCodesAction)
-  
+
+  /// Called when a custom action configured in the builder is triggered on the screen.
+  /// The No-Codes SDK does not execute anything itself — handle the value in your app code.
+  /// The screen stays open; close it using `NoCodes.shared.close()` if needed.
+  /// - Parameters:
+  ///   - value: the string value configured for the custom action in the builder
+  func noCodesReceivedCustomAction(value: String)
+
   /// Called when No-Codes flow is finished and the No-Codes screen is closed
   func noCodesFinished()
   
@@ -143,9 +150,13 @@ public extension NoCodesDelegate {
   }
   
   func noCodesFinishedExecuting(action: NoCodesAction) {
-    
+
   }
-  
+
+  func noCodesReceivedCustomAction(value: String) {
+
+  }
+
   func noCodesFinished() {
     
   }

--- a/Sources/NoCodes/Entities/NoCodesAction.swift
+++ b/Sources/NoCodes/Entities/NoCodesAction.swift
@@ -54,6 +54,11 @@ public enum NoCodesActionType {
   /// Internal action: the web page announces it renders its own purchase loader,
   /// so the native purchase spinner should be suppressed to avoid a double loader
   case purchaseLoaderPresent
+
+  /// Custom action configured in the builder. The SDK does not execute anything itself —
+  /// the configured string value is delivered to the app code via
+  /// ``NoCodesDelegate/noCodesReceivedCustomAction(value:)``
+  case custom
 }
 
 /// Action performed in the No-Codes

--- a/Sources/NoCodes/Mappers/NoCodesMapper.swift
+++ b/Sources/NoCodes/Mappers/NoCodesMapper.swift
@@ -27,7 +27,8 @@ final class NoCodesMapper: NoCodesMapperInterface {
       "redeemPromoCode": .redeemPromoCode,
       "screenAnalytics": .screenAnalytics,
       "getContext": .getContext,
-      "purchaseLoaderPresent": .purchaseLoaderPresent
+      "purchaseLoaderPresent": .purchaseLoaderPresent,
+      "custom": .custom
     ]
     
     let data: [String: Any] = rawAction["data"] as? [String: Any] ?? [:]

--- a/Sources/NoCodes/NoCodesFlowCoordinator.swift
+++ b/Sources/NoCodes/NoCodesFlowCoordinator.swift
@@ -173,7 +173,11 @@ extension NoCodesFlowCoordinator: NoCodesViewControllerDelegate {
   func noCodesFinishedExecuting(action: NoCodesAction) {
     delegate?.noCodesFinishedExecuting(action: action)
   }
-  
+
+  func noCodesReceivedCustomAction(value: String) {
+    delegate?.noCodesReceivedCustomAction(value: value)
+  }
+
   func noCodesFinished() {
     screenEventsService.flush()
     delegate?.noCodesFinished()

--- a/Sources/NoCodes/NoCodesViewController.swift
+++ b/Sources/NoCodes/NoCodesViewController.swift
@@ -21,6 +21,7 @@ enum Constants: String {
   case productId
   case setProducts
   case setContext
+  case value
 }
 
 protocol NoCodesViewControllerDelegate {
@@ -32,11 +33,13 @@ protocol NoCodesViewControllerDelegate {
   func noCodesFailedToExecute(action: NoCodesAction, error: Error?)
   
   func noCodesFinishedExecuting(action: NoCodesAction)
-  
+
+  func noCodesReceivedCustomAction(value: String)
+
   func noCodesFinished()
-  
+
   func noCodesFailedToLoadScreen(error: Error?)
-  
+
 }
 
 final class NoCodesViewController: UIViewController {
@@ -279,6 +282,8 @@ extension NoCodesViewController: WKScriptMessageHandler {
       handle(getContextAction: action)
     case .purchaseLoaderPresent:
       hasWebPurchaseLoader = true
+    case .custom:
+      handle(customAction: action)
     default: break
     }
   }
@@ -537,6 +542,16 @@ extension NoCodesViewController {
     }
   }
   
+  private func handle(customAction: NoCodesAction) {
+    guard let value: String = customAction.parameters?[Constants.value.rawValue] as? String else {
+      logger.error(LoggerInfoMessages.customActionHandlingFailed.rawValue)
+      return delegate.noCodesFailedToExecute(action: customAction, error: nil)
+    }
+
+    delegate.noCodesReceivedCustomAction(value: value)
+    delegate.noCodesFinishedExecuting(action: customAction)
+  }
+
   private func handle(purchaseAction: NoCodesAction) {
     guard let productId: String = purchaseAction.parameters?[Constants.productId.rawValue] as? String else { return }
 

--- a/Sources/NoCodes/NoCodesViewController.swift
+++ b/Sources/NoCodes/NoCodesViewController.swift
@@ -543,10 +543,7 @@ extension NoCodesViewController {
   }
   
   private func handle(customAction: NoCodesAction) {
-    guard let value: String = customAction.parameters?[Constants.value.rawValue] as? String else {
-      logger.error(LoggerInfoMessages.customActionHandlingFailed.rawValue)
-      return delegate.noCodesFailedToExecute(action: customAction, error: nil)
-    }
+    let value: String = customAction.parameters?[Constants.value.rawValue] as? String ?? ""
 
     delegate.noCodesReceivedCustomAction(value: value)
     delegate.noCodesFinishedExecuting(action: customAction)

--- a/Sources/NoCodes/Utils/LoggerWrapper.swift
+++ b/Sources/NoCodes/Utils/LoggerWrapper.swift
@@ -15,7 +15,6 @@ enum LoggerInfoMessages: String {
   case urlHandlingFailed = "Failed to handle the URL"
   case screenEventTrackingFailed = "Failed to send screen events"
   case screenEventFlushed = "Screen events flushed successfully"
-  case customActionHandlingFailed = "Failed to handle the custom action: value is missing"
 }
 
 enum LogLevel: Int {

--- a/Sources/NoCodes/Utils/LoggerWrapper.swift
+++ b/Sources/NoCodes/Utils/LoggerWrapper.swift
@@ -15,6 +15,7 @@ enum LoggerInfoMessages: String {
   case urlHandlingFailed = "Failed to handle the URL"
   case screenEventTrackingFailed = "Failed to send screen events"
   case screenEventFlushed = "Screen events flushed successfully"
+  case customActionHandlingFailed = "Failed to handle the custom action: value is missing"
 }
 
 enum LogLevel: Int {


### PR DESCRIPTION
Issue: [DEV-1174](https://linear.app/qonversion/issue/DEV-1174)

## Summary
Adds support for the new **Custom action** configured in the No Codes builder (dash-mono#554). Wire contract: `{type: 'custom', parameters: {value: '<string>'}}`.

- New `NoCodesActionType.custom` + `"custom"` mapping in `NoCodesMapper`
- New delegate method `noCodesReceivedCustomAction(value:)` with a default no-op implementation — existing conformers keep compiling, **minor release**
- The SDK executes nothing itself: `noCodesStartsExecuting` → `noCodesReceivedCustomAction(value:)` → `noCodesFinishedExecuting`; a missing `value` is delivered as an empty string
- The screen stays open — the client decides whether to close it

## Testing
- `xcodebuild build` for the Qonversion framework scheme (iOS Simulator) passes; NoCodes sources are part of the target

Fixes [DEV-1174](https://linear.app/qonversion/issue/DEV-1174)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KQDQpPzKctBcLGHVpet57