### PR TITLE
fix: unify the observed-transaction funnel and stop losing latched re…

### DIFF
--- a/Sources/Managers/PurchasesManager/PurchasesManager.swift
+++ b/Sources/Managers/PurchasesManager/PurchasesManager.swift
@@ -104,7 +104,9 @@ final class PurchasesManager: PurchasesManagerInterface, @unchecked Sendable {
     /// The entitlements-only projection of the deferred purchases: one
     /// subscription of its own, so both streams stay independent.
     func entitlementsUpdates() -> AsyncStream<[String: Qonversion.Entitlement]> {
-        return AsyncStream { continuation in
+        // The same bound as the subscription it wraps: a host that stops
+        // reading must not turn the projection into an unbounded queue.
+        return AsyncStream(bufferingPolicy: .bufferingNewest(AsyncMulticast<Qonversion.DeferredPurchase>.subscriberBufferSize)) { continuation in
             // Subscribing here does not consume what deferredPurchases() is
             // owed: AsyncMulticast replays its backlog to every subscriber.
             let purchases: AsyncStream<Qonversion.DeferredPurchase> = self.deferredPurchasesMulticast.stream()
@@ -487,10 +489,6 @@ final class PurchasesManager: PurchasesManagerInterface, @unchecked Sendable {
     }
 
     func processUnfinishedTransactions() async {
-        // Both modes re-report; only subscription management may FINISH
-        // afterwards — in Analytics mode the host app owns the lifecycle.
-        let finishAfterReport: Bool = launchModeProvider.launchMode == .subscriptionManagement
-
         let transactions: [Qonversion.Transaction] = await storeKitFacade.unfinishedTransactions()
         guard !transactions.isEmpty else { return }
 
@@ -504,22 +502,71 @@ final class PurchasesManager: PurchasesManagerInterface, @unchecked Sendable {
         }
 
         for transaction in transactions {
-            if let id: String = transaction.id {
-                guard reportsGate.tryTake(id) else { continue }
-            }
+            await processObservedTransaction(transaction, userId: userId, trigger: .initialization)
+        }
+    }
+
+    /// The single funnel for transactions the SDK did not purchase itself: the
+    /// launch sweep and the updates listener race for the same deliveries, so
+    /// whichever claims one produces the WHOLE outcome — report, finish per
+    /// launch mode, one deferred purchase. A nil `userId` makes the funnel pass
+    /// the user gate itself, and only once it owns the transaction.
+    private func processObservedTransaction(_ transaction: Qonversion.Transaction, userId: String?, trigger: RequestTrigger) async {
+        // A purchase() call owns this product's lifecycle. Step aside BEFORE
+        // reporting or finishing: a skipped transaction must stay unfinished so
+        // the store re-delivers it.
+        guard !isPurchasing(transaction.productId) else { return }
+
+        // Transactions without a store id (degraded SK1 mapping) cannot be
+        // deduplicated and are reported unconditionally.
+        if let id: String = transaction.id {
+            guard reportsGate.tryTake(id) else { return }
+        }
+
+        let reportUserId: String
+        if let userId {
+            reportUserId = userId
+        } else {
             do {
-                try await purchasesService.send(transaction, userId: userId, options: reportOptions(for: transaction), trigger: .initialization)
-                purchaseAssociationsStorage.remove(for: transaction.productId)
-                if finishAfterReport {
-                    await storeKitFacade.finish(transaction)
-                }
+                _ = try await userManager.obtainUser()
+                reportUserId = userIdProvider.getUserId()
             } catch {
                 if let id: String = transaction.id {
                     reportsGate.release(id)
                 }
-                logger.error("Failed to re-report an unfinished transaction: " + error.message)
+                logger.error("Skipping an observed transaction: no backend user: " + error.message)
+                return
             }
         }
+
+        var reportFailed = false
+        do {
+            try await purchasesService.send(transaction, userId: reportUserId, options: reportOptions(for: transaction), trigger: trigger)
+            purchaseAssociationsStorage.remove(for: transaction.productId)
+        } catch {
+            if let id: String = transaction.id {
+                reportsGate.release(id)
+            }
+            logger.error("Failed to report an observed transaction: " + error.message)
+            // An unreachable backend must not swallow the update; a rejected
+            // report stays silent.
+            guard error.allowsLocalEntitlementsFallback else { return }
+
+            reportFailed = true
+        }
+
+        // Only a reported transaction may be finished, and only when the SDK
+        // owns the lifecycle — in Analytics mode the host app does.
+        if !reportFailed && launchModeProvider.launchMode == .subscriptionManagement {
+            await storeKitFacade.finish(transaction)
+        }
+
+        // Gates what the host sees, not the report: a relaunch re-delivers
+        // every unfinished transaction, and the host must hear it once.
+        if let id: String = transaction.id, !markSurfacedIfNew(id) { return }
+
+        let deferredPurchase: Qonversion.DeferredPurchase = await self.deferredPurchase(for: transaction, reportFailed: reportFailed)
+        deferredPurchasesMulticast.yield(deferredPurchase)
     }
 }
 
@@ -565,47 +612,7 @@ extension PurchasesManager: StoreKitFacadeDelegate {
         Task { [weak self] in
             guard let self else { return }
 
-            // A purchase() call owns this product's lifecycle. Step aside
-            // BEFORE reporting or finishing: a skipped transaction must stay
-            // unfinished so the store re-delivers it.
-            guard !self.isPurchasing(transaction.productId) else { return }
-
-            // Transactions without a store id (degraded SK1 mapping) cannot be
-            // deduplicated and are reported unconditionally.
-            if let id: String = transaction.id {
-                guard self.reportsGate.tryTake(id) else { return }
-            }
-
-            var reportFailed = false
-            do {
-                _ = try await self.userManager.obtainUser()
-                let userId: String = self.userIdProvider.getUserId()
-                try await self.purchasesService.send(transaction, userId: userId, options: self.reportOptions(for: transaction), trigger: .purchase)
-                self.purchaseAssociationsStorage.remove(for: transaction.productId)
-            } catch {
-                if let id: String = transaction.id {
-                    self.reportsGate.release(id)
-                }
-                self.logger.error("Failed to report an observed transaction: " + error.message)
-                // An unreachable backend must not swallow the update; a
-                // rejected report stays silent.
-                guard error.allowsLocalEntitlementsFallback else { return }
-
-                reportFailed = true
-            }
-
-            // Only a reported transaction may be finished, and only when the
-            // SDK owns the lifecycle.
-            if !reportFailed && self.launchModeProvider.launchMode == .subscriptionManagement {
-                await self.storeKitFacade.finish(transaction)
-            }
-
-            // Gates what the host sees, not the report: a relaunch re-delivers
-            // every unfinished transaction, and the host must hear it once.
-            if let id: String = transaction.id, !self.markSurfacedIfNew(id) { return }
-
-            let deferredPurchase: Qonversion.DeferredPurchase = await self.deferredPurchase(for: transaction, reportFailed: reportFailed)
-            self.deferredPurchasesMulticast.yield(deferredPurchase)
+            await self.processObservedTransaction(transaction, userId: nil, trigger: .purchase)
         }
     }
 

--- a/Sources/NetworkLayer/RequestProcessor/RequestProcessor.swift
+++ b/Sources/NetworkLayer/RequestProcessor/RequestProcessor.swift
@@ -240,13 +240,17 @@ class RequestProcessor: RequestProcessorInterface, @unchecked Sendable {
         }
 
         guard error == nil else {
-            if let error, error.type == .critical {
+            let latchesCriticalError: Bool = error?.type == .critical
+            if let error, latchesCriticalError {
                 criticalErrorLatch.latch(error)
             }
 
             // The backend did not process the request (5xx/429) — persist
             // retriable ones for the offline replay, like transport failures.
-            if Self.isRetriableStatusCode(responseCode) && retriableRequestKinds.contains(request.kind) {
+            // A revoked key (401/402/403) is queued too: every request AFTER
+            // the latch is, and the one that tripped it carries data the store
+            // already charged for.
+            if (Self.isRetriableStatusCode(responseCode) || latchesCriticalError) && retriableRequestKinds.contains(request.kind) {
                 queueForReplay(request, as: urlRequest, trigger: trigger, attempt: attemptsMade.total, ifGenerationIs: generation)
             }
 
@@ -263,7 +267,10 @@ class RequestProcessor: RequestProcessorInterface, @unchecked Sendable {
         // transaction (it may sit under the previous uid) — replaying it on
         // the next launch would double-report the purchase.
         if request.kind == .createPurchase, let transactionId: String = request.replayTransactionId {
-            requestsStorage.removeAll { stored in
+            // Only within the generation this request was sent for: after a
+            // user switch the queued copy of the same transaction belongs to
+            // the NEW user and this delivery says nothing about it.
+            requestsStorage.removeAll(ifGenerationIs: generation) { stored in
                 if let storedTransactionId: String = stored.transactionId {
                     return storedTransactionId == transactionId
                 }
@@ -288,10 +295,11 @@ class RequestProcessor: RequestProcessorInterface, @unchecked Sendable {
 
     // MARK: - Transport retries
 
-    /// How many times a connection-class failure is retried inside the call
-    /// that produced it. Matches the ObjC client, which resent up to three
-    /// times (QNAPIClient.m:523-551, `tryCount < 3`) before giving up and
-    /// handing the request to the offline queue.
+    /// How many times a connection-class failure is resent inside the call that
+    /// produced it — four sends in total, the first one included. Matches the
+    /// ObjC client, which resent up to three times (QNAPIClient.m:523-551,
+    /// `tryCount < 3`) before giving up and handing the request to the offline
+    /// queue.
     static let maxTransportRetries: Int = 3
 
     /// The in-session backoff is capped: the caller is usually blocked on this

--- a/Sources/NetworkLayer/RequestsStorage/RequestsStorage.swift
+++ b/Sources/NetworkLayer/RequestsStorage/RequestsStorage.swift
@@ -55,9 +55,11 @@ class RequestsStorage: RequestsStorageInterface, @unchecked Sendable {
         persist(requests)
     }
 
-    func removeAll(where shouldRemove: @Sendable (StoredRequest) -> Bool) {
+    func removeAll(ifGenerationIs generation: Int, where shouldRemove: @Sendable (StoredRequest) -> Bool) {
         lock.lock()
         defer { lock.unlock() }
+
+        guard _cleanGeneration == generation else { return }
 
         var requests: [StoredRequest] = fetchStoredRequests()
         requests.removeAll(where: shouldRemove)

--- a/Sources/NetworkLayer/RequestsStorage/RequestsStorageInterface.swift
+++ b/Sources/NetworkLayer/RequestsStorage/RequestsStorageInterface.swift
@@ -23,7 +23,11 @@ protocol RequestsStorageInterface: Sendable {
     /// between must not be undone by the replacement.
     func replace(_ request: StoredRequest, with replacement: StoredRequest, ifGenerationIs generation: Int)
 
-    func removeAll(where shouldRemove: @Sendable (StoredRequest) -> Bool)
+    /// Drops every queued request the predicate matches, and only while the
+    /// queue still belongs to the same user: entries appended after a clean()
+    /// (user switch) are the new user's and no longer superseded by whatever
+    /// the previous one delivered.
+    func removeAll(ifGenerationIs generation: Int, where shouldRemove: @Sendable (StoredRequest) -> Bool)
 
     func fetchRequests() -> [StoredRequest]
 
@@ -42,5 +46,9 @@ extension RequestsStorageInterface {
     /// user switch could have happened behind their back).
     func append(_ request: StoredRequest) {
         append(request, ifGenerationIs: cleanGeneration)
+    }
+
+    func removeAll(where shouldRemove: @Sendable (StoredRequest) -> Bool) {
+        removeAll(ifGenerationIs: cleanGeneration, where: shouldRemove)
     }
 }

--- a/Tests/QonversionUnitTests/Mocks.swift
+++ b/Tests/QonversionUnitTests/Mocks.swift
@@ -234,7 +234,9 @@ final class MockRequestsStorage: RequestsStorageInterface {
         storedRequests[index] = replacement
     }
 
-    func removeAll(where shouldRemove: @Sendable (StoredRequest) -> Bool) {
+    func removeAll(ifGenerationIs generation: Int, where shouldRemove: @Sendable (StoredRequest) -> Bool) {
+        guard cleanGeneration == generation else { return }
+
         storedRequests.removeAll(where: shouldRemove)
     }
 

--- a/Tests/QonversionUnitTests/PurchasesManagerTests.swift
+++ b/Tests/QonversionUnitTests/PurchasesManagerTests.swift
@@ -924,6 +924,30 @@ final class PurchasesManagerTests: XCTestCase {
         XCTAssertEqual(received.first?.keys.sorted(), ["premium"])
     }
 
+    func testTheEntitlementsProjectionIsBoundedLikeItsSubscription() async {
+        // A host that builds the projection and stops reading it must not turn
+        // it into an unbounded queue: the subscription it wraps keeps only the
+        // newest values, and the projection must keep exactly as many.
+        manager = makeManager(launchMode: .analytics)
+        let bufferSize: Int = AsyncMulticast<Qonversion.DeferredPurchase>.subscriberBufferSize
+        let emissions: Int = bufferSize + 5
+        // Subscribed here, iterated only at the end.
+        let projection: AsyncStream<[String: Qonversion.Entitlement]> = manager.entitlementsUpdates()
+        let purchases = StreamCollector(manager.deferredPurchases())
+
+        for index in 0..<emissions {
+            entitlementsManager.entitlementsResult = ["e\(index)": entitlement(id: "e\(index)")]
+            manager.transactionUpdated(makeTransaction(id: "buffered-\(index)"))
+            await waitUntil { await purchases.received.count >= index + 1 }
+        }
+
+        let collector = StreamCollector(projection)
+        await waitUntil { await collector.received.last?.keys.first == "e\(emissions - 1)" }
+
+        let received: [[String: Qonversion.Entitlement]] = await collector.received
+        XCTAssertEqual(received.count, bufferSize, "the projection must drop the oldest values, not queue them all")
+    }
+
     // MARK: - promotional offer signature
 
     func testPromotionalOfferPassesGateAndForwardsToService() async throws {
@@ -1358,6 +1382,109 @@ final class PurchasesManagerTests: XCTestCase {
         await manager.processUnfinishedTransactions()
 
         XCTAssertEqual(service.sentTransactions.map(\.transaction.id), ["t1"])
+    }
+
+    // MARK: - the host hears the transaction whichever path claims it
+
+    func testTheLaunchSweepSurfacesTheTransactionToTheHost() async {
+        // The sweep and the listener race for the same transaction at launch.
+        // Whichever wins, the host must hear the purchase — the sweep also
+        // FINISHES it in subscription management mode, so a transaction it
+        // claimed silently would never come back through the listener.
+        manager = makeManager(launchMode: .subscriptionManagement)
+        entitlementsManager.entitlementsResult = ["premium": entitlement(id: "premium")]
+        facade.unfinishedTransactionsResult = [makeTransaction(id: "swept-1")]
+        let collector = StreamCollector(manager.deferredPurchases())
+
+        await manager.processUnfinishedTransactions()
+
+        await waitUntil { await !collector.received.isEmpty }
+        let received: [Qonversion.DeferredPurchase] = await collector.received
+        XCTAssertEqual(received.map(\.transaction.id), ["swept-1"])
+        XCTAssertEqual(received.first?.entitlements.keys.sorted(), ["premium"])
+        XCTAssertEqual(service.sentTransactions.map(\.transaction.id), ["swept-1"])
+        XCTAssertEqual(facade.finishedTransactions.map(\.id), ["swept-1"])
+    }
+
+    func testATransactionSurfacedByTheSweepIsNotEmittedAgainOnTheNextLaunch() async {
+        // Analytics mode never finishes anything, so the store re-delivers the
+        // same transaction on every cold start.
+        manager = makeManager(launchMode: .analytics)
+        entitlementsManager.entitlementsResult = ["premium": entitlement(id: "premium")]
+        facade.unfinishedTransactionsResult = [makeTransaction(id: "swept-2")]
+        let collector = StreamCollector(manager.deferredPurchases())
+
+        await manager.processUnfinishedTransactions()
+        await waitUntil { await !collector.received.isEmpty }
+
+        // "Next launch": a fresh manager over the same storage, so only the
+        // persisted surfaced-transactions set can stop the second emission.
+        let relaunched: PurchasesManager = makeManager(launchMode: .analytics)
+        let relaunchedCollector = StreamCollector(relaunched.deferredPurchases())
+        relaunched.transactionUpdated(makeTransaction(id: "swept-2"))
+        await waitUntil { self.service.sentTransactions.count >= 2 }
+
+        // A transaction the listener DOES surface, delivered afterwards: its
+        // emission is the marker that the previous one produced none.
+        relaunched.transactionUpdated(makeTransaction(id: "fresh-2", productId: "com.app.lite"))
+        await waitUntil { await !relaunchedCollector.received.isEmpty }
+
+        let receivedAfterRelaunch: [Qonversion.DeferredPurchase] = await relaunchedCollector.received
+        XCTAssertEqual(receivedAfterRelaunch.map(\.transaction.id), ["fresh-2"],
+                       "a purchase the sweep already surfaced must not come back on the next launch")
+    }
+
+    func testTheListenerWinningTheGateKeepsTheSweepFromRepeatingTheOutcome() async {
+        manager = makeManager(launchMode: .subscriptionManagement)
+        entitlementsManager.entitlementsResult = ["premium": entitlement(id: "premium")]
+        let transaction: Qonversion.Transaction = makeTransaction(id: "race-1")
+        facade.unfinishedTransactionsResult = [transaction]
+        let collector = StreamCollector(manager.deferredPurchases())
+
+        manager.transactionUpdated(transaction)
+        await waitUntil { self.service.sentTransactions.count >= 1 }
+
+        await manager.processUnfinishedTransactions()
+        await waitUntil { await !collector.received.isEmpty }
+
+        let received: [Qonversion.DeferredPurchase] = await collector.received
+        XCTAssertEqual(received.map(\.transaction.id), ["race-1"])
+        XCTAssertEqual(service.sentTransactions.map(\.transaction.id), ["race-1"])
+        XCTAssertEqual(facade.finishedTransactions.map(\.id), ["race-1"])
+    }
+
+    func testTheSweepAndTheListenerRacingOneTransactionProduceOneOutcome() async {
+        // The sweep is already inside its report when the listener picks the
+        // same transaction up: exactly one report, one finish, one emission.
+        manager = makeManager(launchMode: .subscriptionManagement)
+        entitlementsManager.entitlementsResult = ["premium": entitlement(id: "premium")]
+        let transaction: Qonversion.Transaction = makeTransaction(id: "race-2")
+        facade.unfinishedTransactionsResult = [transaction]
+        let collector = StreamCollector(manager.deferredPurchases())
+        let sweepIsReporting = PurchasesAsyncGate()
+        let listenerHasArrived = PurchasesAsyncGate()
+        service.onSend = {
+            await sweepIsReporting.open()
+            await listenerHasArrived.wait()
+        }
+
+        let sweep = Task { await self.manager.processUnfinishedTransactions() }
+        await sweepIsReporting.wait()
+        manager.transactionUpdated(transaction)
+        await listenerHasArrived.open()
+        await sweep.value
+
+        await waitUntil { await !collector.received.isEmpty }
+        // The listener may still be running: a transaction it does surface,
+        // delivered now, marks the point where its earlier task is done.
+        service.onSend = nil
+        manager.transactionUpdated(makeTransaction(id: "marker-2", productId: "com.app.lite"))
+        await waitUntil { await collector.received.count >= 2 }
+
+        let received: [Qonversion.DeferredPurchase] = await collector.received
+        XCTAssertEqual(received.map(\.transaction.id), ["race-2", "marker-2"])
+        XCTAssertEqual(service.sentTransactions.map(\.transaction.id), ["race-2", "marker-2"])
+        XCTAssertEqual(facade.finishedTransactions.map(\.id), ["race-2", "marker-2"])
     }
 }
 

--- a/Tests/QonversionUnitTests/RequestProcessorTests.swift
+++ b/Tests/QonversionUnitTests/RequestProcessorTests.swift
@@ -935,6 +935,87 @@ final class RequestProcessorTests: XCTestCase {
         XCTAssertTrue(networkProvider.sentRequests.isEmpty)
     }
 
+    func testTheRequestThatTripsTheLatchIsQueuedForReplay() async {
+        // The FIRST request answered with a revoked key is the one that latches
+        // it — and it carries data the store already charged for. Every request
+        // after it is queued; dropping this one loses it permanently.
+        networkProvider.response = makeHTTPResponse(statusCode: 401)
+        errorHandler.errorToReturn = QonversionError(type: .critical, message: "unauthorized")
+        let processor = makeProcessor(retriableRequestKinds: [.createPurchase])
+        let purchaseBody: RequestBodyDict = ["store_data": ["transaction_id": "tx-1"] as RequestBodyDict]
+
+        do {
+            _ = try await processor.process(request: .createPurchase(userId: "u", body: purchaseBody), responseType: EmptyApiResponse.self)
+            XCTFail("Expected the critical error")
+        } catch {
+            XCTAssertEqual((error as? QonversionError)?.type, .critical)
+        }
+
+        XCTAssertNotNil(processor.criticalError, "401 latches the revoked key")
+        let stored: [StoredRequest] = requestsStorage.fetchRequests()
+        XCTAssertEqual(stored.count, 1, "the purchase that tripped the latch must be deferred, not lost")
+        XCTAssertEqual(stored.first?.transactionId, "tx-1")
+    }
+
+    func testTheRequestThatTripsTheLatchIsNotQueuedWhenItCarriesNoData() async {
+        networkProvider.response = makeHTTPResponse(statusCode: 401)
+        errorHandler.errorToReturn = QonversionError(type: .critical, message: "unauthorized")
+        let processor = makeProcessor(retriableRequestKinds: [.createPurchase])
+
+        do {
+            _ = try await processor.process(request: .getUser(id: "u"), responseType: ProcessorTestPayload.self)
+            XCTFail("Expected the critical error")
+        } catch {
+            XCTAssertEqual((error as? QonversionError)?.type, .critical)
+        }
+
+        XCTAssertNotNil(processor.criticalError)
+        XCTAssertTrue(requestsStorage.fetchRequests().isEmpty, "a read carries nothing to deliver")
+    }
+
+    func testAPermanentlyRejectedPurchaseIsNotQueued() async {
+        networkProvider.response = makeHTTPResponse(statusCode: 400)
+        errorHandler.errorToReturn = QonversionError(type: .invalidRequest, message: "bad request")
+        let processor = makeProcessor(retriableRequestKinds: [.createPurchase])
+        let purchaseBody: RequestBodyDict = ["store_data": ["transaction_id": "tx-1"] as RequestBodyDict]
+
+        _ = try? await processor.process(request: .createPurchase(userId: "u", body: purchaseBody), responseType: EmptyApiResponse.self)
+
+        XCTAssertNil(processor.criticalError)
+        XCTAssertTrue(requestsStorage.fetchRequests().isEmpty, "a rejected request would be rejected again on every replay")
+    }
+
+    func testADeliveredReportDoesNotEvictAQueuedEntryOfTheNextUser() async {
+        // The report left for the PREVIOUS uid; the user switch cleaned the
+        // queue while it was in flight, and the new user queued the same
+        // transaction of its own. The delivery must supersede its own copy,
+        // never the entry that belongs to the queue's new generation.
+        let gate = ProcessorAsyncGate()
+        networkProvider.onSend = { await gate.wait() }
+        networkProvider.response = makeHTTPResponse(statusCode: 200)
+        networkProvider.responseData = Data("{}".utf8)
+        let processor = makeProcessor(retriableRequestKinds: [.createPurchase])
+        let body: RequestBodyDict = ["store_data": ["transaction_id": "tx42"] as RequestBodyDict]
+
+        let sending = Task {
+            _ = try? await processor.process(request: .createPurchase(userId: "OLD_UID", body: body), responseType: EmptyApiResponse.self)
+        }
+        await waitUntil { self.networkProvider.sentRequests.count == 1 }
+        requestsStorage.clean()
+        requestsStorage.append(StoredRequest(
+            url: "https://api2.qonversion.io/v4/users/NEW_UID/purchases",
+            method: "POST",
+            body: nil,
+            dedupKey: "createPurchase-NEW_UID-tx42",
+            transactionId: "tx42"
+        ))
+        await gate.open()
+        _ = await sending.value
+
+        XCTAssertEqual(requestsStorage.fetchRequests().count, 1,
+                       "the new user's queued purchase must survive the previous user's delivery")
+    }
+
     func testTheFirstCriticalErrorWins() async {
         let latch = CriticalErrorLatch()
         let first = QonversionError(type: .critical, message: "first")


### PR DESCRIPTION
…ports

R5A-1: the launch sweep and the Transaction.updates listener contended for the same reports gate, but only the listener surfaced the transaction to the host — a sweep that won the gate reported and (in subscription management mode) finished it silently, so the DeferredPurchase was lost forever. Both paths now run through one funnel: step aside for an in-flight purchase, claim the gate, report, finish per launch mode, mark surfaced and emit exactly one deferred purchase.

R5A-3: the request that TRIPS the critical latch (401/402/403) was dropped while every request after it was queued — the first ASA attribution or purchase report after a key revocation was lost permanently. A retriable kind is now queued for replay before the critical error is thrown; other 4xx stay unqueued.

R5A-6: the delivered-purchase dedup removal now carries the same clean generation guard as append and replace, so a user switch landing while the previous user's report is in flight cannot evict the new user's queued entry.

R5A-11: entitlementsUpdates() bounds its outer stream with the same policy as the subscription it wraps, instead of buffering without bound.

R5A-12: the transport retry doc now states the real send count (four).