### PR TITLE
feat: [DEV-1180] NoCodes — typed defaultVariables on the loadScreen entity, remove screen-shown overloads

### DIFF
--- a/IntegrationTests/NoCodesIntegrationTest.swift
+++ b/IntegrationTests/NoCodesIntegrationTest.swift
@@ -88,7 +88,10 @@ class NoCodesIntegrationTest: XCTestCase {
     [{"id":"s1","body":"<html>","context_key":"ctx","variables":[\
     {"key":"legacy","type":"string","value":"pre-kind payload"},\
     {"kind":"device","key":"future","type":"string","value":"added later"},\
-    {"kind":"custom","key":"known","type":"boolean","value":false}]}]
+    {"kind":"custom","key":"known","type":"boolean","value":false},\
+    {"kind":"custom","key":"primary","type":"string","value":"custom wins unfiltered"},\
+    {"kind":"product","key":"primary","type":"string","value":"weekly_299"},\
+    {"kind":"selected_product","key":"default_selected_product","type":"string","value":"annual"}]}]
     """
     let screen = try decoder.decode(NoCodesScreen.self, from: Data(json.utf8))
 
@@ -96,11 +99,30 @@ class NoCodesIntegrationTest: XCTestCase {
     XCTAssertEqual(screen.defaultVariables[0].kind, .custom, "Missing kind must default to custom")
     XCTAssertEqual(screen.defaultVariables[1].kind, .unknown, "Unknown kind must decode tolerantly")
     XCTAssertEqual(screen.defaultVariables[2].kind, .custom)
+    XCTAssertEqual(screen.defaultVariables[5].kind, .selectedProduct, "selected_product must decode to the dedicated kind")
 
     // By-key lookup is exact and case-sensitive.
     XCTAssertEqual(screen.defaultVariable(forKey: "known")?.value, .bool(false))
     XCTAssertNil(screen.defaultVariable(forKey: "Known"))
     XCTAssertNil(screen.defaultVariable(forKey: "absent"))
+
+    // Keys are only unique within a kind — the kind filter disambiguates collisions.
+    XCTAssertEqual(screen.defaultVariable(forKey: "primary")?.kind, .custom, "Unfiltered lookup returns the first match in payload order")
+    XCTAssertEqual(screen.defaultVariable(forKey: "primary", kind: .product)?.value, .string("weekly_299"))
+    XCTAssertNil(screen.defaultVariable(forKey: "known", kind: .product))
+    XCTAssertEqual(screen.defaultVariable(forKey: "default_selected_product", kind: .selectedProduct)?.value, .string("annual"))
+  }
+
+  // stringValue renders any variable value as a plain string regardless of native type.
+  func testVariableValueStringValue() {
+    XCTAssertEqual(NoCodesScreenVariableValue.bool(true).stringValue, "true")
+    XCTAssertEqual(NoCodesScreenVariableValue.bool(false).stringValue, "false")
+    XCTAssertEqual(NoCodesScreenVariableValue.string("Go Premium").stringValue, "Go Premium")
+    XCTAssertEqual(NoCodesScreenVariableValue.string("").stringValue, "")
+    XCTAssertEqual(NoCodesScreenVariableValue.number(34).stringValue, "34", "Integral numbers must not carry a trailing .0")
+    XCTAssertEqual(NoCodesScreenVariableValue.number(-2).stringValue, "-2")
+    XCTAssertEqual(NoCodesScreenVariableValue.number(3.5).stringValue, "3.5")
+    XCTAssertEqual(NoCodesScreenVariableValue.none.stringValue, "")
   }
 
   func testGetScreenById() async throws {

--- a/IntegrationTests/NoCodesIntegrationTest.swift
+++ b/IntegrationTests/NoCodesIntegrationTest.swift
@@ -43,58 +43,64 @@ class NoCodesIntegrationTest: XCTestCase {
     XCTAssertEqual(screen.id, ID_FOR_SCREEN_BY_CONTEXT_KEY, "Screen ID should match")
   }
 
-  // Backend-independent: exercises NoCodesScreen decoding of the configured `products`
-  // list across both decode branches, and the defaulting when the key is absent
-  // (older payloads / bundled fallbacks).
-  func testScreenDecodesConfiguredProducts() throws {
+  // Backend-independent: exercises NoCodesScreen decoding of the typed `variables` into
+  // `defaultVariables` — kind (custom/product, tolerant), native value types, and the
+  // defaulting when the key is absent. The shapes (space in key, empty-string default)
+  // mirror real published_configs.
+  func testScreenDecodesTypedDefaultVariables() throws {
     let decoder = JSONDecoder()
 
-    // Array-nested shape (legacy get-by-id `[{…}]`) → the unkeyed CodingKeys branch.
-    let arrayJSON = "[{\"id\":\"s1\",\"body\":\"<html>\",\"context_key\":\"ctx\",\"products\":[\"annual\",\"weekly\"]}]"
-    let arrayScreen = try decoder.decode(NoCodesScreen.self, from: Data(arrayJSON.utf8))
-    XCTAssertEqual(arrayScreen.products, ["annual", "weekly"], "Products should decode from the array-nested response")
-
-    // Keyed shape (by-context-key / preload / bundled fallback) → the ResponseCodingKeys branch.
-    let keyedJSON = "{\"data\":{},\"id\":\"s2\",\"body\":\"<html>\",\"context_key\":\"ctx2\",\"products\":[\"lifetime\"]}"
-    let keyedScreen = try decoder.decode(NoCodesScreen.self, from: Data(keyedJSON.utf8))
-    XCTAssertEqual(keyedScreen.products, ["lifetime"], "Products should decode from the keyed response")
-
-    // Missing products key defaults to an empty array (no crash).
-    let legacyJSON = "[{\"id\":\"s3\",\"body\":\"<html>\",\"context_key\":\"ctx3\"}]"
-    let legacyScreen = try decoder.decode(NoCodesScreen.self, from: Data(legacyJSON.utf8))
-    XCTAssertEqual(legacyScreen.products, [], "Missing products should default to an empty array")
-  }
-
-  // Backend-independent: exercises NoCodesScreen decoding of the authored `variables`, that the
-  // native type is preserved per variable, and defaulting when the key is absent. The shapes
-  // (space in key, empty-string default) mirror real published_configs.
-  func testScreenDecodesTypedVariables() throws {
-    let decoder = JSONDecoder()
-
-    // Array-nested shape → the unkeyed CodingKeys branch.
+    // Array-nested shape (get-by-id `[{…}]`) → the unkeyed CodingKeys branch.
     let arrayJSON = """
     [{"id":"s1","body":"<html>","context_key":"ctx","variables":[\
-    {"key":"isTrial","type":"boolean","value":true},\
-    {"key":"headline","type":"string","value":"Go Premium"},\
-    {"key":"discount","type":"number","value":30},\
-    {"key":"custom var","type":"string","value":""}]}]
+    {"kind":"custom","key":"isTrial","type":"boolean","value":true},\
+    {"kind":"custom","key":"headline","type":"string","value":"Go Premium"},\
+    {"kind":"custom","key":"discount","type":"number","value":30},\
+    {"kind":"custom","key":"custom var","type":"string","value":""},\
+    {"kind":"product","key":"primary","type":"string","value":"weekly_299"}]}]
     """
     let arrayScreen = try decoder.decode(NoCodesScreen.self, from: Data(arrayJSON.utf8))
-    XCTAssertEqual(arrayScreen.variables.map { $0.key }, ["isTrial", "headline", "discount", "custom var"])
-    XCTAssertEqual(arrayScreen.variables[0].value, .bool(true))
-    XCTAssertEqual(arrayScreen.variables[1].value, .string("Go Premium"))
-    XCTAssertEqual(arrayScreen.variables[2].value, .number(30))
-    XCTAssertEqual(arrayScreen.variables[3].value, .string(""), "Empty-string default is preserved")
+    XCTAssertEqual(arrayScreen.defaultVariables.map { $0.key }, ["isTrial", "headline", "discount", "custom var", "primary"])
+    XCTAssertEqual(arrayScreen.defaultVariables[0].value, .bool(true))
+    XCTAssertEqual(arrayScreen.defaultVariables[0].kind, .custom)
+    XCTAssertEqual(arrayScreen.defaultVariables[1].value, .string("Go Premium"))
+    XCTAssertEqual(arrayScreen.defaultVariables[2].value, .number(30))
+    XCTAssertEqual(arrayScreen.defaultVariables[3].value, .string(""), "Empty-string default is preserved")
+    XCTAssertEqual(arrayScreen.defaultVariables[4].kind, .product)
+    XCTAssertEqual(arrayScreen.defaultVariables[4].value, .string("weekly_299"), "Product slot carries the default product id")
 
-    // Keyed shape → the ResponseCodingKeys branch.
-    let keyedJSON = "{\"data\":{},\"id\":\"s2\",\"body\":\"<html>\",\"context_key\":\"ctx2\",\"variables\":[{\"key\":\"promo\",\"type\":\"boolean\",\"value\":false}]}"
+    // Keyed shape (by-context-key / preload / bundled fallback) → the ResponseCodingKeys branch.
+    let keyedJSON = "{\"data\":{},\"id\":\"s2\",\"body\":\"<html>\",\"context_key\":\"ctx2\",\"variables\":[{\"kind\":\"product\",\"key\":\"primary\",\"type\":\"string\",\"value\":\"annual_4999\"}]}"
     let keyedScreen = try decoder.decode(NoCodesScreen.self, from: Data(keyedJSON.utf8))
-    XCTAssertEqual(keyedScreen.variables.first?.value, .bool(false), "Variables should decode from the keyed response")
+    XCTAssertEqual(keyedScreen.defaultVariables.first?.value, .string("annual_4999"), "Variables should decode from the keyed response")
 
     // Missing variables key defaults to an empty array (no crash).
     let legacyJSON = "[{\"id\":\"s3\",\"body\":\"<html>\",\"context_key\":\"ctx3\"}]"
     let legacyScreen = try decoder.decode(NoCodesScreen.self, from: Data(legacyJSON.utf8))
-    XCTAssertEqual(legacyScreen.variables.count, 0, "Missing variables should default to an empty array")
+    XCTAssertEqual(legacyScreen.defaultVariables.count, 0, "Missing variables should default to an empty array")
+  }
+
+  // Forward/backward wire compatibility of the `kind` field and the by-key lookup helper.
+  func testVariableKindToleranceAndLookup() throws {
+    let decoder = JSONDecoder()
+
+    let json = """
+    [{"id":"s1","body":"<html>","context_key":"ctx","variables":[\
+    {"key":"legacy","type":"string","value":"pre-kind payload"},\
+    {"kind":"device","key":"future","type":"string","value":"added later"},\
+    {"kind":"custom","key":"known","type":"boolean","value":false}]}]
+    """
+    let screen = try decoder.decode(NoCodesScreen.self, from: Data(json.utf8))
+
+    // Missing kind (payload predating the field) → .custom; unknown kind → .unknown.
+    XCTAssertEqual(screen.defaultVariables[0].kind, .custom, "Missing kind must default to custom")
+    XCTAssertEqual(screen.defaultVariables[1].kind, .unknown, "Unknown kind must decode tolerantly")
+    XCTAssertEqual(screen.defaultVariables[2].kind, .custom)
+
+    // By-key lookup is exact and case-sensitive.
+    XCTAssertEqual(screen.defaultVariable(forKey: "known")?.value, .bool(false))
+    XCTAssertNil(screen.defaultVariable(forKey: "Known"))
+    XCTAssertNil(screen.defaultVariable(forKey: "absent"))
   }
 
   func testGetScreenById() async throws {

--- a/IntegrationTests/NoCodesIntegrationTest.swift
+++ b/IntegrationTests/NoCodesIntegrationTest.swift
@@ -110,7 +110,11 @@ class NoCodesIntegrationTest: XCTestCase {
     XCTAssertEqual(screen.defaultVariable(forKey: "primary")?.kind, .custom, "Unfiltered lookup returns the first match in payload order")
     XCTAssertEqual(screen.defaultVariable(forKey: "primary", kind: .product)?.value, .string("weekly_299"))
     XCTAssertNil(screen.defaultVariable(forKey: "known", kind: .product))
-    XCTAssertEqual(screen.defaultVariable(forKey: "default_selected_product", kind: .selectedProduct)?.value, .string("annual"))
+
+    // The default selected product resolves via the typed shortcut — no magic key needed.
+    XCTAssertEqual(screen.defaultSelectedProductId, "annual")
+    let bareScreen = try decoder.decode(NoCodesScreen.self, from: Data("[{\"id\":\"s2\",\"body\":\"<html>\",\"context_key\":\"c\"}]".utf8))
+    XCTAssertNil(bareScreen.defaultSelectedProductId, "No selected_product entry -> nil")
   }
 
   // stringValue renders any variable value as a plain string regardless of native type.

--- a/Sample/Views/NoCodesView.swift
+++ b/Sample/Views/NoCodesView.swift
@@ -242,10 +242,11 @@ struct NoCodesView: View {
                 appState.addNoCodesEvent("Screen loaded (id: \(screen.id)), presenting from warm cache")
 
                 // The loaded entity carries the typed default variables configured in the
-                // builder — authored custom variables and product slots — readable by key
-                // (e.g. screen.defaultVariable(forKey: "show_trial")) before presenting.
+                // builder — custom variables, product slots and the default selected
+                // product — readable by key (e.g. screen.defaultVariable(forKey: "primary",
+                // kind: .product)) before presenting.
                 let variables = screen.defaultVariables
-                    .map { "\($0.kind.rawValue) \($0.key) = \(formatVariableValue($0.value))" }
+                    .map { "\($0.kind.rawValue) \($0.key) = \($0.value.stringValue)" }
                     .joined(separator: ", ")
                 appState.addNoCodesEvent("Default variables: [\(variables)]")
 
@@ -258,14 +259,6 @@ struct NoCodesView: View {
         }
     }
 
-    private func formatVariableValue(_ value: NoCodesScreenVariableValue) -> String {
-        switch value {
-        case .bool(let boolValue): return String(boolValue)
-        case .string(let stringValue): return "\"\(stringValue)\""
-        case .number(let numberValue): return String(numberValue)
-        case .none: return "null"
-        }
-    }
 }
 
 // MARK: - NoCodes Presentation Style Option

--- a/Sample/Views/NoCodesView.swift
+++ b/Sample/Views/NoCodesView.swift
@@ -249,6 +249,7 @@ struct NoCodesView: View {
                     .map { "\($0.kind.rawValue) \($0.key) = \($0.value.stringValue)" }
                     .joined(separator: ", ")
                 appState.addNoCodesEvent("Default variables: [\(variables)]")
+                appState.addNoCodesEvent("Default selected product: \(screen.defaultSelectedProductId ?? "none")")
 
                 NoCodes.shared.showScreen(withContextKey: key)
             } catch {

--- a/Sample/Views/NoCodesView.swift
+++ b/Sample/Views/NoCodesView.swift
@@ -240,12 +240,30 @@ struct NoCodesView: View {
                 // Gate on real availability before anything is presented.
                 let screen = try await NoCodes.shared.loadScreen(withContextKey: key)
                 appState.addNoCodesEvent("Screen loaded (id: \(screen.id)), presenting from warm cache")
+
+                // The loaded entity carries the typed default variables configured in the
+                // builder — authored custom variables and product slots — readable by key
+                // (e.g. screen.defaultVariable(forKey: "show_trial")) before presenting.
+                let variables = screen.defaultVariables
+                    .map { "\($0.kind.rawValue) \($0.key) = \(formatVariableValue($0.value))" }
+                    .joined(separator: ", ")
+                appState.addNoCodesEvent("Default variables: [\(variables)]")
+
                 NoCodes.shared.showScreen(withContextKey: key)
             } catch {
                 // The SDK skeleton never appeared, so we can show our own fallback UI instead.
                 let type = (error as? NoCodesError)?.type
                 appState.errorMessage = "Load failed (\(String(describing: type))), showing app fallback instead of the No-Code screen."
             }
+        }
+    }
+
+    private func formatVariableValue(_ value: NoCodesScreenVariableValue) -> String {
+        switch value {
+        case .bool(let boolValue): return String(boolValue)
+        case .string(let stringValue): return "\"\(stringValue)\""
+        case .number(let numberValue): return String(numberValue)
+        case .none: return "null"
         }
     }
 }
@@ -302,10 +320,9 @@ class NoCodesListenerHandler: NoCodesDelegate {
         return nil
     }
     
-    func noCodesHasShownScreen(id: String, products: [String], variables: [NoCodesScreenVariable]) {
+    func noCodesHasShownScreen(id: String) {
         Task { @MainActor in
-            let vars = variables.map { "\($0.key)=\($0.value)" }.joined(separator: ", ")
-            appState?.addNoCodesEvent("Screen shown: \(id), products: \(products), variables: [\(vars)]")
+            appState?.addNoCodesEvent("Screen shown: \(id)")
         }
     }
 

--- a/Sources/NoCodes/Delegate.swift
+++ b/Sources/NoCodes/Delegate.swift
@@ -24,23 +24,6 @@ public protocol NoCodesDelegate {
   ///   - id: Screen identifier
   func noCodesHasShownScreen(id: String)
 
-  /// Called when No-Codes screen is shown, providing the product ids configured on that screen.
-  /// Use this to keep analytics consistent with the full set of products the screen was built with,
-  /// not only the ones the rendered screen requested.
-  /// - Parameters:
-  ///   - id: Screen identifier
-  ///   - products: Qonversion product ids configured on the screen (may be empty)
-  func noCodesHasShownScreen(id: String, products: [String])
-
-  /// Called when No-Codes screen is shown, providing the screen variables authored on it.
-  /// Read them by key (`NoCodesScreenVariable.key`) to react to the screen's configured
-  /// values after it loads; each value keeps its authored type (bool / string / number).
-  /// - Parameters:
-  ///   - id: Screen identifier
-  ///   - products: Qonversion product ids configured on the screen (may be empty)
-  ///   - variables: Screen variables authored on the screen (may be empty)
-  func noCodesHasShownScreen(id: String, products: [String], variables: [NoCodesScreenVariable])
-
   /// Called when No-Codes flow starts executing an action
   /// - Parameters:
   ///   - action: ``NoCodesAction``
@@ -128,18 +111,6 @@ public extension NoCodesDelegate {
   
   func noCodesHasShownScreen(id: String) {
 
-  }
-
-  /// Defaults to the id-only callback so existing conformers keep working; only the
-  /// screen-shown event is fired once (via the 2-arg variant at the call site).
-  func noCodesHasShownScreen(id: String, products: [String]) {
-    noCodesHasShownScreen(id: id)
-  }
-
-  /// Defaults to the products variant so existing conformers keep working; the screen-shown
-  /// event is fired once (via the 3-arg variant at the call site).
-  func noCodesHasShownScreen(id: String, products: [String], variables: [NoCodesScreenVariable]) {
-    noCodesHasShownScreen(id: id, products: products)
   }
 
   func noCodesStartsExecuting(action: NoCodesAction) {

--- a/Sources/NoCodes/Entities/NoCodesScreen.swift
+++ b/Sources/NoCodes/Entities/NoCodesScreen.swift
@@ -14,38 +14,35 @@ public struct NoCodesScreen: Decodable, Sendable {
   public let id: String
   let html: String
   public let contextKey: String
-  /// Qonversion product ids configured in the builder for this screen (may be empty).
-  let products: [String]
-  /// Screen variables authored in the builder for this screen, read by key (may be empty).
-  let variables: [NoCodesScreenVariable]
+  /// Typed default variables of the screen configured in the builder: authored custom
+  /// variables and product slots. Read them by ``NoCodesScreenVariable/key`` (may be empty).
+  public let defaultVariables: [NoCodesScreenVariable]
 
   private enum CodingKeys: String, CodingKey {
     // After adding any keys here, duplicate them in the ResponseCodingKeys
     case id
     case body
     case context_key
-    case products
     case variables
   }
 
   private enum ResponseCodingKeys: String, CodingKey {
-    // Getting screen by id works via legacy API. By context key - via the new, they have different response structure,
-    // so the keys are duplicated to support both.
+    // Getting a screen by context key returns an array of screens, while getting it by id
+    // returns a single object with a `data` envelope — the keys are duplicated to support
+    // both response shapes.
     case data
     case id
     case body
     case context_key
-    case products
     case variables
   }
 
   /// Internal initializer for creating a screen with modified HTML (e.g., with preloaded images).
-  init(id: String, html: String, contextKey: String, products: [String] = [], variables: [NoCodesScreenVariable] = []) {
+  init(id: String, html: String, contextKey: String, defaultVariables: [NoCodesScreenVariable] = []) {
     self.id = id
     self.html = html
     self.contextKey = contextKey
-    self.products = products
-    self.variables = variables
+    self.defaultVariables = defaultVariables
   }
 
   public init(from decoder: Decoder) throws {
@@ -54,42 +51,84 @@ public struct NoCodesScreen: Decodable, Sendable {
       id = try screenContainer.decode(String.self, forKey: .id)
       html = try screenContainer.decode(String.self, forKey: .body)
       contextKey = try screenContainer.decode(String.self, forKey: .context_key)
-      // Older payloads and bundled fallbacks may omit `products`; default to empty.
-      products = (try? screenContainer.decodeIfPresent([String].self, forKey: .products)) ?? []
-      variables = (try? screenContainer.decodeIfPresent([NoCodesScreenVariable].self, forKey: .variables)) ?? []
+      // Older payloads and bundled fallbacks may omit `variables`; default to empty.
+      defaultVariables = (try? screenContainer.decodeIfPresent([NoCodesScreenVariable].self, forKey: .variables)) ?? []
     } else {
       let container = try decoder.container(keyedBy: ResponseCodingKeys.self)
       id = try container.decode(String.self, forKey: .id)
       html = try container.decode(String.self, forKey: .body)
       contextKey = try container.decode(String.self, forKey: .context_key)
-      products = (try? container.decodeIfPresent([String].self, forKey: .products)) ?? []
-      variables = (try? container.decodeIfPresent([NoCodesScreenVariable].self, forKey: .variables)) ?? []
+      defaultVariables = (try? container.decodeIfPresent([NoCodesScreenVariable].self, forKey: .variables)) ?? []
     }
+  }
+
+  /// Returns the default variable configured under the given key, or `nil` when the screen
+  /// has no variable with that exact (case-sensitive) key.
+  public func defaultVariable(forKey key: String) -> NoCodesScreenVariable? {
+    return defaultVariables.first { $0.key == key }
   }
 
   /// Creates a copy of the screen with modified HTML content.
   /// Used for replacing image URLs with base64 data URIs.
   func withHtml(_ newHtml: String) -> NoCodesScreen {
-    return NoCodesScreen(id: id, html: newHtml, contextKey: contextKey, products: products, variables: variables)
+    return NoCodesScreen(id: id, html: newHtml, contextKey: contextKey, defaultVariables: defaultVariables)
   }
 }
 
-/// A No-Codes screen variable authored in the builder, delivered to the SDK at screen load
-/// so it can be read by key. The value keeps its authored type (bool / string / number) rather
-/// than being coerced to a string.
+/// A typed default variable of a No-Codes screen, configured in the builder and delivered
+/// to the SDK at screen load so it can be read by key. The value keeps its authored type
+/// (bool / string / number) rather than being coerced to a string.
 public struct NoCodesScreenVariable: Decodable, Sendable {
-  /// Variable name it is addressed by (`variable.<key>` in the builder). May contain spaces.
+  /// What the variable represents — see ``NoCodesScreenVariableKind``.
+  public let kind: NoCodesScreenVariableKind
+  /// Variable name it is addressed by (`variable.<key>` in the builder for custom
+  /// variables, the slot name for product slots). May contain spaces.
   public let key: String
-  /// Authored type: `"boolean"`, `"string"` or `"number"`.
+  /// Authored value type: `"boolean"`, `"string"` or `"number"`.
   public let type: String
-  /// The authored default value, preserving its native type.
+  /// The configured default value, preserving its native type.
   public let value: NoCodesScreenVariableValue
 
   private enum CodingKeys: String, CodingKey {
+    case kind
     case key
     case type
     case value
   }
+
+  init(kind: NoCodesScreenVariableKind, key: String, type: String, value: NoCodesScreenVariableValue) {
+    self.kind = kind
+    self.key = key
+    self.type = type
+    self.value = value
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    // Payloads predating the `kind` field carry only authored custom variables; unknown
+    // kinds (added on the backend after this SDK version) must not fail the decode.
+    if let rawKind = try container.decodeIfPresent(String.self, forKey: .kind) {
+      kind = NoCodesScreenVariableKind(rawValue: rawKind) ?? .unknown
+    } else {
+      kind = .custom
+    }
+    key = try container.decode(String.self, forKey: .key)
+    type = try container.decode(String.self, forKey: .type)
+    value = try container.decodeIfPresent(NoCodesScreenVariableValue.self, forKey: .value) ?? .none
+  }
+}
+
+/// Kind of a ``NoCodesScreenVariable`` — what it was configured as in the builder.
+/// The set may grow in future backend versions; values this SDK version does not know
+/// decode as ``unknown`` instead of failing.
+public enum NoCodesScreenVariableKind: String, Sendable {
+  /// A Screen Variable authored in the builder's Variables section.
+  case custom
+  /// A product slot: ``NoCodesScreenVariable/key`` is the slot name and
+  /// ``NoCodesScreenVariable/value`` is the default Qonversion product id assigned to it.
+  case product
+  /// A kind introduced on the backend after this SDK version was released.
+  case unknown
 }
 
 /// Typed value of a ``NoCodesScreenVariable``. Preserves the authored JSON type instead of

--- a/Sources/NoCodes/Entities/NoCodesScreen.swift
+++ b/Sources/NoCodes/Entities/NoCodesScreen.swift
@@ -64,8 +64,12 @@ public struct NoCodesScreen: Decodable, Sendable {
 
   /// Returns the default variable configured under the given key, or `nil` when the screen
   /// has no variable with that exact (case-sensitive) key.
-  public func defaultVariable(forKey key: String) -> NoCodesScreenVariable? {
-    return defaultVariables.first { $0.key == key }
+  ///
+  /// Keys are only unique within a kind — a custom variable and a product slot may share a
+  /// name — so pass `kind` to disambiguate; without it the first match in payload order
+  /// (custom variables, then product slots, then the selected product) is returned.
+  public func defaultVariable(forKey key: String, kind: NoCodesScreenVariableKind? = nil) -> NoCodesScreenVariable? {
+    return defaultVariables.first { $0.key == key && (kind == nil || $0.kind == kind) }
   }
 
   /// Creates a copy of the screen with modified HTML content.
@@ -127,6 +131,10 @@ public enum NoCodesScreenVariableKind: String, Sendable {
   /// A product slot: ``NoCodesScreenVariable/key`` is the slot name and
   /// ``NoCodesScreenVariable/value`` is the default Qonversion product id assigned to it.
   case product
+  /// The screen's Default Product configured in the builder:
+  /// ``NoCodesScreenVariable/key`` is always `"default_selected_product"` and
+  /// ``NoCodesScreenVariable/value`` is the Qonversion product id selected by default.
+  case selectedProduct = "selected_product"
   /// A kind introduced on the backend after this SDK version was released.
   case unknown
 }
@@ -139,6 +147,25 @@ public enum NoCodesScreenVariableValue: Decodable, Equatable, Sendable {
   case number(Double)
   /// A `null`/absent authored default.
   case none
+
+  /// The value rendered as a plain string regardless of its native type: `"true"`/`"false"`
+  /// for booleans, the string itself, a number without a trailing `.0` when integral
+  /// (`34`, `3.5`), or an empty string for ``none``.
+  public var stringValue: String {
+    switch self {
+    case .bool(let boolValue):
+      return boolValue ? "true" : "false"
+    case .string(let stringValue):
+      return stringValue
+    case .number(let numberValue):
+      if numberValue.truncatingRemainder(dividingBy: 1) == 0, abs(numberValue) < 1e15 {
+        return String(Int64(numberValue))
+      }
+      return String(numberValue)
+    case .none:
+      return ""
+    }
+  }
 
   public init(from decoder: Decoder) throws {
     let container = try decoder.singleValueContainer()

--- a/Sources/NoCodes/Entities/NoCodesScreen.swift
+++ b/Sources/NoCodes/Entities/NoCodesScreen.swift
@@ -62,12 +62,25 @@ public struct NoCodesScreen: Decodable, Sendable {
     }
   }
 
+  /// The Qonversion product id selected by default when the screen opens (the builder's
+  /// Default Product), or `nil` when none is configured. Convenience over the
+  /// ``NoCodesScreenVariableKind/selectedProduct`` entry of ``defaultVariables``.
+  public var defaultSelectedProductId: String? {
+    guard let variable = defaultVariables.first(where: { $0.kind == .selectedProduct }),
+          case .string(let productId) = variable.value else {
+      return nil
+    }
+    return productId
+  }
+
   /// Returns the default variable configured under the given key, or `nil` when the screen
   /// has no variable with that exact (case-sensitive) key.
   ///
   /// Keys are only unique within a kind — a custom variable and a product slot may share a
   /// name — so pass `kind` to disambiguate; without it the first match in payload order
   /// (custom variables, then product slots, then the selected product) is returned.
+  ///
+  /// For the default selected product prefer ``defaultSelectedProductId`` — it needs no key.
   public func defaultVariable(forKey key: String, kind: NoCodesScreenVariableKind? = nil) -> NoCodesScreenVariable? {
     return defaultVariables.first { $0.key == key && (kind == nil || $0.kind == kind) }
   }

--- a/Sources/NoCodes/NoCodes.swift
+++ b/Sources/NoCodes/NoCodes.swift
@@ -84,6 +84,10 @@ public final class NoCodes {
   /// A successful load warms the shared cache, so a following ``showScreen(withContextKey:)``
   /// renders from cache with a minimal skeleton.
   ///
+  /// The returned screen carries the typed default variables configured in the builder
+  /// (``NoCodesScreen/defaultVariables``) — authored custom variables and product slots —
+  /// so you can read them by key before presenting.
+  ///
   /// - Parameters:
   ///   - contextKey: the context key of the screen.
   /// - Returns: the loaded ``NoCodesScreen``.

--- a/Sources/NoCodes/NoCodesFlowCoordinator.swift
+++ b/Sources/NoCodes/NoCodesFlowCoordinator.swift
@@ -158,8 +158,8 @@ final class NoCodesFlowCoordinator {
 
 extension NoCodesFlowCoordinator: NoCodesViewControllerDelegate {
   
-  func noCodesHasShownScreen(id: String, products: [String], variables: [NoCodesScreenVariable]) {
-    delegate?.noCodesHasShownScreen(id: id, products: products, variables: variables)
+  func noCodesHasShownScreen(id: String) {
+    delegate?.noCodesHasShownScreen(id: id)
   }
   
   func noCodesStartsExecuting(action: NoCodesAction) {

--- a/Sources/NoCodes/NoCodesViewController.swift
+++ b/Sources/NoCodes/NoCodesViewController.swift
@@ -26,7 +26,7 @@ enum Constants: String {
 
 protocol NoCodesViewControllerDelegate {
 
-  func noCodesHasShownScreen(id: String, products: [String], variables: [NoCodesScreenVariable])
+  func noCodesHasShownScreen(id: String)
 
   func noCodesStartsExecuting(action: NoCodesAction)
   
@@ -151,7 +151,7 @@ final class NoCodesViewController: UIViewController {
 
         self.screenId = screen.id
         self.contextKey = screen.contextKey
-        delegate.noCodesHasShownScreen(id: screen.id, products: screen.products, variables: screen.variables)
+        delegate.noCodesHasShownScreen(id: screen.id)
         trackScreenShownIfNeeded()
 
         var htmlToLoad = htmlInjector.injectCustomLocale(into: screen.html, locale: customLocale)


### PR DESCRIPTION
Issue: [DEV-1180](https://linear.app/qonversion/issue/DEV-1180)

Rework of the DEV-1167 exposure API (#695/#696). That API shipped only in `prerelease/6.13.0` — the latest public release 6.12.1 does not contain it, so removing it is **not** a public breaking change.

## What changed
- **`NoCodesScreen.defaultVariables`** (public) — typed default variables configured in the builder, plus a `defaultVariable(forKey:)` lookup. `products` removed from the entity and both decode branches.
- **`NoCodesScreenVariable.kind`** — `.custom` (authored Screen Variable) / `.product` (product slot: key = slot name, value = default Qonversion product id) with tolerant decoding: missing kind (pre-DEV-1180 payload) → `.custom`, unknown kind (future backend) → `.unknown`.
- **Delegate overloads removed**: `noCodesHasShownScreen(id:products:)` and `(id:products:variables:)` are gone; only the id-only callback remains. Variables are read from the entity returned by `loadScreen(withContextKey:)` (pull model instead of the 3-overload push chain).
- Fixed the stale `ResponseCodingKeys` comment (both get-by-id and by-context-key are v3; only the response envelope differs).

## Wire compatibility
Payload key stays `variables` (additive `kind` per entry); `products` key dropped. Backend counterparts: qonversion/dash-mono#556, qonversion/configurator#259, qonversion/api-gateway#580.

## Testing
- Full package builds for iOS simulator (`swift build --triple arm64-apple-ios16.0-simulator`).
- `NoCodesIntegrationTest` reworked: typed decode incl. product slots across both response shapes, kind tolerance (missing/unknown), by-key lookup.

Part of [DEV-1180](https://linear.app/qonversion/issue/DEV-1180)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015YXuzBxSjRGXowA2ovkXx2