### PR TITLE
fix: make No-Codes intro conditions respect user trial eligibility (DEV-1213)

### DIFF
--- a/Sources/NoCodes/NoCodesViewController.swift
+++ b/Sources/NoCodes/NoCodesViewController.swift
@@ -496,38 +496,6 @@ extension NoCodesViewController {
     return eligibility.status != .ineligible
   }
 
-  // Dead context channel: no published runtime has ever listened to
-  // noCodesContextUpdate, and the setContext handler replaces
-  // window.noCodesContext wholesale. Intentionally presence-based — an
-  // eligibility request here would fire on every screen open for nothing.
-  private func injectProductsContext(products: [String: Qonversion.Product]) async {
-    var productEntries: [String] = []
-    var hasAnyIntro = false
-
-    for (id, product) in products {
-      let hasIntro = product.skProduct?.introductoryPrice != nil
-      if hasIntro { hasAnyIntro = true }
-
-      var introType = "null"
-      if let introPrice = product.skProduct?.introductoryPrice {
-        introType = "\"\(noCodesMapper.map(introPricePaymentType: introPrice.paymentMode))\""
-      }
-
-      productEntries.append("\"\(id)\": { hasIntro: \(hasIntro), introType: \(introType) }")
-    }
-
-    let productsJS = "{ " + productEntries.joined(separator: ", ") + " }"
-    let js = """
-    window.noCodesContext = window.noCodesContext || {};
-    window.noCodesContext.products = \(productsJS);
-    window.noCodesContext.products.hasAnyIntro = \(hasAnyIntro);
-    window.dispatchEvent(new Event("noCodesContextUpdate"));
-    """
-    await MainActor.run {
-      webView?.evaluateJavaScript(js, completionHandler: nil)
-    }
-  }
-
   private var isModalPresentation: Bool {
     if let navigationController = navigationController, navigationController.viewControllers.count > 1 {
       return false
@@ -586,7 +554,6 @@ extension NoCodesViewController {
         return delegate.noCodesFailedToLoadScreen(error: NoCodesError(type: .productsLoadingFailed))
       }
       await send(event: Constants.setProducts.rawValue, data: jsString)
-      await injectProductsContext(products: filteredProducts)
     }
   }
 

--- a/Sources/NoCodes/NoCodesViewController.swift
+++ b/Sources/NoCodes/NoCodesViewController.swift
@@ -65,6 +65,7 @@ final class NoCodesViewController: UIViewController {
   private var didTrackScreenShown = false
   private var didTrackScreenClosed = false
   private var hasWebPurchaseLoader = false
+  private var screenProductIds: [String] = []
   private var contextBuilder: NoCodesContextBuilderInterface!
   private var htmlInjector: NoCodesHTMLInjectorInterface!
 
@@ -356,10 +357,14 @@ extension NoCodesViewController {
   private func handle(getContextAction: NoCodesAction) {
     Task {
       let variables = getContextAction.parameters?["variables"] as? [String] ?? []
-      let requestedProductIds = extractProductIds(from: variables)
+      var contextProductIds = extractProductIds(from: variables)
+      if variables.contains("products.hasAnyIntro") {
+        contextProductIds = Array(Set(contextProductIds).union(screenProductIds))
+      }
+      let checkEligibility = requiresIntroEligibility(variables: variables)
 
       async let entitlementsResult = loadActiveEntitlementIds()
-      async let productsResult = loadProductsContext(productIds: requestedProductIds)
+      async let productsResult = loadProductsContext(productIds: contextProductIds, checkEligibility: checkEligibility)
       async let userPropsResult = loadUserProperties()
 
       let activeEntitlementIds = await entitlementsResult
@@ -385,6 +390,13 @@ extension NoCodesViewController {
     return Array(ids)
   }
 
+  private func requiresIntroEligibility(variables: [String]) -> Bool {
+    return variables.contains { variable in
+      guard variable.hasPrefix("products.") else { return false }
+      return variable == "products.hasAnyIntro" || variable.hasSuffix(".hasIntro") || variable.hasSuffix(".introType")
+    }
+  }
+
   private func loadActiveEntitlementIds() async -> [String] {
     do {
       let entitlements = try await Qonversion.shared().checkEntitlements()
@@ -395,12 +407,12 @@ extension NoCodesViewController {
     }
   }
 
-  private func loadProductsContext(productIds: [String]) async -> [String: Any] {
+  private func loadProductsContext(productIds: [String], checkEligibility: Bool) async -> [String: Any] {
     guard !productIds.isEmpty else { return [:] }
 
     do {
       let products = try await Qonversion.shared().products()
-      let eligibilities = await loadIntroEligibility(productIds: productIds.filter { products[$0] != nil })
+      let eligibilities = checkEligibility ? await loadIntroEligibility(productIds: productIds.filter { products[$0] != nil }) : [:]
       var context: [String: Any] = [:]
       var hasAnyIntro = false
 
@@ -459,17 +471,20 @@ extension NoCodesViewController {
     return eligibility.status != .ineligible
   }
 
+  // Legacy context channel for screens published with older runtime scripts;
+  // the current runtime consumes only the getContext/setContext flow. Kept
+  // presence-based on purpose: an eligibility request here would fire on every
+  // screen open, even when no condition needs it.
   private func injectProductsContext(products: [String: Qonversion.Product]) async {
-    let eligibilities = await loadIntroEligibility(productIds: Array(products.keys))
     var productEntries: [String] = []
     var hasAnyIntro = false
 
     for (id, product) in products {
-      let hasIntro = product.skProduct?.introductoryPrice != nil && isIntroEligible(eligibilities[id])
+      let hasIntro = product.skProduct?.introductoryPrice != nil
       if hasIntro { hasAnyIntro = true }
 
       var introType = "null"
-      if hasIntro, let introPrice = product.skProduct?.introductoryPrice {
+      if let introPrice = product.skProduct?.introductoryPrice {
         introType = "\"\(noCodesMapper.map(introPricePaymentType: introPrice.paymentMode))\""
       }
 
@@ -516,6 +531,12 @@ extension NoCodesViewController {
   }
   
   private func handle(loadProductsAction: NoCodesAction) {
+    // Captured synchronously: the runtime sends getProducts before getContext,
+    // and hasAnyIntro in the context must cover all products of the screen,
+    // not only the ones referenced by three-part condition variables.
+    if let productIds = loadProductsAction.parameters?["productIds"] as? [String] {
+      screenProductIds = productIds
+    }
     Task {
       guard let productIds: [String] = loadProductsAction.parameters?["productIds"] as? [String],
             let products: [String: Qonversion.Product] = try? await Qonversion.shared().products()

--- a/Sources/NoCodes/NoCodesViewController.swift
+++ b/Sources/NoCodes/NoCodesViewController.swift
@@ -357,9 +357,13 @@ extension NoCodesViewController {
   private func handle(getContextAction: NoCodesAction) {
     Task {
       let variables = getContextAction.parameters?["variables"] as? [String] ?? []
-      var contextProductIds = extractProductIds(from: variables)
-      if variables.contains("products.hasAnyIntro") {
-        contextProductIds = Array(Set(contextProductIds).union(screenProductIds))
+      let requestedProductIds = extractProductIds(from: variables)
+      let needsHasAnyIntro = variables.contains(IntroConditionVariable.hasAnyIntro)
+      let contextProductIds = needsHasAnyIntro
+        ? Array(Set(requestedProductIds).union(screenProductIds))
+        : requestedProductIds
+      if needsHasAnyIntro && contextProductIds.isEmpty {
+        logger.warning("products.hasAnyIntro is used in conditions, but the screen has no known products — the condition will evaluate to false")
       }
       let checkEligibility = requiresIntroEligibility(variables: variables)
 
@@ -390,10 +394,22 @@ extension NoCodesViewController {
     return Array(ids)
   }
 
+  // Names of the builder's intro condition variables (conditionalLogicVariables.ts
+  // in dash-mono). Must stay in sync with the builder: a variable missing here
+  // silently skips the eligibility request for screens that use it.
+  private enum IntroConditionVariable {
+    static let productsPrefix = "products."
+    static let hasAnyIntro = "products.hasAnyIntro"
+    static let hasIntroSuffix = ".hasIntro"
+    static let introTypeSuffix = ".introType"
+  }
+
   private func requiresIntroEligibility(variables: [String]) -> Bool {
     return variables.contains { variable in
-      guard variable.hasPrefix("products.") else { return false }
-      return variable == "products.hasAnyIntro" || variable.hasSuffix(".hasIntro") || variable.hasSuffix(".introType")
+      guard variable.hasPrefix(IntroConditionVariable.productsPrefix) else { return false }
+      return variable == IntroConditionVariable.hasAnyIntro
+        || variable.hasSuffix(IntroConditionVariable.hasIntroSuffix)
+        || variable.hasSuffix(IntroConditionVariable.introTypeSuffix)
     }
   }
 
@@ -408,7 +424,9 @@ extension NoCodesViewController {
   }
 
   private func loadProductsContext(productIds: [String], checkEligibility: Bool) async -> [String: Any] {
-    guard !productIds.isEmpty else { return [:] }
+    // An explicit false keeps products.hasAnyIntro defined even when the screen
+    // has no known products, matching the evaluator's missing-variable → false.
+    guard !productIds.isEmpty else { return ["hasAnyIntro": "false"] }
 
     do {
       let products = try await Qonversion.shared().products()
@@ -464,17 +482,19 @@ extension NoCodesViewController {
     }
   }
 
-  // Unknown status and eligibility loading failures fall back to eligible
-  // to keep the pre-eligibility behavior of the intro conditions.
+  // Only an explicit ineligible status hides the intro: unknown and
+  // nonIntroOrTrialProduct statuses, missing entries, and eligibility loading
+  // failures all fall back to eligible to keep the pre-eligibility behavior
+  // of the intro conditions. Store presence still gates hasIntro.
   private func isIntroEligible(_ eligibility: Qonversion.IntroEligibility?) -> Bool {
     guard let eligibility else { return true }
     return eligibility.status != .ineligible
   }
 
-  // Legacy context channel for screens published with older runtime scripts;
-  // the current runtime consumes only the getContext/setContext flow. Kept
-  // presence-based on purpose: an eligibility request here would fire on every
-  // screen open, even when no condition needs it.
+  // Dead context channel: no published runtime has ever listened to
+  // noCodesContextUpdate, and the setContext handler replaces
+  // window.noCodesContext wholesale. Intentionally presence-based — an
+  // eligibility request here would fire on every screen open for nothing.
   private func injectProductsContext(products: [String: Qonversion.Product]) async {
     var productEntries: [String] = []
     var hasAnyIntro = false
@@ -531,9 +551,11 @@ extension NoCodesViewController {
   }
   
   private func handle(loadProductsAction: NoCodesAction) {
-    // Captured synchronously: the runtime sends getProducts before getContext,
-    // and hasAnyIntro in the context must cover all products of the screen,
-    // not only the ones referenced by three-part condition variables.
+    // Captured synchronously: when the screen has products, the runtime sends
+    // getProducts before getContext in the same tick, and hasAnyIntro must
+    // cover all screen products, not only the ones referenced by three-part
+    // condition variables. Screens without product bindings never send
+    // getProducts, leaving this empty.
     if let productIds = loadProductsAction.parameters?["productIds"] as? [String] {
       screenProductIds = productIds
     }

--- a/Sources/NoCodes/NoCodesViewController.swift
+++ b/Sources/NoCodes/NoCodesViewController.swift
@@ -358,14 +358,17 @@ extension NoCodesViewController {
     Task {
       let variables = getContextAction.parameters?["variables"] as? [String] ?? []
       let requestedProductIds = extractProductIds(from: variables)
-      let needsHasAnyIntro = variables.contains(IntroConditionVariable.hasAnyIntro)
-      let contextProductIds = needsHasAnyIntro
+      let checkEligibility = requiresIntroEligibility(variables: variables)
+      // Intro conditions need entries for every screen product, not only the ones
+      // referenced by three-part variables: hasAnyIntro aggregates over all of
+      // them, and slot variables (vars.products.{slot}) are resolved by the
+      // runtime against ctx.products by the bound product id.
+      let contextProductIds = checkEligibility
         ? Array(Set(requestedProductIds).union(screenProductIds))
         : requestedProductIds
-      if needsHasAnyIntro && contextProductIds.isEmpty {
+      if variables.contains(IntroConditionVariable.hasAnyIntro) && contextProductIds.isEmpty {
         logger.warning("products.hasAnyIntro is used in conditions, but the screen has no known products — the condition will evaluate to false")
       }
-      let checkEligibility = requiresIntroEligibility(variables: variables)
 
       async let entitlementsResult = loadActiveEntitlementIds()
       async let productsResult = loadProductsContext(productIds: contextProductIds, checkEligibility: checkEligibility)
@@ -399,6 +402,7 @@ extension NoCodesViewController {
   // silently skips the eligibility request for screens that use it.
   private enum IntroConditionVariable {
     static let productsPrefix = "products."
+    static let slotProductsPrefix = "vars.products."
     static let hasAnyIntro = "products.hasAnyIntro"
     static let hasIntroSuffix = ".hasIntro"
     static let introTypeSuffix = ".introType"
@@ -406,7 +410,8 @@ extension NoCodesViewController {
 
   private func requiresIntroEligibility(variables: [String]) -> Bool {
     return variables.contains { variable in
-      guard variable.hasPrefix(IntroConditionVariable.productsPrefix) else { return false }
+      guard variable.hasPrefix(IntroConditionVariable.productsPrefix)
+              || variable.hasPrefix(IntroConditionVariable.slotProductsPrefix) else { return false }
       return variable == IntroConditionVariable.hasAnyIntro
         || variable.hasSuffix(IntroConditionVariable.hasIntroSuffix)
         || variable.hasSuffix(IntroConditionVariable.introTypeSuffix)

--- a/Sources/NoCodes/NoCodesViewController.swift
+++ b/Sources/NoCodes/NoCodesViewController.swift
@@ -400,16 +400,17 @@ extension NoCodesViewController {
 
     do {
       let products = try await Qonversion.shared().products()
+      let eligibilities = await loadIntroEligibility(productIds: productIds.filter { products[$0] != nil })
       var context: [String: Any] = [:]
       var hasAnyIntro = false
 
       for id in productIds {
         guard let product = products[id] else { continue }
-        let hasIntro = product.skProduct?.introductoryPrice != nil
+        let hasIntro = product.skProduct?.introductoryPrice != nil && isIntroEligible(eligibilities[id])
         if hasIntro { hasAnyIntro = true }
 
         var introType = ""
-        if let introPrice = product.skProduct?.introductoryPrice {
+        if hasIntro, let introPrice = product.skProduct?.introductoryPrice {
           switch introPrice.paymentMode {
           case .freeTrial: introType = "free_trial"
           case .payUpFront: introType = "pay_up_front"
@@ -432,16 +433,43 @@ extension NoCodesViewController {
     }
   }
 
+  private func loadIntroEligibility(productIds: [String]) async -> [String: Qonversion.IntroEligibility] {
+    guard !productIds.isEmpty else { return [:] }
+
+    do {
+      return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<[String: Qonversion.IntroEligibility], Error>) in
+        Qonversion.shared().checkTrialIntroEligibility(productIds) { eligibilities, error in
+          if let error {
+            continuation.resume(throwing: error)
+          } else {
+            continuation.resume(returning: eligibilities)
+          }
+        }
+      }
+    } catch {
+      logger.error("Failed to load intro eligibility: \(error.localizedDescription)")
+      return [:]
+    }
+  }
+
+  // Unknown status and eligibility loading failures fall back to eligible
+  // to keep the pre-eligibility behavior of the intro conditions.
+  private func isIntroEligible(_ eligibility: Qonversion.IntroEligibility?) -> Bool {
+    guard let eligibility else { return true }
+    return eligibility.status != .ineligible
+  }
+
   private func injectProductsContext(products: [String: Qonversion.Product]) async {
+    let eligibilities = await loadIntroEligibility(productIds: Array(products.keys))
     var productEntries: [String] = []
     var hasAnyIntro = false
 
     for (id, product) in products {
-      let hasIntro = product.skProduct?.introductoryPrice != nil
+      let hasIntro = product.skProduct?.introductoryPrice != nil && isIntroEligible(eligibilities[id])
       if hasIntro { hasAnyIntro = true }
 
       var introType = "null"
-      if let introPrice = product.skProduct?.introductoryPrice {
+      if hasIntro, let introPrice = product.skProduct?.introductoryPrice {
         introType = "\"\(noCodesMapper.map(introPricePaymentType: introPrice.paymentMode))\""
       }
 


### PR DESCRIPTION
## Problem

The `Has Any Intro` condition in No-Codes screens (`products.hasAnyIntro` / `products.{id}.hasIntro`) was built from `SKProduct.introductoryPrice` only. That StoreKit 1 field is static product configuration and is user-independent, so users who had already consumed their trial still matched the condition and saw trial copy (and a trial buy button leading to a dead-end purchase flow). Reported by customer, project 8291.

## Fix

The `getContext` context builder (`loadProductsContext`) now calls the existing `checkTrialIntroEligibility` API and treats a product as having an intro only when the user is not ineligible for it:

- `hasIntro` / `hasAnyIntro` = intro offer configured **and** user eligible
- `introType` is emitted only when the intro is available to the user, so trial copy cannot leak through type-based conditions
- `unknown`/`nonIntroOrTrialProduct` statuses, missing entries, and eligibility request failures fall back to **eligible**, preserving today's behavior on any failure path

This aligns iOS with the effective Android behavior, where Google Play returns subscription offers already filtered by user eligibility.

## Scoping the eligibility request

The request carries the full base64 App Store receipt, so it is fired only where it matters: only the `getContext`/`setContext` flow requests eligibility, and only when the screen's condition variables reference `hasIntro`/`introType`/`hasAnyIntro` (including slot `vars.products.{slot}.*` variables). Plain paywalls and screens with non-intro conditions add **no extra request and no show delay**; only screens with intro conditions wait for the single roundtrip (overlapped with the parallel entitlements/userProperties loads behind the show-screen barrier).

## Slot variables

Intro conditions expose **every** screen product in the context (ids captured from `getProducts`), so the runtime can resolve slot variables (`vars.products.{slot}.hasIntro`/`introType`) against eligibility-aware `ctx.products` values — counterpart runtime change: dash-mono#626.

## Also fixed / cleaned up

- `products.hasAnyIntro` is a two-part variable, so `extractProductIds` produced no product ids for it; a screen whose only product condition was `Has Any Intro` got an empty products context and the condition always evaluated to false. It is now computed over the screen's products, stays defined (explicit `false`) when none are known, and logs a warning.
- Removed the dead `injectProductsContext` channel: no published runtime has ever listened to the `noCodesContextUpdate` event it dispatched, and the runtime's `setContext` handler replaces `window.noCodesContext` wholesale (both channels shipped together in 6.9.0).

Android counterpart: android-sdk#846.

Linear: [DEV-1213](https://linear.app/qonversion/issue/DEV-1213/no-codes-expose-introtrial-eligibility-as-a-screen-condition-variable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8y4ndEAtUVwKcvtrz22px