### PR TITLE
fix: reliable pre-RC properties flush + named-key RC cache invalidation on attach/detach (DEV-1231)

### DIFF
--- a/Qonversion.xcodeproj/project.pbxproj
+++ b/Qonversion.xcodeproj/project.pbxproj
@@ -273,6 +273,8 @@
 		89673C2926F35D29008D209A /* QNIdentityServiceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 89673C2826F35D29008D209A /* QNIdentityServiceTests.m */; };
 		89673C2C26F37DC2008D209A /* XCTestCase+Helpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 89673C2B26F37DC2008D209A /* XCTestCase+Helpers.m */; };
 		89673C2F26F49BAA008D209A /* QNIdentityManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 89673C2E26F49BA9008D209A /* QNIdentityManagerTests.m */; };
+		A1DEV1231000000000000001 /* QNUserPropertiesManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A1DEV1231000000000000002 /* QNUserPropertiesManagerTests.m */; };
+		A1DEV1231000000000000003 /* QONRemoteConfigManagerInvalidationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A1DEV1231000000000000004 /* QONRemoteConfigManagerInvalidationTests.m */; };
 		8981E78825C030DD002310BD /* QonversionFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 45239D6E2517CEB00085D0A8 /* QonversionFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		89A192A52604974800C3FCD9 /* QNUserInfoServiceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 89A192A42604974800C3FCD9 /* QNUserInfoServiceTests.m */; };
 		89A193262604B99C00C3FCD9 /* XCTestCase+Unmock.m in Sources */ = {isa = PBXBuildFile; fileRef = 89A193252604B99C00C3FCD9 /* XCTestCase+Unmock.m */; };
@@ -644,6 +646,8 @@
 		89673C2A26F37DC2008D209A /* XCTestCase+Helpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCTestCase+Helpers.h"; sourceTree = "<group>"; };
 		89673C2B26F37DC2008D209A /* XCTestCase+Helpers.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "XCTestCase+Helpers.m"; sourceTree = "<group>"; };
 		89673C2E26F49BA9008D209A /* QNIdentityManagerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QNIdentityManagerTests.m; sourceTree = "<group>"; };
+		A1DEV1231000000000000002 /* QNUserPropertiesManagerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QNUserPropertiesManagerTests.m; sourceTree = "<group>"; };
+		A1DEV1231000000000000004 /* QONRemoteConfigManagerInvalidationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QONRemoteConfigManagerInvalidationTests.m; sourceTree = "<group>"; };
 		89713B4625C1B95700A2448E /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk/System/iOSSupport/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		89713B4A25C1BA1F00A2448E /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk/System/iOSSupport/System/Library/Frameworks/WebKit.framework; sourceTree = DEVELOPER_DIR; };
 		89A192A42604974800C3FCD9 /* QNUserInfoServiceTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QNUserInfoServiceTests.m; sourceTree = "<group>"; };
@@ -1774,6 +1778,8 @@
 			isa = PBXGroup;
 			children = (
 				89673C2E26F49BA9008D209A /* QNIdentityManagerTests.m */,
+				A1DEV1231000000000000002 /* QNUserPropertiesManagerTests.m */,
+				A1DEV1231000000000000004 /* QONRemoteConfigManagerInvalidationTests.m */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -2435,6 +2441,8 @@
 				4531CBC6245789D40022C422 /* QDeviceTests.m in Sources */,
 				891DEA802703BA1B0079B439 /* QNErrorsMapperTests.m in Sources */,
 				89673C2F26F49BAA008D209A /* QNIdentityManagerTests.m in Sources */,
+				A1DEV1231000000000000001 /* QNUserPropertiesManagerTests.m in Sources */,
+				A1DEV1231000000000000003 /* QONRemoteConfigManagerInvalidationTests.m in Sources */,
 				4531CBCB24581BD80022C422 /* QNUserInfoTests.m in Sources */,
 				456ECD37249BB68B00D2BC40 /* QRequestBuilderTests.m in Sources */,
 				89A193262604B99C00C3FCD9 /* XCTestCase+Unmock.m in Sources */,

--- a/Qonversion.xcodeproj/project.pbxproj
+++ b/Qonversion.xcodeproj/project.pbxproj
@@ -273,8 +273,8 @@
 		89673C2926F35D29008D209A /* QNIdentityServiceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 89673C2826F35D29008D209A /* QNIdentityServiceTests.m */; };
 		89673C2C26F37DC2008D209A /* XCTestCase+Helpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 89673C2B26F37DC2008D209A /* XCTestCase+Helpers.m */; };
 		89673C2F26F49BAA008D209A /* QNIdentityManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 89673C2E26F49BA9008D209A /* QNIdentityManagerTests.m */; };
-		A1DEV1231000000000000001 /* QNUserPropertiesManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A1DEV1231000000000000002 /* QNUserPropertiesManagerTests.m */; };
-		A1DEV1231000000000000003 /* QONRemoteConfigManagerInvalidationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A1DEV1231000000000000004 /* QONRemoteConfigManagerInvalidationTests.m */; };
+		A1DEF1231000000000000001 /* QNUserPropertiesManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A1DEF1231000000000000002 /* QNUserPropertiesManagerTests.m */; };
+		A1DEF1231000000000000003 /* QONRemoteConfigManagerInvalidationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A1DEF1231000000000000004 /* QONRemoteConfigManagerInvalidationTests.m */; };
 		8981E78825C030DD002310BD /* QonversionFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 45239D6E2517CEB00085D0A8 /* QonversionFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		89A192A52604974800C3FCD9 /* QNUserInfoServiceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 89A192A42604974800C3FCD9 /* QNUserInfoServiceTests.m */; };
 		89A193262604B99C00C3FCD9 /* XCTestCase+Unmock.m in Sources */ = {isa = PBXBuildFile; fileRef = 89A193252604B99C00C3FCD9 /* XCTestCase+Unmock.m */; };
@@ -646,8 +646,8 @@
 		89673C2A26F37DC2008D209A /* XCTestCase+Helpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCTestCase+Helpers.h"; sourceTree = "<group>"; };
 		89673C2B26F37DC2008D209A /* XCTestCase+Helpers.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "XCTestCase+Helpers.m"; sourceTree = "<group>"; };
 		89673C2E26F49BA9008D209A /* QNIdentityManagerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QNIdentityManagerTests.m; sourceTree = "<group>"; };
-		A1DEV1231000000000000002 /* QNUserPropertiesManagerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QNUserPropertiesManagerTests.m; sourceTree = "<group>"; };
-		A1DEV1231000000000000004 /* QONRemoteConfigManagerInvalidationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QONRemoteConfigManagerInvalidationTests.m; sourceTree = "<group>"; };
+		A1DEF1231000000000000002 /* QNUserPropertiesManagerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QNUserPropertiesManagerTests.m; sourceTree = "<group>"; };
+		A1DEF1231000000000000004 /* QONRemoteConfigManagerInvalidationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QONRemoteConfigManagerInvalidationTests.m; sourceTree = "<group>"; };
 		89713B4625C1B95700A2448E /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk/System/iOSSupport/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		89713B4A25C1BA1F00A2448E /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk/System/iOSSupport/System/Library/Frameworks/WebKit.framework; sourceTree = DEVELOPER_DIR; };
 		89A192A42604974800C3FCD9 /* QNUserInfoServiceTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QNUserInfoServiceTests.m; sourceTree = "<group>"; };
@@ -1778,8 +1778,8 @@
 			isa = PBXGroup;
 			children = (
 				89673C2E26F49BA9008D209A /* QNIdentityManagerTests.m */,
-				A1DEV1231000000000000002 /* QNUserPropertiesManagerTests.m */,
-				A1DEV1231000000000000004 /* QONRemoteConfigManagerInvalidationTests.m */,
+				A1DEF1231000000000000002 /* QNUserPropertiesManagerTests.m */,
+				A1DEF1231000000000000004 /* QONRemoteConfigManagerInvalidationTests.m */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -2441,8 +2441,8 @@
 				4531CBC6245789D40022C422 /* QDeviceTests.m in Sources */,
 				891DEA802703BA1B0079B439 /* QNErrorsMapperTests.m in Sources */,
 				89673C2F26F49BAA008D209A /* QNIdentityManagerTests.m in Sources */,
-				A1DEV1231000000000000001 /* QNUserPropertiesManagerTests.m in Sources */,
-				A1DEV1231000000000000003 /* QONRemoteConfigManagerInvalidationTests.m in Sources */,
+				A1DEF1231000000000000001 /* QNUserPropertiesManagerTests.m in Sources */,
+				A1DEF1231000000000000003 /* QONRemoteConfigManagerInvalidationTests.m in Sources */,
 				4531CBCB24581BD80022C422 /* QNUserInfoTests.m in Sources */,
 				456ECD37249BB68B00D2BC40 /* QRequestBuilderTests.m in Sources */,
 				89A193262604B99C00C3FCD9 /* XCTestCase+Unmock.m in Sources */,

--- a/QonversionTests/Managers/QNUserPropertiesManagerTests.m
+++ b/QonversionTests/Managers/QNUserPropertiesManagerTests.m
@@ -57,6 +57,10 @@
 }
 
 - (void)tearDown {
+  // The manager's init schedules collectIntegrationsDataInBackground with a 5s
+  // performSelector that retains it past tearDown — cancel it so the delayed
+  // fire cannot message a stopMocking'd class mock mid-suite.
+  [NSObject cancelPreviousPerformRequestsWithTarget:self.manager];
   [self.mockClient stopMocking];
   self.mockClient = nil;
   self.manager = nil;

--- a/QonversionTests/Managers/QNUserPropertiesManagerTests.m
+++ b/QonversionTests/Managers/QNUserPropertiesManagerTests.m
@@ -7,31 +7,155 @@
 //
 
 #import <XCTest/XCTest.h>
+#import <OCMock/OCMock.h>
+#import "QNUserPropertiesManager.h"
+#import "QNAPIClient.h"
+#import "QNInMemoryStorage.h"
+
+/*
+ * Contract tests for the forceSendProperties waiter guarantee (DEV-1231).
+ *
+ * The remote-config path wraps every network fetch in
+ * -forceSendProperties: and only issues the GET from the completion, so the
+ * completion must fire strictly AFTER the buffered properties actually reached
+ * the API — including the two historically leaky windows:
+ *   1) the buffer is empty only because an in-flight POST drained it;
+ *   2) a force flush lands while a POST is in flight (follow-up send).
+ */
+
+@interface QNUserPropertiesManager (FlushContractPrivate)
+
+@property (nonatomic) QNAPIClient *apiClient;
+@property (nonatomic) QNInMemoryStorage *inMemoryStorage;
+@property (atomic, strong) NSMutableArray<QONUserPropertiesEmptyCompletionHandler> *completionBlocks;
+@property (atomic, assign) BOOL sendingScheduled;
+@property (atomic, assign) BOOL updatingCurrently;
+@property (atomic, assign) BOOL forceResendRequired;
+
+- (void)sendProperties:(BOOL)force;
+
+@end
 
 @interface QNUserPropertiesManagerTests : XCTestCase
+
+@property (nonatomic, strong) id mockClient;
+@property (nonatomic, strong) QNUserPropertiesManager *manager;
 
 @end
 
 @implementation QNUserPropertiesManagerTests
 
 - (void)setUp {
-    // Put setup code here. This method is called before the invocation of each test method in the class.
+  [super setUp];
+
+  self.mockClient = OCMClassMock([QNAPIClient class]);
+  OCMStub([self.mockClient shared]).andReturn(self.mockClient);
+  OCMStub([self.mockClient apiKey]).andReturn(@"test_api_key");
+
+  self.manager = [QNUserPropertiesManager new];
+  [self.manager setApiClient:self.mockClient];
 }
 
 - (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
+  [self.mockClient stopMocking];
+  self.mockClient = nil;
+  self.manager = nil;
+
+  [super tearDown];
 }
 
-- (void)testExample {
-    // This is an example of a functional test case.
-    // Use XCTAssert and related functions to verify your tests produce the correct results.
+- (void)testForceSendCompletesImmediatelyWhenIdleAndEmpty {
+  // given - nothing pending, nothing in flight
+
+  // when
+  __block BOOL completionFired = NO;
+  [self.manager forceSendProperties:^{
+    completionFired = YES;
+  }];
+
+  // then - the flush is trivially done, synchronously
+  XCTAssertTrue(completionFired);
+  XCTAssertEqual(self.manager.completionBlocks.count, 0);
 }
 
-- (void)testPerformanceExample {
-    // This is an example of a performance test case.
-    [self measureBlock:^{
-        // Put the code you want to measure the time of here.
-    }];
+- (void)testForceSendWithEmptyBufferAndInFlightPostQueuesTheWaiter {
+  // given - a POST is in flight and has already drained the buffer (hole #1)
+  self.manager.updatingCurrently = YES;
+
+  // when
+  __block BOOL completionFired = NO;
+  [self.manager forceSendProperties:^{
+    completionFired = YES;
+  }];
+
+  // then - the waiter must NOT be released synchronously: it waits for a real
+  // request completion; the follow-up intent is recorded atomically with the
+  // enqueue
+  XCTAssertFalse(completionFired);
+  XCTAssertEqual(self.manager.completionBlocks.count, 1);
+  XCTAssertTrue(self.manager.forceResendRequired);
+}
+
+- (void)testEmptySendDrainsQueuedWaiters {
+  // given - a waiter queued behind an in-flight POST that finished without
+  // leaving anything to send
+  self.manager.updatingCurrently = YES;
+  XCTestExpectation *waiterReleased = [self expectationWithDescription:@"waiter released"];
+  [self.manager forceSendProperties:^{
+    [waiterReleased fulfill];
+  }];
+
+  // when - the next send finds an empty buffer
+  self.manager.updatingCurrently = NO;
+  [self.manager sendProperties:NO];
+
+  // then - the empty branch releases the waiter instead of stranding it, and
+  // clears the stale follow-up intent
+  [self waitForExpectations:@[waiterReleased] timeout:2.0];
+  XCTAssertFalse(self.manager.forceResendRequired);
+}
+
+- (void)testForceFlushDuringInFlightPostTriggersFollowUpBeforeReleasingWaiters {
+  // given - the API captures completions so the test controls request timing
+  __block void (^firstCompletion)(NSDictionary *, NSError *) = nil;
+  __block void (^secondCompletion)(NSDictionary *, NSError *) = nil;
+  XCTestExpectation *firstPost = [self expectationWithDescription:@"first POST started"];
+  XCTestExpectation *secondPost = [self expectationWithDescription:@"follow-up POST started"];
+  __block NSInteger postCount = 0;
+  OCMStub([self.mockClient sendProperties:[OCMArg any] completion:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
+    __unsafe_unretained void (^completion)(NSDictionary *, NSError *) = nil;
+    [invocation getArgument:&completion atIndex:3];
+    postCount += 1;
+    if (postCount == 1) {
+      firstCompletion = [completion copy];
+      [firstPost fulfill];
+    } else {
+      secondCompletion = [completion copy];
+      [secondPost fulfill];
+    }
+  });
+
+  [self.manager.inMemoryStorage storeObject:@"a" forKey:@"key_a"];
+  [self.manager forceSendProperties:^{}];
+  [self waitForExpectations:@[firstPost] timeout:2.0];
+
+  // when - a property lands and a force flush arrives while POST-1 is in flight
+  [self.manager.inMemoryStorage storeObject:@"b" forKey:@"key_b"];
+  __block BOOL waiterFired = NO;
+  [self.manager forceSendProperties:^{
+    waiterFired = YES;
+  }];
+  XCTAssertTrue(self.manager.forceResendRequired);
+
+  // POST-1 completes successfully - the follow-up POST must start with the
+  // leftover property while the waiter stays queued (hole #2)
+  firstCompletion(@{}, nil);
+  [self waitForExpectations:@[secondPost] timeout:2.0];
+  XCTAssertFalse(waiterFired);
+
+  // then - only the follow-up completion releases the waiter
+  secondCompletion(@{}, nil);
+  XCTAssertTrue(waiterFired);
 }
 
 @end

--- a/QonversionTests/Managers/QONRemoteConfigManagerInvalidationTests.m
+++ b/QonversionTests/Managers/QONRemoteConfigManagerInvalidationTests.m
@@ -13,6 +13,8 @@
 #import "QNProductCenterManager.h"
 #import "QNUserPropertiesManager.h"
 #import "QONRemoteConfig.h"
+#import "QONRemoteConfigList+Protected.h"
+#import "QONRemoteConfigurationSource.h"
 
 /*
  * Contract tests for the attach/detach cache invalidation (DEV-1231).
@@ -151,6 +153,49 @@
   XCTAssertEqual(deliveredConfig, staleConfig);
   XCTAssertNil(self.manager.loadingStates[@"ctx"].loadedConfig);
   XCTAssertFalse(self.manager.loadingStates[@"ctx"].isInProgress);
+}
+
+- (void)testAttachInvalidationPreventsInFlightListLoadFromReCachingStaleConfigs {
+  // given - the user is stable and a list load is in flight (attach does NOT
+  // replace the states map, so the generation guard is the only barrier here)
+  OCMStub([self.mockProductCenterManager isUserStable]).andReturn(YES);
+  OCMStub([self.mockUserPropertiesManager forceSendProperties:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
+    __unsafe_unretained QONUserPropertiesEmptyCompletionHandler flushCompletion = nil;
+    [invocation getArgument:&flushCompletion atIndex:2];
+    if (flushCompletion) {
+      flushCompletion();
+    }
+  });
+
+  __block QONRemoteConfigListCompletionHandler serviceCompletion = nil;
+  OCMStub([self.mockService loadRemoteConfigList:[OCMArg any] includeEmptyContextKey:NO completion:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
+    __unsafe_unretained QONRemoteConfigListCompletionHandler completion = nil;
+    [invocation getArgument:&completion atIndex:4];
+    serviceCompletion = [completion copy];
+  });
+
+  __block QONRemoteConfigList *deliveredList = nil;
+  [self.manager obtainRemoteConfigListWithContextKeys:@[@"ctx"]
+                               includeEmptyContextKey:NO
+                                           completion:^(QONRemoteConfigList * _Nullable remoteConfigList, NSError * _Nullable error) {
+    deliveredList = remoteConfigList;
+  }];
+  XCTAssertNotNil(serviceCompletion, @"the list load must reach the service");
+
+  // when - the attach invalidates mid-flight, then the pre-attach list lands
+  [self.manager attachUserToRemoteConfiguration:@"config_id"
+                                     completion:^(BOOL success, NSError * _Nullable error) {}];
+
+  id staleConfig = OCMClassMock([QONRemoteConfig class]);
+  id staleSource = OCMClassMock([QONRemoteConfigurationSource class]);
+  OCMStub([staleConfig source]).andReturn(staleSource);
+  OCMStub([staleSource contextKey]).andReturn(@"ctx");
+  QONRemoteConfigList *staleList = [[QONRemoteConfigList alloc] initWithRemoteConfigs:@[staleConfig]];
+  serviceCompletion(staleList, nil);
+
+  // then - the list is delivered but nothing from it is cached
+  XCTAssertEqual(deliveredList, staleList);
+  XCTAssertNil(self.manager.loadingStates[@"ctx"].loadedConfig);
 }
 
 @end

--- a/QonversionTests/Managers/QONRemoteConfigManagerInvalidationTests.m
+++ b/QonversionTests/Managers/QONRemoteConfigManagerInvalidationTests.m
@@ -1,0 +1,156 @@
+//
+//  QONRemoteConfigManagerInvalidationTests.m
+//  QonversionTests
+//
+//  Copyright © 2026 Qonversion Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import <OCMock/OCMock.h>
+#import "QONRemoteConfigManager.h"
+#import "QONRemoteConfigService.h"
+#import "QONRemoteConfigLoadingState.h"
+#import "QNProductCenterManager.h"
+#import "QNUserPropertiesManager.h"
+#import "QONRemoteConfig.h"
+
+/*
+ * Contract tests for the attach/detach cache invalidation (DEV-1231).
+ *
+ * An attach/detach is addressed by experiment/configuration id, and the SDK
+ * cannot know which context key that entity serves — so EVERY cached config
+ * must be dropped (named keys included), loading states must survive with
+ * their pending completions, and an in-flight load must not re-cache a
+ * pre-attach evaluation (generation guard).
+ */
+
+@interface QONRemoteConfigManager (InvalidationContractPrivate)
+
+@property (nonatomic, strong) NSMutableDictionary<NSString *, QONRemoteConfigLoadingState *> *loadingStates;
+@property (atomic, assign) NSUInteger cacheGeneration;
+
+@end
+
+@interface QONRemoteConfigManagerInvalidationTests : XCTestCase
+
+@property (nonatomic, strong) id mockService;
+@property (nonatomic, strong) id mockProductCenterManager;
+@property (nonatomic, strong) id mockUserPropertiesManager;
+@property (nonatomic, strong) QONRemoteConfigManager *manager;
+
+@end
+
+@implementation QONRemoteConfigManagerInvalidationTests
+
+- (void)setUp {
+  [super setUp];
+
+  self.manager = [QONRemoteConfigManager new];
+
+  self.mockService = OCMClassMock([QONRemoteConfigService class]);
+  self.mockProductCenterManager = OCMClassMock([QNProductCenterManager class]);
+  self.mockUserPropertiesManager = OCMClassMock([QNUserPropertiesManager class]);
+
+  self.manager.remoteConfigService = self.mockService;
+  self.manager.productCenterManager = self.mockProductCenterManager;
+  self.manager.userPropertiesManager = self.mockUserPropertiesManager;
+}
+
+- (void)tearDown {
+  [self.mockService stopMocking];
+  [self.mockProductCenterManager stopMocking];
+  [self.mockUserPropertiesManager stopMocking];
+  self.manager = nil;
+
+  [super tearDown];
+}
+
+- (void)seedCachedConfigs {
+  QONRemoteConfigLoadingState *emptyKeyState = [QONRemoteConfigLoadingState new];
+  emptyKeyState.loadedConfig = OCMClassMock([QONRemoteConfig class]);
+
+  QONRemoteConfigLoadingState *namedKeyState = [QONRemoteConfigLoadingState new];
+  namedKeyState.loadedConfig = OCMClassMock([QONRemoteConfig class]);
+  [namedKeyState.completions addObject:^(QONRemoteConfig * _Nullable config, NSError * _Nullable error) {}];
+
+  self.manager.loadingStates[@""] = emptyKeyState;
+  self.manager.loadingStates[@"ctx"] = namedKeyState;
+}
+
+- (void)assertInvalidatedForEntryPoint:(NSString *)entryPoint {
+  XCTAssertNil(self.manager.loadingStates[@""].loadedConfig,
+               @"%@ must drop the empty-key config", entryPoint);
+  XCTAssertNil(self.manager.loadingStates[@"ctx"].loadedConfig,
+               @"%@ must drop the named-key config", entryPoint);
+  XCTAssertNotNil(self.manager.loadingStates[@"ctx"],
+                  @"%@ must preserve the loading state", entryPoint);
+  XCTAssertEqual(self.manager.loadingStates[@"ctx"].completions.count, 1,
+                 @"%@ must preserve pending completions", entryPoint);
+}
+
+- (void)testEveryAttachAndDetachEntryPointInvalidatesNamedKeyCachedConfigs {
+  // attach to remote configuration
+  [self seedCachedConfigs];
+  [self.manager attachUserToRemoteConfiguration:@"config_id"
+                                     completion:^(BOOL success, NSError * _Nullable error) {}];
+  [self assertInvalidatedForEntryPoint:@"attachUserToRemoteConfiguration"];
+
+  // detach from remote configuration
+  [self seedCachedConfigs];
+  [self.manager detachUserFromRemoteConfiguration:@"config_id"
+                                       completion:^(BOOL success, NSError * _Nullable error) {}];
+  [self assertInvalidatedForEntryPoint:@"detachUserFromRemoteConfiguration"];
+
+  // attach to experiment
+  [self seedCachedConfigs];
+  [self.manager attachUserToExperiment:@"experiment_id"
+                               groupId:@"group_id"
+                            completion:^(BOOL success, NSError * _Nullable error) {}];
+  [self assertInvalidatedForEntryPoint:@"attachUserToExperiment"];
+
+  // detach from experiment
+  [self seedCachedConfigs];
+  [self.manager detachUserFromExperiment:@"experiment_id"
+                              completion:^(BOOL success, NSError * _Nullable error) {}];
+  [self assertInvalidatedForEntryPoint:@"detachUserFromExperiment"];
+}
+
+- (void)testAttachInvalidationPreventsInFlightLoadFromReCachingStaleConfig {
+  // given - the user is stable and a single-key load is in flight
+  OCMStub([self.mockProductCenterManager isUserStable]).andReturn(YES);
+  OCMStub([self.mockUserPropertiesManager forceSendProperties:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
+    __unsafe_unretained QONUserPropertiesEmptyCompletionHandler flushCompletion = nil;
+    [invocation getArgument:&flushCompletion atIndex:2];
+    if (flushCompletion) {
+      flushCompletion();
+    }
+  });
+
+  __block QONRemoteConfigCompletionHandler serviceCompletion = nil;
+  OCMStub([self.mockService loadRemoteConfig:[OCMArg any] completion:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
+    __unsafe_unretained QONRemoteConfigCompletionHandler completion = nil;
+    [invocation getArgument:&completion atIndex:3];
+    serviceCompletion = [completion copy];
+  });
+
+  __block QONRemoteConfig *deliveredConfig = nil;
+  [self.manager obtainRemoteConfigWithContextKey:@"ctx"
+                                      completion:^(QONRemoteConfig * _Nullable remoteConfig, NSError * _Nullable error) {
+    deliveredConfig = remoteConfig;
+  }];
+  XCTAssertNotNil(serviceCompletion, @"the load must reach the service");
+
+  // when - the attach invalidates mid-flight, then the pre-attach response lands
+  [self.manager attachUserToRemoteConfiguration:@"config_id"
+                                     completion:^(BOOL success, NSError * _Nullable error) {}];
+  QONRemoteConfig *staleConfig = OCMClassMock([QONRemoteConfig class]);
+  serviceCompletion(staleConfig, nil);
+
+  // then - the stale evaluation is delivered to the waiting caller but must
+  // NOT be re-cached; the state stays refetchable
+  XCTAssertEqual(deliveredConfig, staleConfig);
+  XCTAssertNil(self.manager.loadingStates[@"ctx"].loadedConfig);
+  XCTAssertFalse(self.manager.loadingStates[@"ctx"].isInProgress);
+}
+
+@end

--- a/QonversionTests/Managers/QONRemoteConfigManagerInvalidationTests.m
+++ b/QonversionTests/Managers/QONRemoteConfigManagerInvalidationTests.m
@@ -186,8 +186,10 @@
   [self.manager attachUserToRemoteConfiguration:@"config_id"
                                      completion:^(BOOL success, NSError * _Nullable error) {}];
 
-  id staleConfig = OCMClassMock([QONRemoteConfig class]);
-  id staleSource = OCMClassMock([QONRemoteConfigurationSource class]);
+  // Typed receivers: with plain id the compiler cannot disambiguate the many
+  // -source selectors in scope and fails the build.
+  QONRemoteConfig *staleConfig = OCMClassMock([QONRemoteConfig class]);
+  QONRemoteConfigurationSource *staleSource = OCMClassMock([QONRemoteConfigurationSource class]);
   OCMStub([staleConfig source]).andReturn(staleSource);
   OCMStub([staleSource contextKey]).andReturn(@"ctx");
   QONRemoteConfigList *staleList = [[QONRemoteConfigList alloc] initWithRemoteConfigs:@[staleConfig]];

--- a/Sources/Qonversion/Qonversion/Main/QNUserPropertiesManager/QNUserPropertiesManager.h
+++ b/Sources/Qonversion/Qonversion/Main/QNUserPropertiesManager/QNUserPropertiesManager.h
@@ -14,7 +14,7 @@ typedef void (^QONUserPropertiesEmptyCompletionHandler)(void) NS_SWIFT_NAME(Qonv
 
 - (void)setUserProperty:(NSString *)property value:(NSString *)value;
 - (void)getUserProperties:(QONUserPropertiesCompletionHandler)completion;
-- (void)forceSendProperties:(QONUserPropertiesEmptyCompletionHandler)completion;
+- (void)forceSendProperties:(nullable QONUserPropertiesEmptyCompletionHandler)completion;
 
 @end
 

--- a/Sources/Qonversion/Qonversion/Main/QNUserPropertiesManager/QNUserPropertiesManager.m
+++ b/Sources/Qonversion/Qonversion/Main/QNUserPropertiesManager/QNUserPropertiesManager.m
@@ -30,6 +30,7 @@ static NSString * const kBackgroundQueueName = @"qonversion.background.queue.nam
 
 @property (atomic, assign, readwrite) BOOL sendingScheduled;
 @property (atomic, assign, readwrite) BOOL updatingCurrently;
+@property (atomic, assign, readwrite) BOOL forceResendRequired;
 @property (nonatomic, assign, readwrite) NSUInteger retryDelay;
 @property (nonatomic, assign, readwrite) NSUInteger retriesCounter;
 
@@ -89,19 +90,28 @@ static NSString * const kBackgroundQueueName = @"qonversion.background.queue.nam
 }
 
 - (void)forceSendProperties:(QONUserPropertiesEmptyCompletionHandler)completion {
-  if (self.inMemoryStorage.storageDictionary.count == 0) {
+  BOOL completeImmediately = NO;
+  @synchronized (self) {
+    if (self.inMemoryStorage.storageDictionary.count == 0 && !self.updatingCurrently) {
+      // Nothing pending and nothing in flight — the flush is trivially done.
+      completeImmediately = YES;
+    } else {
+      // Either properties are waiting in the buffer, or the buffer is empty
+      // only because an in-flight POST has already drained it — in both cases
+      // the caller must wait for a real request completion, not race it.
+      if (completion) {
+        [self.completionBlocks addObject:completion];
+      }
+    }
+  }
+
+  if (completeImmediately) {
     if (completion) {
       completion();
     }
     return;
   }
-  
-  @synchronized (self) {
-    if (completion) {
-      [self.completionBlocks addObject:completion];
-    }
-  }
-  
+
   [self sendProperties:YES];
 }
 
@@ -137,18 +147,35 @@ static NSString * const kBackgroundQueueName = @"qonversion.background.queue.nam
   }
   
   @synchronized (self) {
-    if (self.updatingCurrently && !force) {
+    if (self.updatingCurrently) {
+      if (force) {
+        // A force flush arrived while a POST is in flight. Starting a parallel
+        // POST would let the older response drain the shared completion pool
+        // early — mark a follow-up send instead; the in-flight completion
+        // triggers it and keeps the waiters queued until it finishes.
+        self.forceResendRequired = YES;
+      }
       return;
     }
     self.updatingCurrently = YES;
   }
-  
+
   [self runOnBackgroundQueue:^{
     NSDictionary *properties = [self.inMemoryStorage.storageDictionary copy];
-    
+
     if (!properties || ![properties respondsToSelector:@selector(valueForKey:)] || properties.count == 0) {
+      NSArray *completions = @[];
       @synchronized (self) {
         self.updatingCurrently = NO;
+        completions = [self.completionBlocks copy];
+        [self.completionBlocks removeAllObjects];
+      }
+      // Nothing left to send — release any queued force-flush waiters instead
+      // of leaving them stuck until the next request.
+      for (QONUserPropertiesEmptyCompletionHandler storedCompletion in completions) {
+        if (storedCompletion) {
+          storedCompletion();
+        }
       }
       return;
     }
@@ -157,13 +184,23 @@ static NSString * const kBackgroundQueueName = @"qonversion.background.queue.nam
     __block __weak QNUserPropertiesManager *weakSelf = self;
     [self.apiClient sendProperties:properties
                         completion:^(NSDictionary * _Nullable dict, NSError * _Nullable error) {
-      
+
       NSArray *completions = @[];
+      BOOL followUpSend = NO;
       @synchronized (self) {
         weakSelf.updatingCurrently = NO;
-        
-        completions = [weakSelf.completionBlocks copy];
-        [weakSelf.completionBlocks removeAllObjects];
+
+        // A force flush was swallowed while this POST was in flight and the
+        // buffer holds properties that were not part of the sent snapshot —
+        // deliver them first and keep the waiters queued until that follow-up
+        // request finishes.
+        followUpSend = weakSelf.forceResendRequired && !error && weakSelf.inMemoryStorage.storageDictionary.count > 0;
+        weakSelf.forceResendRequired = NO;
+
+        if (!followUpSend) {
+          completions = [weakSelf.completionBlocks copy];
+          [weakSelf.completionBlocks removeAllObjects];
+        }
       }
 
       for (QONUserPropertiesEmptyCompletionHandler storedCompletion in completions) {
@@ -171,7 +208,7 @@ static NSString * const kBackgroundQueueName = @"qonversion.background.queue.nam
           storedCompletion();
         }
       }
-      
+
       if (error) {
         // copy of an existing array to prevent erasing properties set while the current request is in progress
         NSMutableDictionary *allProperties = [self.inMemoryStorage.storageDictionary mutableCopy];
@@ -193,6 +230,10 @@ static NSString * const kBackgroundQueueName = @"qonversion.background.queue.nam
       } else {
         weakSelf.retryDelay = kQPropertiesSendingPeriodInSeconds;
         weakSelf.retriesCounter = 0;
+
+        if (followUpSend) {
+          [weakSelf sendProperties:YES];
+        }
       }
     }];
   }];

--- a/Sources/Qonversion/Qonversion/Main/QNUserPropertiesManager/QNUserPropertiesManager.m
+++ b/Sources/Qonversion/Qonversion/Main/QNUserPropertiesManager/QNUserPropertiesManager.m
@@ -91,17 +91,27 @@ static NSString * const kBackgroundQueueName = @"qonversion.background.queue.nam
 
 - (void)forceSendProperties:(QONUserPropertiesEmptyCompletionHandler)completion {
   BOOL completeImmediately = NO;
+  BOOL startSend = NO;
   @synchronized (self) {
-    if (self.inMemoryStorage.storageDictionary.count == 0 && !self.updatingCurrently) {
-      // Nothing pending and nothing in flight — the flush is trivially done.
-      completeImmediately = YES;
-    } else {
-      // Either properties are waiting in the buffer, or the buffer is empty
-      // only because an in-flight POST has already drained it — in both cases
-      // the caller must wait for a real request completion, not race it.
+    if (self.updatingCurrently) {
+      // A POST is in flight (it may have already drained the buffer). The
+      // waiter enqueue and the follow-up intent must be recorded in the SAME
+      // critical section — deciding later would let the in-flight completion
+      // drain this waiter before the intent is visible.
+      self.forceResendRequired = YES;
       if (completion) {
         [self.completionBlocks addObject:completion];
       }
+    } else if (self.inMemoryStorage.storageDictionary.count == 0) {
+      // Nothing pending and nothing in flight — the flush is trivially done.
+      // Property writers do not take this lock, so a concurrent set can still
+      // slip past this check (pre-existing storage race, best effort).
+      completeImmediately = YES;
+    } else {
+      if (completion) {
+        [self.completionBlocks addObject:completion];
+      }
+      startSend = YES;
     }
   }
 
@@ -112,7 +122,9 @@ static NSString * const kBackgroundQueueName = @"qonversion.background.queue.nam
     return;
   }
 
-  [self sendProperties:YES];
+  if (startSend) {
+    [self sendProperties:YES];
+  }
 }
 
 - (void)sendPropertiesWithDelay:(NSUInteger)delay {
@@ -143,6 +155,18 @@ static NSString * const kBackgroundQueueName = @"qonversion.background.queue.nam
 - (void)sendProperties:(BOOL)force {
   if ([QNUtils isEmptyString:self.apiClient.apiKey]) {
     QONVERSION_ERROR(@"ERROR: apiKey cannot be nil or empty, set apiKey with launchWithKey:");
+    // No request will ever run — release queued force-flush waiters instead of
+    // leaving them stuck forever.
+    NSArray *completions = @[];
+    @synchronized (self) {
+      completions = [self.completionBlocks copy];
+      [self.completionBlocks removeAllObjects];
+    }
+    for (QONUserPropertiesEmptyCompletionHandler storedCompletion in completions) {
+      if (storedCompletion) {
+        storedCompletion();
+      }
+    }
     return;
   }
   
@@ -165,11 +189,26 @@ static NSString * const kBackgroundQueueName = @"qonversion.background.queue.nam
 
     if (!properties || ![properties respondsToSelector:@selector(valueForKey:)] || properties.count == 0) {
       NSArray *completions = @[];
+      BOOL resend = NO;
       @synchronized (self) {
         self.updatingCurrently = NO;
-        completions = [self.completionBlocks copy];
-        [self.completionBlocks removeAllObjects];
+        self.forceResendRequired = NO;
+        // Re-check under the lock: a property stored after the empty snapshot
+        // was taken must trigger a real send instead of releasing the queued
+        // waiters early.
+        if (self.inMemoryStorage.storageDictionary.count > 0) {
+          resend = YES;
+        } else {
+          completions = [self.completionBlocks copy];
+          [self.completionBlocks removeAllObjects];
+        }
       }
+
+      if (resend) {
+        [self sendProperties:YES];
+        return;
+      }
+
       // Nothing left to send — release any queued force-flush waiters instead
       // of leaving them stuck until the next request.
       for (QONUserPropertiesEmptyCompletionHandler storedCompletion in completions) {
@@ -184,22 +223,30 @@ static NSString * const kBackgroundQueueName = @"qonversion.background.queue.nam
     __block __weak QNUserPropertiesManager *weakSelf = self;
     [self.apiClient sendProperties:properties
                         completion:^(NSDictionary * _Nullable dict, NSError * _Nullable error) {
+      // Explicit strong capture: the lock token and every state access below
+      // must target the same live object (weakSelf alone would silently no-op
+      // the critical section if it ever became nil).
+      QNUserPropertiesManager *strongSelf = weakSelf;
+      if (!strongSelf) {
+        return;
+      }
 
       NSArray *completions = @[];
       BOOL followUpSend = NO;
-      @synchronized (self) {
-        weakSelf.updatingCurrently = NO;
+      @synchronized (strongSelf) {
+        strongSelf.updatingCurrently = NO;
 
         // A force flush was swallowed while this POST was in flight and the
         // buffer holds properties that were not part of the sent snapshot —
         // deliver them first and keep the waiters queued until that follow-up
-        // request finishes.
-        followUpSend = weakSelf.forceResendRequired && !error && weakSelf.inMemoryStorage.storageDictionary.count > 0;
-        weakSelf.forceResendRequired = NO;
+        // request finishes. On error the waiters are released right away (best
+        // effort); the data itself is re-merged below and retried with backoff.
+        followUpSend = strongSelf.forceResendRequired && !error && strongSelf.inMemoryStorage.storageDictionary.count > 0;
+        strongSelf.forceResendRequired = NO;
 
         if (!followUpSend) {
-          completions = [weakSelf.completionBlocks copy];
-          [weakSelf.completionBlocks removeAllObjects];
+          completions = [strongSelf.completionBlocks copy];
+          [strongSelf.completionBlocks removeAllObjects];
         }
       }
 
@@ -211,28 +258,28 @@ static NSString * const kBackgroundQueueName = @"qonversion.background.queue.nam
 
       if (error) {
         // copy of an existing array to prevent erasing properties set while the current request is in progress
-        NSMutableDictionary *allProperties = [self.inMemoryStorage.storageDictionary mutableCopy];
+        NSMutableDictionary *allProperties = [strongSelf.inMemoryStorage.storageDictionary mutableCopy];
         for (NSString *key in properties.allKeys) {
           if (!allProperties[key]) {
             allProperties[key] = properties[key];
           }
         }
-        
-        self.inMemoryStorage.storageDictionary = [allProperties copy];
-        
+
+        strongSelf.inMemoryStorage.storageDictionary = [allProperties copy];
+
         if ([error.domain isEqualToString:QonversionErrorDomain] && error.code == QONErrorCodeInvalidClientUID) {
-          [weakSelf.productCenterManager launchWithTrigger:QONRequestTriggerUserProperties completion:^(QONLaunchResult * _Nonnull result, NSError * _Nullable error) {
+          [strongSelf.productCenterManager launchWithTrigger:QONRequestTriggerUserProperties completion:^(QONLaunchResult * _Nonnull result, NSError * _Nullable error) {
             [weakSelf retryProperties];
           }];
         } else {
-          [weakSelf retryProperties];
+          [strongSelf retryProperties];
         }
       } else {
-        weakSelf.retryDelay = kQPropertiesSendingPeriodInSeconds;
-        weakSelf.retriesCounter = 0;
+        strongSelf.retryDelay = kQPropertiesSendingPeriodInSeconds;
+        strongSelf.retriesCounter = 0;
 
         if (followUpSend) {
-          [weakSelf sendProperties:YES];
+          [strongSelf sendProperties:YES];
         }
       }
     }];

--- a/Sources/Qonversion/Qonversion/Main/QONRemoteConfigManager/QONRemoteConfigManager.m
+++ b/Sources/Qonversion/Qonversion/Main/QONRemoteConfigManager/QONRemoteConfigManager.m
@@ -81,8 +81,17 @@ static NSString *const kEmptyContextKey = @"";
 }
 
 - (void)userHasBeenChanged {
-  self.cacheGeneration += 1;
+  [self bumpCacheGeneration];
   self.loadingStates = [NSMutableDictionary new];
+}
+
+// The increment is a read-modify-write: user changes fire from network
+// callback threads while attach/detach invalidations run on the caller
+// thread, so it is taken under the lock to avoid losing a bump.
+- (void)bumpCacheGeneration {
+  @synchronized (self) {
+    self.cacheGeneration += 1;
+  }
 }
 
 - (void)obtainRemoteConfigWithContextKey:(NSString * _Nullable)contextKey completion:(QONRemoteConfigCompletionHandler)completion {
@@ -240,8 +249,10 @@ static NSString *const kEmptyContextKey = @"";
 // does not know which context key that entity serves — drop every cached
 // config, not just the empty-key one, or configs under named context keys stay
 // stale until the process restarts. Loading states themselves are kept so
-// pending completions survive.
+// pending completions survive. The generation bump also stops in-flight loads
+// from re-caching a pre-attach response.
 - (void)invalidateLoadedConfigs {
+  [self bumpCacheGeneration];
   for (QONRemoteConfigLoadingState *loadingState in self.loadingStates.allValues) {
     loadingState.loadedConfig = nil;
   }
@@ -266,9 +277,10 @@ static NSString *const kEmptyContextKey = @"";
 
 - (QONRemoteConfigListCompletionHandler)remoteConfigListCompletionWrapper:(QONRemoteConfigListCompletionHandler)completion contextKeys:(NSArray *)contextKeys includeEmptyContextKey:(BOOL)includeEmptyContextKey {
   NSMutableDictionary<NSString *, QONRemoteConfigLoadingState *> *localLoadingStates = self.loadingStates;
+  NSUInteger generationAtStart = self.cacheGeneration;
 
   __block __weak QONRemoteConfigManager *weakSelf = self;
-  
+
   return ^(QONRemoteConfigList * _Nullable remoteConfigList, NSError * _Nullable error) {
     if (error) {
       [weakSelf actualizeFallbackData];
@@ -284,8 +296,11 @@ static NSString *const kEmptyContextKey = @"";
         return;
       }
     }
-    
-    if (remoteConfigList) {
+
+    if (remoteConfigList && generationAtStart == weakSelf.cacheGeneration) {
+      // Cache only when no invalidation happened while the list load was in
+      // flight — pre-attach evaluations must not be re-cached as fresh. The
+      // list is still delivered below either way.
       for (QONRemoteConfig *remoteConfig in remoteConfigList.remoteConfigs) {
         NSString *contextKey = remoteConfig.source.contextKey ?: kEmptyContextKey;
         QONRemoteConfigLoadingState *loadingState = localLoadingStates[contextKey] ?: [QONRemoteConfigLoadingState new];

--- a/Sources/Qonversion/Qonversion/Main/QONRemoteConfigManager/QONRemoteConfigManager.m
+++ b/Sources/Qonversion/Qonversion/Main/QONRemoteConfigManager/QONRemoteConfigManager.m
@@ -27,6 +27,12 @@ static NSString *const kEmptyContextKey = @"";
 @property (nonatomic, strong) NSMutableArray<QONRemoteConfigListRequestData *> *listRequests;
 @property (nonatomic, strong) QONFallbackObject *fallbackData;
 
+// Bumped on every cache invalidation (attach/detach, user change). Loads
+// capture it when they start and skip the cache write if it moved — an
+// in-flight response evaluated before the invalidating event must not be
+// re-cached as fresh. Completions are still delivered either way.
+@property (atomic, assign) NSUInteger cacheGeneration;
+
 @end
 
 @implementation QONRemoteConfigManager
@@ -75,6 +81,7 @@ static NSString *const kEmptyContextKey = @"";
 }
 
 - (void)userHasBeenChanged {
+  self.cacheGeneration += 1;
   self.loadingStates = [NSMutableDictionary new];
 }
 
@@ -101,9 +108,10 @@ static NSString *const kEmptyContextKey = @"";
   }
   
   loadingState.isInProgress = YES;
-  
+  NSUInteger generationAtStart = self.cacheGeneration;
+
   __block __weak QONRemoteConfigManager *weakSelf = self;
-  
+
   [self.userPropertiesManager forceSendProperties:^{
     [weakSelf.remoteConfigService loadRemoteConfig:contextKey completion:^(QONRemoteConfig * _Nullable remoteConfig, NSError * _Nullable error) {
       loadingState.isInProgress = NO;
@@ -118,26 +126,31 @@ static NSString *const kEmptyContextKey = @"";
           }
 
           if (remoteConfig) {
-            [weakSelf fireRemoteConfig:remoteConfig contextKey:contextKey loadingState:loadingState error:nil completion:completion];
+            [weakSelf fireRemoteConfig:remoteConfig contextKey:contextKey loadingState:loadingState error:nil generation:generationAtStart completion:completion];
           } else {
-            [weakSelf fireRemoteConfig:nil contextKey:contextKey loadingState:loadingState error:error completion:completion];
+            [weakSelf fireRemoteConfig:nil contextKey:contextKey loadingState:loadingState error:error generation:generationAtStart completion:completion];
           }
         } else {
-          [weakSelf fireRemoteConfig:nil contextKey:contextKey loadingState:loadingState error:error completion:completion];
+          [weakSelf fireRemoteConfig:nil contextKey:contextKey loadingState:loadingState error:error generation:generationAtStart completion:completion];
         }
       } else {
-        [weakSelf fireRemoteConfig:remoteConfig contextKey:contextKey loadingState:loadingState error:nil completion:completion];
+        [weakSelf fireRemoteConfig:remoteConfig contextKey:contextKey loadingState:loadingState error:nil generation:generationAtStart completion:completion];
       }
     }];
   }];
 }
 
-- (void)fireRemoteConfig:(QONRemoteConfig *)remoteConfig contextKey:(NSString *)contextKey loadingState:(QONRemoteConfigLoadingState *)loadingState error:(NSError *)error completion:(QONRemoteConfigCompletionHandler)completion {
+- (void)fireRemoteConfig:(QONRemoteConfig *)remoteConfig contextKey:(NSString *)contextKey loadingState:(QONRemoteConfigLoadingState *)loadingState error:(NSError *)error generation:(NSUInteger)generation completion:(QONRemoteConfigCompletionHandler)completion {
   if (error) {
     [self executeRemoteConfigCompletionsWithContextKey:contextKey remoteConfig:nil error:error];
     completion(nil, error);
   } else {
-    loadingState.loadedConfig = remoteConfig;
+    if (generation == self.cacheGeneration) {
+      // Cache only when no invalidation happened while the load was in flight —
+      // a pre-attach evaluation must not be re-cached as fresh. The response is
+      // still delivered below either way.
+      loadingState.loadedConfig = remoteConfig;
+    }
     [self executeRemoteConfigCompletionsWithContextKey:contextKey remoteConfig:remoteConfig error:nil];
     completion(remoteConfig, nil);
   }
@@ -160,8 +173,12 @@ static NSString *const kEmptyContextKey = @"";
 
   if (configs.count == allKeys.count) {
     // Same as the single-key cache hit: serve the cached list, but flush
-    // pending properties so they are not swallowed by the hit.
-    [self.userPropertiesManager forceSendProperties:nil];
+    // pending properties so they are not swallowed by the hit. Gated on user
+    // stability (parity with the single-key path, which checks stability before
+    // its cache hit) so the flush cannot POST mid-identify to a switching uid.
+    if ([self.productCenterManager isUserStable]) {
+      [self.userPropertiesManager forceSendProperties:nil];
+    }
     QONRemoteConfigList *remoteConfigList = [[QONRemoteConfigList alloc] initWithRemoteConfigs:configs];
     return completion(remoteConfigList, nil);
   }

--- a/Sources/Qonversion/Qonversion/Main/QONRemoteConfigManager/QONRemoteConfigManager.m
+++ b/Sources/Qonversion/Qonversion/Main/QONRemoteConfigManager/QONRemoteConfigManager.m
@@ -93,6 +93,10 @@ static NSString *const kEmptyContextKey = @"";
   }
   
   if (loadingState.loadedConfig) {
+    // The cached config is served as is, but properties set right before this
+    // call must still reach the server — otherwise a cache hit swallows both
+    // the property flush and the request.
+    [self.userPropertiesManager forceSendProperties:nil];
     return completion(loadingState.loadedConfig, nil);
   }
   
@@ -155,6 +159,9 @@ static NSString *const kEmptyContextKey = @"";
   }
 
   if (configs.count == allKeys.count) {
+    // Same as the single-key cache hit: serve the cached list, but flush
+    // pending properties so they are not swallowed by the hit.
+    [self.userPropertiesManager forceSendProperties:nil];
     QONRemoteConfigList *remoteConfigList = [[QONRemoteConfigList alloc] initWithRemoteConfigs:configs];
     return completion(remoteConfigList, nil);
   }
@@ -193,23 +200,34 @@ static NSString *const kEmptyContextKey = @"";
 }
 
 - (void)attachUserToExperiment:(NSString *)experimentId groupId:(NSString *)groupId completion:(QONExperimentAttachCompletionHandler)completion {
-  self.loadingStates[kEmptyContextKey] = nil;
+  [self invalidateLoadedConfigs];
   [self.remoteConfigService attachUserToExperiment:experimentId groupId:groupId completion:completion];
 }
 
 - (void)detachUserFromExperiment:(NSString *)experimentId completion:(QONExperimentAttachCompletionHandler)completion {
-  self.loadingStates[kEmptyContextKey] = nil;
+  [self invalidateLoadedConfigs];
   [self.remoteConfigService detachUserFromExperiment:experimentId completion:completion];
 }
 
 - (void)attachUserToRemoteConfiguration:(NSString *)remoteConfigurationId completion:(QONRemoteConfigurationAttachCompletionHandler)completion {
-  self.loadingStates[kEmptyContextKey] = nil;
+  [self invalidateLoadedConfigs];
   [self.remoteConfigService attachUserToRemoteConfiguration:remoteConfigurationId completion:completion];
 }
 
 - (void)detachUserFromRemoteConfiguration:(NSString *)remoteConfigurationId completion:(QONRemoteConfigurationAttachCompletionHandler)completion {
-  self.loadingStates[kEmptyContextKey] = nil;
+  [self invalidateLoadedConfigs];
   [self.remoteConfigService detachUserFromRemoteConfiguration:remoteConfigurationId completion:completion];
+}
+
+// An attach/detach is addressed by experiment/configuration id, and the SDK
+// does not know which context key that entity serves — drop every cached
+// config, not just the empty-key one, or configs under named context keys stay
+// stale until the process restarts. Loading states themselves are kept so
+// pending completions survive.
+- (void)invalidateLoadedConfigs {
+  for (QONRemoteConfigLoadingState *loadingState in self.loadingStates.allValues) {
+    loadingState.loadedConfig = nil;
+  }
 }
 
 - (void)executeRemoteConfigCompletionsWithContextKey:(NSString *)contextKey remoteConfig:(QONRemoteConfig *)remoteConfig error:(NSError *)error {


### PR DESCRIPTION
A5 from the production-defects block of the Remote Config targeting review ([dash-mono PR #674](https://github.com/qonversion/dash-mono/pull/674)). Linear: [DEV-1231](https://linear.app/qonversion/issue/DEV-1231).

## Three holes in the best-effort `forceSendProperties` guarantee (~1 RTT window each)

1. **Empty buffer with an in-flight POST**: `forceSendProperties` completed synchronously when the buffer was empty — even when the buffer was empty only because a still-flying POST had just drained it. The remote-config GET raced that POST. The caller is now queued and released by a real request completion, and the follow-up intent is recorded atomically with the enqueue (same critical section).
2. **Shared completion pool / parallel POSTs**: `force = YES` bypassed the `updatingCurrently` guard, so two POSTs could fly at once and the older response drained the entire shared completion pool early. A force arriving mid-flight now marks a follow-up send instead: the in-flight completion delivers the properties accumulated during the flight first, and only then releases the waiters. The empty-buffer branch re-checks the buffer under the lock (resending when non-empty) and drains the pool otherwise; the empty-apiKey guard drains queued waiters too.
3. **Cache hit swallowing the flush**: a cached config short-circuited before `forceSendProperties`, so a property set right before the call never left the device at all. Cache hits (single and list) now flush pending properties fire-and-forget while still serving the cached config; the list-path flush is gated on user stability (parity with the single-key path).

## Named context keys invalidation on attach/detach + generation guard

Attaching/detaching an experiment or a remote configuration invalidated only the empty-context-key cache entry — configs under named context keys stayed stale until process restart. Every cached config is dropped now (loading states survive to keep pending completions), and a **cache generation** (bumped under a lock on every invalidation and user change) stops in-flight single-key and list loads from re-caching a pre-attach evaluation — the response is still delivered, only the cache write is skipped.

Mirror Android change: [android-sdk#852](https://github.com/qonversion/android-sdk/pull/852).

## Tests

New, wired into the QonversionTests target explicitly (the tests group is a classic PBXGroup with an explicit source list — files without pbxproj references are never compiled): waiter queued behind an in-flight POST instead of a synchronous release, empty-send waiter drain, follow-up POST ordering before waiter release, all four attach/detach entry points invalidating named-key caches non-destructively, and in-flight stale re-cache prevention for both single-key and list loads.

**Follow-up (pre-existing, out of scope):** three test files in the repo have zero pbxproj references and have never run in CI: `ProductCenterManagerIdentifyContractTests.m`, `DeferredPurchaseListenerTests.m`, `QONRedemptionManagerTests.m`. They should be reviewed and wired into the target separately.

## Verification

The framework builds (`xcodebuild -target Qonversion` BUILD SUCCEEDED); both test files compile clean (clang -fsyntax-only with the target include set); `plutil -lint`/`xcodebuild -list` accept the project after the pbxproj edit. The unit suite could not be run locally — the test bundle is hosted by the Sample app with an embedded watch app and the watchOS simulator runtime is not installed on this machine; relying on the CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y4V5cx2SMU4VrfPntwfKJ9