### PR TITLE
chore: deprecate public Offerings API

### DIFF
--- a/Sources/Qonversion/Public/Qonversion.h
+++ b/Sources/Qonversion/Public/Qonversion.h
@@ -243,16 +243,16 @@ static NSString *const QonversionErrorDomain = @"com.qonversion.io";
 
 /**
  Returns Qonversion Offerings Object
- 
+
  An offering is a group of products that you can offer to a user on a given paywall based on your business logic.
  For example, you can offer one set of products on a paywall immediately after onboarding and another set of products
  with discounts later on if a user has not converted.
  Offerings allow changing the products offered remotely without releasing app updates.
- 
- @see [Offerings](https://qonversion.io/docs/offerings)
+
+ @see [Migrate Offerings to Remote Configs](https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs)
  @param completion Completion block that includes information about the offerings user and error
  */
-- (void)offerings:(QONOfferingsCompletionHandler)completion;
+- (void)offerings:(QONOfferingsCompletionHandler)completion DEPRECATED_MSG_ATTRIBUTE("Offerings are deprecated. Manage paywall products with Remote Configs instead: https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs");
 
 /**
  Information about the current Qonversion user


### PR DESCRIPTION
## What

Marks the public **Offerings** entry point as deprecated in the iOS SDK.

- `- (void)offerings:` on the `Qonversion` facade (`Sources/Qonversion/Public/Qonversion.h`) now carries a `DEPRECATED_MSG_ATTRIBUTE` pointing to the Remote Configs migration guide.
- The `@see` doc link was repointed from `qonversion.io/docs/offerings` to the migration guide.

## Why

Offerings is a legacy Qonversion feature that has been superseded by **Remote Configs**. This PR begins the sunset by nudging integrators toward the replacement.

Behavior is unchanged — this only surfaces a compiler deprecation warning for new code. DTO/model classes (`QONOfferings`, `QONOffering`, etc.) are intentionally left untouched to avoid a cascade of deprecation warnings inside the SDK itself. Version and CHANGELOG are not touched.

## Migration

https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs

## Related

- documentation_mintlify#100
- dash-mono#571

Please review — **do not merge** yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
