### PR TITLE
fix: map StoreKit enums by value, memoize currency symbols, fix tvOS/…

### DIFF
--- a/Sources/Entities/Transaction.swift
+++ b/Sources/Entities/Transaction.swift
@@ -65,17 +65,11 @@ extension Qonversion {
         
         /// The Apple server environment that generates and signs the transaction.
         @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, visionOS 1.0, *)
-        public var environment: Qonversion.Transaction.Environment? { Qonversion.Transaction.Environment(rawValue: storeKitTransaction?.environment.rawValue ?? "") }
+        public var environment: Qonversion.Transaction.Environment? { Qonversion.Transaction.Environment.from(environment: storeKitTransaction?.environment) }
         
         /// A cause of a purchase transaction, indicating whether it’s a customer’s purchase or an auto-renewable subscription renewal that the system initiates.
         @available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
-        public var reason: Qonversion.Transaction.Reason {
-            guard let storeKitTransaction = storeKitTransaction,
-                  let reason = Qonversion.Transaction.Reason(rawValue: storeKitTransaction.reason.rawValue)
-            else { return Qonversion.Transaction.Reason.purchase }
-            
-            return reason
-        }
+        public var reason: Qonversion.Transaction.Reason { Qonversion.Transaction.Reason.from(reason: storeKitTransaction?.reason) }
         
         /// The decimal representation of the cost of the product, in local currency.
         public let price: Decimal?
@@ -96,13 +90,7 @@ extension Qonversion {
         public var signedDate: Date? { storeKitTransaction?.signedDate }
         
         /// A value that indicates whether the transaction was purchased by the user, or is made available to them through Family Sharing.
-        public var ownershipType: Qonversion.Transaction.OwnershipType {
-            guard let storeKitTransaction = storeKitTransaction,
-                  let ownershipType = Qonversion.Transaction.OwnershipType(rawValue: storeKitTransaction.ownershipType.rawValue)
-            else { return Qonversion.Transaction.OwnershipType.purchased }
-            
-            return ownershipType
-        }
+        public var ownershipType: Qonversion.Transaction.OwnershipType { Qonversion.Transaction.OwnershipType.from(ownershipType: storeKitTransaction?.ownershipType) }
         
         /// Original StoreKit 2 Transaction.
         public var storeKitTransaction: StoreKit.Transaction? { _storeKitTransaction as? StoreKit.Transaction }
@@ -143,7 +131,19 @@ extension Qonversion {
             
             /// The user has access to this transaction through family sharing.
             case familyShared
-            
+
+            // StoreKit spells these "PURCHASED"/"FAMILY_SHARED", not the case names.
+            static func from(ownershipType: StoreKit.Transaction.OwnershipType?) -> Qonversion.Transaction.OwnershipType {
+                guard let ownershipType: StoreKit.Transaction.OwnershipType = ownershipType else { return Qonversion.Transaction.OwnershipType.purchased }
+
+                switch ownershipType {
+                case .familyShared:
+                    return Qonversion.Transaction.OwnershipType.familyShared
+                default:
+                    return Qonversion.Transaction.OwnershipType.purchased
+                }
+            }
+
         }
         
         /// Transaction environment type.
@@ -158,7 +158,24 @@ extension Qonversion {
             
             /// A value that indicates the StoreKit Testing in Xcode environment.
             case xcode
-            
+
+            // StoreKit spells these "Production"/"Sandbox"/"Xcode", not the case names.
+            @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, visionOS 1.0, *)
+            static func from(environment: StoreKit.AppStore.Environment?) -> Qonversion.Transaction.Environment? {
+                guard let environment: StoreKit.AppStore.Environment = environment else { return nil }
+
+                switch environment {
+                case .production:
+                    return Qonversion.Transaction.Environment.production
+                case .sandbox:
+                    return Qonversion.Transaction.Environment.sandbox
+                case .xcode:
+                    return Qonversion.Transaction.Environment.xcode
+                default:
+                    return nil
+                }
+            }
+
         }
         
         /// The subscription offers that apply to a transaction.
@@ -293,7 +310,20 @@ extension Qonversion {
             
             /// A transaction reason that indicates the App Store server initiated a purchase transaction to renew an auto-renewable subscription.
             case renewal
-            
+
+            // StoreKit spells these "PURCHASE"/"RENEWAL", not the case names.
+            @available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+            static func from(reason: StoreKit.Transaction.Reason?) -> Qonversion.Transaction.Reason {
+                guard let reason: StoreKit.Transaction.Reason = reason else { return Qonversion.Transaction.Reason.purchase }
+
+                switch reason {
+                case .renewal:
+                    return Qonversion.Transaction.Reason.renewal
+                default:
+                    return Qonversion.Transaction.Reason.purchase
+                }
+            }
+
         }
         
         /// The JWS representation of the signed transaction — the purchase proof

--- a/Sources/Services/Device/DeviceInfoCollector.swift
+++ b/Sources/Services/Device/DeviceInfoCollector.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-#if os(iOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
 import UIKit
 #elseif os(macOS)
 import IOKit
@@ -147,7 +147,7 @@ final class DeviceInfoCollector: DeviceInfoCollectorInterface {
 
     private func vendorId() -> String? {
         var identifier: String? = nil
-        #if os(iOS)
+        #if os(iOS) || os(tvOS) || os(visionOS)
         identifier = UIDevice.current.identifierForVendor?.uuidString
         #elseif os(watchOS)
         identifier = WKInterfaceDevice.current().identifierForVendor?.uuidString

--- a/Sources/Utils/Utils.swift
+++ b/Sources/Utils/Utils.swift
@@ -23,20 +23,46 @@ extension Bundle {
 // the resolved currency symbol is deterministic across calls and launches.
 fileprivate let sortedLocaleIdentifiers: [String] = Locale.availableIdentifiers.sorted()
 
+// The scan walks roughly a thousand locales and runs once per mapped transaction,
+// so the answers — misses included — are memoized per currency code.
+// @unchecked: the only mutable state is `symbols`, guarded by `lock` on every access.
+private final class CurrencySymbolCache: @unchecked Sendable {
+
+    static let shared = CurrencySymbolCache()
+
+    private let lock = NSLock()
+    private var symbols: [String: String?] = [:]
+
+    func symbol(for currencyCode: String) -> String? {
+        lock.lock()
+        let cached: String?? = symbols[currencyCode]
+        lock.unlock()
+
+        if let cached {
+            return cached
+        }
+
+        let locale: Locale? = sortedLocaleIdentifiers.lazy.map { Locale(identifier: $0) }.first { $0.currencyCode == currencyCode }
+        let symbol: String? = locale?.currencySymbol
+
+        lock.lock()
+        symbols[currencyCode] = symbol
+        lock.unlock()
+
+        return symbol
+    }
+}
+
 extension String {
     func toCurrencySymbol() -> String? {
-        let locale: Locale? = sortedLocaleIdentifiers.lazy.map { Locale(identifier: $0) }.first { $0.currencyCode == self }
-        
-        return locale?.currencySymbol
+        return CurrencySymbolCache.shared.symbol(for: self)
     }
 }
 
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 extension Locale.Currency {
     func currencySymbol() -> String? {
-        let locale: Locale? = sortedLocaleIdentifiers.lazy.map { Locale(identifier: $0) }.first { $0.currencyCode == identifier }
-        
-        return locale?.currencySymbol
+        return CurrencySymbolCache.shared.symbol(for: identifier)
     }
 }
 

--- a/Tests/QonversionUnitTests/TransactionMappingTests.swift
+++ b/Tests/QonversionUnitTests/TransactionMappingTests.swift
@@ -1,0 +1,156 @@
+//
+//  TransactionMappingTests.swift
+//  QonversionUnitTests
+//
+//  Pins the StoreKit -> Qonversion mappings on Qonversion.Transaction: environment,
+//  ownership type and reason. The StoreKit sources are RawRepresentable structs whose
+//  raw spellings ("Production", "FAMILY_SHARED", "RENEWAL") do not match the Swift case
+//  names, so the mappings are driven by the StoreKit values themselves, never by rawValue.
+//
+
+import XCTest
+import StoreKit
+@testable import Qonversion
+
+final class TransactionMappingTests: XCTestCase {
+
+    // MARK: - Environment
+
+    func testEnvironmentMapsProduction() throws {
+        guard #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, visionOS 1.0, *) else {
+            throw XCTSkip("AppStore.Environment requires macOS 13")
+        }
+
+        let mapped: Qonversion.Transaction.Environment? = Qonversion.Transaction.Environment.from(environment: StoreKit.AppStore.Environment.production)
+
+        XCTAssertEqual(mapped, Qonversion.Transaction.Environment.production)
+    }
+
+    func testEnvironmentMapsSandbox() throws {
+        guard #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, visionOS 1.0, *) else {
+            throw XCTSkip("AppStore.Environment requires macOS 13")
+        }
+
+        let mapped: Qonversion.Transaction.Environment? = Qonversion.Transaction.Environment.from(environment: StoreKit.AppStore.Environment.sandbox)
+
+        XCTAssertEqual(mapped, Qonversion.Transaction.Environment.sandbox)
+    }
+
+    func testEnvironmentMapsXcode() throws {
+        guard #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, visionOS 1.0, *) else {
+            throw XCTSkip("AppStore.Environment requires macOS 13")
+        }
+
+        let mapped: Qonversion.Transaction.Environment? = Qonversion.Transaction.Environment.from(environment: StoreKit.AppStore.Environment.xcode)
+
+        XCTAssertEqual(mapped, Qonversion.Transaction.Environment.xcode)
+    }
+
+    func testEnvironmentMapsUnknownValueToNil() throws {
+        guard #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, visionOS 1.0, *) else {
+            throw XCTSkip("AppStore.Environment requires macOS 13")
+        }
+        let unknown = StoreKit.AppStore.Environment(rawValue: "FutureEnvironment")
+
+        let mapped: Qonversion.Transaction.Environment? = Qonversion.Transaction.Environment.from(environment: unknown)
+
+        XCTAssertNil(mapped)
+    }
+
+    func testEnvironmentMapsNilToNil() throws {
+        guard #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, visionOS 1.0, *) else {
+            throw XCTSkip("AppStore.Environment requires macOS 13")
+        }
+
+        let mapped: Qonversion.Transaction.Environment? = Qonversion.Transaction.Environment.from(environment: nil)
+
+        XCTAssertNil(mapped)
+    }
+
+    // MARK: - OwnershipType
+
+    func testOwnershipTypeMapsPurchased() {
+        let mapped: Qonversion.Transaction.OwnershipType = Qonversion.Transaction.OwnershipType.from(ownershipType: StoreKit.Transaction.OwnershipType.purchased)
+
+        XCTAssertEqual(mapped, Qonversion.Transaction.OwnershipType.purchased)
+    }
+
+    func testOwnershipTypeMapsFamilyShared() {
+        let mapped: Qonversion.Transaction.OwnershipType = Qonversion.Transaction.OwnershipType.from(ownershipType: StoreKit.Transaction.OwnershipType.familyShared)
+
+        XCTAssertEqual(mapped, Qonversion.Transaction.OwnershipType.familyShared)
+    }
+
+    func testOwnershipTypeMapsUnknownValueToPurchased() {
+        let unknown = StoreKit.Transaction.OwnershipType(rawValue: "FUTURE_TYPE")
+
+        let mapped: Qonversion.Transaction.OwnershipType = Qonversion.Transaction.OwnershipType.from(ownershipType: unknown)
+
+        XCTAssertEqual(mapped, Qonversion.Transaction.OwnershipType.purchased)
+    }
+
+    func testOwnershipTypeMapsNilToPurchased() {
+        let mapped: Qonversion.Transaction.OwnershipType = Qonversion.Transaction.OwnershipType.from(ownershipType: nil)
+
+        XCTAssertEqual(mapped, Qonversion.Transaction.OwnershipType.purchased)
+    }
+
+    // MARK: - Reason
+
+    func testReasonMapsPurchase() throws {
+        guard #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) else {
+            throw XCTSkip("Transaction.Reason requires macOS 14")
+        }
+
+        let mapped: Qonversion.Transaction.Reason = Qonversion.Transaction.Reason.from(reason: StoreKit.Transaction.Reason.purchase)
+
+        XCTAssertEqual(mapped, Qonversion.Transaction.Reason.purchase)
+    }
+
+    func testReasonMapsRenewal() throws {
+        guard #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) else {
+            throw XCTSkip("Transaction.Reason requires macOS 14")
+        }
+
+        let mapped: Qonversion.Transaction.Reason = Qonversion.Transaction.Reason.from(reason: StoreKit.Transaction.Reason.renewal)
+
+        XCTAssertEqual(mapped, Qonversion.Transaction.Reason.renewal)
+    }
+
+    func testReasonMapsUnknownValueToPurchase() throws {
+        guard #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) else {
+            throw XCTSkip("Transaction.Reason requires macOS 14")
+        }
+        let unknown = StoreKit.Transaction.Reason(rawValue: "FUTURE_REASON")
+
+        let mapped: Qonversion.Transaction.Reason = Qonversion.Transaction.Reason.from(reason: unknown)
+
+        XCTAssertEqual(mapped, Qonversion.Transaction.Reason.purchase)
+    }
+
+    func testReasonMapsNilToPurchase() throws {
+        guard #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) else {
+            throw XCTSkip("Transaction.Reason requires macOS 14")
+        }
+
+        let mapped: Qonversion.Transaction.Reason = Qonversion.Transaction.Reason.from(reason: nil)
+
+        XCTAssertEqual(mapped, Qonversion.Transaction.Reason.purchase)
+    }
+
+    // MARK: - StoreKit raw spellings
+
+    func testStoreKitRawSpellingsDifferFromSwiftCaseNames() throws {
+        guard #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) else {
+            throw XCTSkip("Transaction.Reason requires macOS 14")
+        }
+
+        XCTAssertEqual(StoreKit.AppStore.Environment.production.rawValue, "Production")
+        XCTAssertEqual(StoreKit.AppStore.Environment.sandbox.rawValue, "Sandbox")
+        XCTAssertEqual(StoreKit.AppStore.Environment.xcode.rawValue, "Xcode")
+        XCTAssertEqual(StoreKit.Transaction.OwnershipType.purchased.rawValue, "PURCHASED")
+        XCTAssertEqual(StoreKit.Transaction.OwnershipType.familyShared.rawValue, "FAMILY_SHARED")
+        XCTAssertEqual(StoreKit.Transaction.Reason.purchase.rawValue, "PURCHASE")
+        XCTAssertEqual(StoreKit.Transaction.Reason.renewal.rawValue, "RENEWAL")
+    }
+}

--- a/Tests/QonversionUnitTests/UtilsTests.swift
+++ b/Tests/QonversionUnitTests/UtilsTests.swift
@@ -127,6 +127,49 @@ final class UtilsTests: XCTestCase {
         XCTAssertNil("ZZZ".toCurrencySymbol())
     }
 
+    func testToCurrencySymbolIsStableAcrossCalls() {
+        let codes: [String] = ["USD", "EUR", "GBP", "JPY", "VND", "ZZZ"]
+
+        let first: [String?] = codes.map { $0.toCurrencySymbol() }
+        let second: [String?] = codes.map { $0.toCurrencySymbol() }
+
+        XCTAssertEqual(first, second)
+    }
+
+    func testToCurrencySymbolMemoizesRepeatedLookups() {
+        // "ZZZ" matches no locale, so an unmemoized lookup walks every available
+        // identifier — roughly a thousand Locale allocations — on every call.
+        let iterations = 2000
+        _ = "ZZZ".toCurrencySymbol()
+
+        let start = Date()
+        for _ in 0..<iterations {
+            _ = "ZZZ".toCurrencySymbol()
+        }
+        let elapsed: TimeInterval = Date().timeIntervalSince(start)
+
+        XCTAssertLessThan(elapsed, 0.2, "\(iterations) repeated lookups took \(elapsed)s — the scan is not memoized")
+    }
+
+    func testToCurrencySymbolMemoizesConcurrentLookups() {
+        let codes: [String] = ["USD", "EUR", "GBP", "JPY", "VND", "ZZZ", "INR", "BRL"]
+        let expected: [String?] = codes.map { $0.toCurrencySymbol() }
+        let results = NSMutableArray()
+        let resultsLock = NSLock()
+
+        DispatchQueue.concurrentPerform(iterations: 64) { iteration in
+            let resolved: [String?] = codes.map { $0.toCurrencySymbol() }
+            resultsLock.lock()
+            results.add(resolved)
+            resultsLock.unlock()
+        }
+
+        XCTAssertEqual(results.count, 64)
+        for element in results {
+            XCTAssertEqual(element as? [String?], expected)
+        }
+    }
+
     // MARK: - Locale.Currency.currencySymbol()
 
     func testLocaleCurrencySymbolMatchesStringHelper() throws {


### PR DESCRIPTION
…visionOS vendorId

Transaction.environment, .ownershipType and .reason were built by feeding StoreKit raw values into Qonversion enums. The raw spellings differ ("Production", "FAMILY_SHARED", "RENEWAL" vs. the lowercase case names), so environment was always nil, family-shared purchases read as purchased and every renewal reported as a purchase. Each mapping now switches over the StoreKit value, mirroring Offer.OfferType.from(transaction:), keeping the previous fallback for unknown values.

Currency symbol derivation scanned all ~1062 available locale identifiers on every call, once per mapped transaction. StoreKit exposes no symbol and no locale on Transaction (only currency/currencyCode), so the scan stays but its answers, misses included, are memoized per currency code — mirroring the NoCodes target.

vendorId() branched on iOS/watchOS/macOS only, leaving tvOS and visionOS — both declared in Package.swift — without a vendor identifier. Both platforms have UIDevice.identifierForVendor, so they now share the iOS branch.