### PR TITLE
fix: bind property batches to their owner and gate the crash sender

### DIFF
--- a/Sources/Assemblies/QonversionAssembly.swift
+++ b/Sources/Assemblies/QonversionAssembly.swift
@@ -109,6 +109,7 @@ final class QonversionAssembly {
             storage: crashReportsStorage(),
             requestProcessor: servicesAssembly.requestProcessor(),
             userIdProvider: miscAssembly.internalConfig,
+            userManager: userManager(),
             platform: deviceInfoCollector.headerDeviceInfo().osName
         )
 

--- a/Sources/Managers/UserProperties/UserPropertiesManager.swift
+++ b/Sources/Managers/UserProperties/UserPropertiesManager.swift
@@ -20,6 +20,9 @@ fileprivate enum Constants: Int {
     // After this many failed attempts the batch stays in the storage but the
     // scheduling stops; the next setProperty call re-triggers sending.
     case sendPropertiesMaxRetries = 10
+    // A forced send drains what was pending when it was called; the cap is what
+    // bounds it when the storage keeps handing the same property back.
+    case forceSendMaxRounds = 3
 }
 
 // @unchecked: mutable state is guarded by stateLock; deps are thread-safe.
@@ -225,15 +228,17 @@ final class UserPropertiesManager : UserPropertiesManagerInterface, @unchecked S
             return
         }
 
-        // Only the batch pending on entry is owned by this call: chasing
-        // properties set while it runs could loop forever.
-        let ownedKeys: Set<String> = Set(propertiesStorage.all().map { $0.key })
-        while true {
+        // Only the exact properties pending on entry are owned by this call:
+        // a key alone is not enough, because a host rewriting its value on a
+        // timer would then keep the loop alive forever.
+        let ownedProperties: Set<Qonversion.UserProperty> = Set(propertiesStorage.all())
+        var round: Int = 0
+        while round < Constants.forceSendMaxRounds.rawValue {
             if let inFlight: Task<Bool, Never> = currentSendingTask() {
                 _ = await inFlight.value
             }
 
-            let remaining: [Qonversion.UserProperty] = propertiesStorage.all().filter { ownedKeys.contains($0.key) }
+            let remaining: [Qonversion.UserProperty] = propertiesStorage.all().filter { ownedProperties.contains($0) }
             guard !remaining.isEmpty else { return }
             guard let task: Task<Bool, Never> = startSendingIfIdle() else {
                 // Another sender took the slot between the two calls. Yield so
@@ -242,15 +247,26 @@ final class UserPropertiesManager : UserPropertiesManagerInterface, @unchecked S
                 continue
             }
 
+            round += 1
             let succeeded: Bool = await task.value
             guard succeeded else { return }
         }
+    }
+
+    /// Which sender a post belongs to. The scheduled sender still owns its
+    /// batch in the storage and owns the retry ladder; the user-switch handoff
+    /// owns neither — it took its copy out before the switch and everything
+    /// left behind belongs to the incoming user.
+    private enum BatchOwner {
+        case scheduledSender
+        case userSwitchHandoff
     }
 
     /// One batch round trip. Returns false when the batch did not reach the
     /// backend — the properties stay in the storage and a retry is scheduled.
     private func performSend() async -> Bool {
         let properties: [Qonversion.UserProperty] = propertiesStorage.all()
+        let userId: String = userIdProvider.getUserId()
 
         guard !properties.isEmpty else { return true }
 
@@ -263,14 +279,16 @@ final class UserPropertiesManager : UserPropertiesManagerInterface, @unchecked S
             return false
         }
 
-        // Read after obtaining the user: that may itself resolve an identity
-        // and move the uid.
-        return await postBatch(properties, userId: userIdProvider.getUserId(), schedulingRetries: true)
+        // The uid only moves through a switch, and a switch claims the pending
+        // batch in userWillChange first: a moved uid means the batch is theirs.
+        guard userIdProvider.getUserId() == userId else { return true }
+
+        return await postBatch(properties, userId: userId, owner: .scheduledSender)
     }
 
     /// The uid is a parameter, not a read of the provider: the user-switch
     /// flush may outlive the switch and must post under the queuing user.
-    private func postBatch(_ properties: [Qonversion.UserProperty], userId: String, schedulingRetries: Bool) async -> Bool {
+    private func postBatch(_ properties: [Qonversion.UserProperty], userId: String, owner: BatchOwner) async -> Bool {
         let items: RequestBodyArray = properties.map { ["key": $0.key, "value": $0.value] as RequestBodyDict }
         let body: RequestBodyDict = ["properties": items]
         let request = Request.sendProperties(userId: userId, body: body)
@@ -279,19 +297,21 @@ final class UserPropertiesManager : UserPropertiesManagerInterface, @unchecked S
             result?.propertyErrors.forEach({ propertyError in
                 logger.error("Failed to save property " + propertyError.key + ": " + propertyError.error)
             })
-            
+
+            guard owner == .scheduledSender else { return true }
+
             resetRetryState()
 
             propertiesStorage.clear(properties: properties)
 
             // Properties set while the batch was in flight.
-            if schedulingRetries && !propertiesStorage.all().isEmpty {
+            if !propertiesStorage.all().isEmpty {
                 scheduleSendingProperties(withDelay: Constants.sendPropertiesMinDelaySec.rawValue)
             }
 
             return true
         } catch {
-            if schedulingRetries {
+            if owner == .scheduledSender {
                 retrySendingProperties()
             }
             return false
@@ -340,7 +360,7 @@ extension UserPropertiesManager: UserChangedObserver {
 
             // No user gate on purpose: both call sites run after user creation.
             // One attempt on purpose: a retry ladder would outlive its relevance.
-            _ = await self.postBatch(outgoingBatch, userId: outgoingUserId, schedulingRetries: false)
+            _ = await self.postBatch(outgoingBatch, userId: outgoingUserId, owner: .userSwitchHandoff)
         }
     }
 

--- a/Sources/Other/CrashReporting/CrashReporter.swift
+++ b/Sources/Other/CrashReporting/CrashReporter.swift
@@ -11,8 +11,10 @@ import Foundation
 /// Mach handlers belong to the host app's own crash reporter, so real crashes
 /// (SIGSEGV, a Swift runtime trap) are not captured here.
 ///
-/// `POST v4/sdk-crashes` does not exist yet, so every failure path leaves the
-/// report queued and nothing ever reaches the host.
+/// `POST v4/sdk-crashes` does not exist yet: the send fails on every launch,
+/// and nothing about it ever reaches the host. A failure the backend answered
+/// about the report itself drops it, everything else keeps it queued —
+/// ``CrashReportsSender/outcome(for:)``.
 // @unchecked: the installed state is lock-guarded and the C handler captures nothing.
 final class CrashReporter: @unchecked Sendable {
 
@@ -84,12 +86,14 @@ struct CrashReportsSender {
     private let storage: CrashReportsStorage
     private let requestProcessor: RequestProcessorInterface
     private let userIdProvider: UserIdProvider
+    private let userManager: UserManagerInterface
     private let platform: String
 
-    init(storage: CrashReportsStorage, requestProcessor: RequestProcessorInterface, userIdProvider: UserIdProvider, platform: String) {
+    init(storage: CrashReportsStorage, requestProcessor: RequestProcessorInterface, userIdProvider: UserIdProvider, userManager: UserManagerInterface, platform: String) {
         self.storage = storage
         self.requestProcessor = requestProcessor
         self.userIdProvider = userIdProvider
+        self.userManager = userManager
         self.platform = platform
     }
 
@@ -101,6 +105,15 @@ struct CrashReportsSender {
     func sendStoredReports() async {
         let reports: [CrashReport] = storage.all()
         guard !reports.isEmpty else { return }
+
+        // A crash on the first launch is reported before the user exists: the
+        // uid would be one the backend has never seen, and the 4xx it answers
+        // drops the report.
+        do {
+            try await userManager.obtainUser()
+        } catch {
+            return
+        }
 
         let userId: String = userIdProvider.getUserId()
         for report in reports {

--- a/Tests/QonversionUnitTests/CrashReportingTests.swift
+++ b/Tests/QonversionUnitTests/CrashReportingTests.swift
@@ -299,6 +299,11 @@ final class CrashReporterTests: XCTestCase {
 
     private var localStorage: LocalStorage!
     private var storage: CrashReportsStorage!
+    private var userManager: MockUserManager!
+    private var gateCallsAtFirstRequest: Int = -1
+    /// The handler the process had before this suite touched it. `uninstall()`
+    /// only restores what `install()` found, which in these tests is a spy.
+    private var originalExceptionHandler: (@convention(c) (NSException) -> Void)?
 
     override func setUp() {
         super.setUp()
@@ -308,10 +313,16 @@ final class CrashReporterTests: XCTestCase {
         decoder.dateDecodingStrategy = .qonversionTolerant
         localStorage = LocalStorage(userDefaults: TestDefaults.makeIsolated(), encoder: encoder, decoder: decoder)
         storage = CrashReportsStorage(localStorage: localStorage)
+        userManager = MockUserManager()
+        userManager.user = try? JSONDecoder.qonversionTest.decode(Qonversion.User.self, from: Data(#"{"id": "QON_u", "created_at": "2023-11-14T22:13:20Z"}"#.utf8))
+        gateCallsAtFirstRequest = -1
+        originalExceptionHandler = NSGetUncaughtExceptionHandler()
     }
 
     override func tearDown() {
         CrashReporter.shared.uninstall()
+        NSSetUncaughtExceptionHandler(originalExceptionHandler)
+        userManager = nil
         storage = nil
         localStorage = nil
         super.tearDown()
@@ -389,6 +400,7 @@ final class CrashReporterTests: XCTestCase {
             storage: storage,
             requestProcessor: processor,
             userIdProvider: userIdProvider,
+            userManager: userManager,
             platform: "iOS"
         )
     }
@@ -413,6 +425,37 @@ final class CrashReporterTests: XCTestCase {
         XCTAssertEqual(type, .post)
         XCTAssertEqual(body["user_id"] as? String, "QON_u")
         XCTAssertTrue(storage.all().isEmpty, "a delivered report is not sent again")
+    }
+
+    func testTheUserGateIsPassedBeforeTheFirstReportIsSent() async {
+        // A crash on the very first launch is reported before createUser ever
+        // ran: the uid on the report is then one the backend has never seen,
+        // and the send is refused with a 4xx that drops the report for good.
+        storage.store(makeReport(id: "r1"))
+        storage.store(makeReport(id: "r2"))
+        let processor = MockRequestProcessor()
+        processor.results = [EmptyApiResponse(), EmptyApiResponse()]
+        processor.onProcess = { [weak self] in
+            guard let self, self.gateCallsAtFirstRequest < 0 else { return }
+            self.gateCallsAtFirstRequest = self.userManager.obtainUserCallsCount
+        }
+
+        await makeSender(processor: processor).sendStoredReports()
+
+        XCTAssertEqual(gateCallsAtFirstRequest, 1, "the backend user must exist before a report carries its uid")
+        XCTAssertEqual(userManager.obtainUserCallsCount, 1, "one gate pass per launch, not one per report")
+        XCTAssertEqual(processor.processedRequests.count, 2)
+    }
+
+    func testAFailingUserGateKeepsTheReportsForTheNextLaunch() async {
+        storage.store(makeReport(id: "r1"))
+        userManager.error = MockError.stubbed
+        let processor = MockRequestProcessor()
+
+        await makeSender(processor: processor).sendStoredReports()
+
+        XCTAssertTrue(processor.processedRequests.isEmpty, "no report may be sent under a uid the backend does not have")
+        XCTAssertEqual(storage.all().map { $0.id }, ["r1"], "a gate failure costs the report nothing")
     }
 
     func testAnEmptyQueueSendsNothing() async {

--- a/Tests/QonversionUnitTests/UserPropertiesManagerTests.swift
+++ b/Tests/QonversionUnitTests/UserPropertiesManagerTests.swift
@@ -31,6 +31,7 @@ final class UserPropertiesManagerTests: XCTestCase {
     private var propertiesStorage: UserPropertiesStorage!
     private var integrationsCollector: MockIntegrationsInfoCollector!
     private var userManager: MockUserManager!
+    private var config: InternalConfig!
     private var manager: UserPropertiesManager!
 
     override func setUp() {
@@ -40,11 +41,12 @@ final class UserPropertiesManagerTests: XCTestCase {
         userManager = MockUserManager()
         userManager.user = try? JSONDecoder.qonversionTest.decode(Qonversion.User.self, from: Data(#"{"id": "test-user-id", "created_at": "2023-11-14T22:13:20Z", "environment": "sandbox"}"#.utf8))
         integrationsCollector = MockIntegrationsInfoCollector()
+        config = InternalConfig(userId: "test-user-id")
         manager = UserPropertiesManager(
             requestProcessor: requestProcessor,
             propertiesStorage: propertiesStorage,
             delayCalculator: IncrementalDelayCalculator(),
-            userIdProvider: InternalConfig(userId: "test-user-id"),
+            userIdProvider: config,
             userManager: userManager,
             integrationsInfoCollector: integrationsCollector,
             logger: LoggerWrapper()
@@ -64,6 +66,7 @@ final class UserPropertiesManagerTests: XCTestCase {
         manager = nil
         propertiesStorage = nil
         requestProcessor = nil
+        config = nil
         super.tearDown()
     }
 
@@ -256,6 +259,110 @@ final class UserPropertiesManagerTests: XCTestCase {
         XCTAssertTrue(requestProcessor.processedRequests.isEmpty)
     }
 
+    func testForceSendReturnsWhenTheOwnedBatchIsRewrittenWithNewValues() async throws {
+        // A host that updates a property on a timer rewrites the same key with
+        // a new value on every round trip. Bounding the drain loop by KEYS lets
+        // that keep the loop alive forever — and NoCodes awaits this call
+        // before showing a screen, so the screen never appears.
+        propertiesStorage.save(Qonversion.UserProperty(key: "ticking", value: "0"))
+        requestProcessor.results = [SendUserPropertiesResult(savedProperties: [], propertyErrors: [])]
+        requestProcessor.onProcess = { [weak self] in
+            guard let self else { return }
+            let round: Int = self.requestProcessor.processedRequests.count
+            self.propertiesStorage.save(Qonversion.UserProperty(key: "ticking", value: "\(round)"))
+            self.requestProcessor.results.append(SendUserPropertiesResult(savedProperties: [], propertyErrors: []))
+        }
+
+        let done = DoneFlag()
+        Task { [manager] in
+            try? await manager?.sendProperties(force: true)
+            await done.markDone()
+        }
+        let finished: Bool = await waitForCompletion(of: done, timeout: 3)
+
+        requestProcessor.onProcess = nil
+        XCTAssertTrue(finished, "a rewritten property must not hold the forced send open forever")
+        XCTAssertLessThanOrEqual(requestProcessor.processedRequests.count, 3, "the forced send owns the batch that existed when it was called")
+    }
+
+    func testForceSendGivesUpAfterItsBoundedNumberOfRounds() async throws {
+        // The pathological shape the key+value snapshot alone cannot bound: the
+        // very same property is pending again after every successful post.
+        let property = Qonversion.UserProperty(key: "ticking", value: "always")
+        let storage = RepopulatingPropertiesStorage(property: property)
+        let processor = MockRequestProcessor()
+        processor.results = Array(repeating: SendUserPropertiesResult(savedProperties: [], propertyErrors: []), count: 10)
+        let boundedManager = UserPropertiesManager(
+            requestProcessor: processor,
+            propertiesStorage: storage,
+            delayCalculator: IncrementalDelayCalculator(),
+            userIdProvider: InternalConfig(userId: "test-user-id"),
+            userManager: userManager,
+            integrationsInfoCollector: integrationsCollector,
+            logger: LoggerWrapper()
+        )
+
+        let done = DoneFlag()
+        Task {
+            try? await boundedManager.sendProperties(force: true)
+            await done.markDone()
+        }
+        let finished: Bool = await waitForCompletion(of: done, timeout: 3)
+
+        XCTAssertTrue(finished, "the forced send must terminate whatever the storage keeps handing back")
+        XCTAssertEqual(processor.processedRequests.count, 3, "the drain loop is capped at three rounds")
+    }
+
+    // MARK: - the batch and the uid it belongs to
+
+    func testAUserSwitchDuringTheUserGateDoesNotPostTheBatchUnderTheNewUid() async throws {
+        // The batch is snapshotted before the gate and the uid was read after
+        // it: a switch landing in that window posts the previous user's
+        // properties under the uid the SDK just moved to.
+        let gatedUserManager = GatedUserManager()
+        gatedUserManager.user = userManager.user
+        let switchConfig = InternalConfig(userId: "old-uid")
+        let storage = UserPropertiesStorage()
+        let processor = MockRequestProcessor()
+        processor.results = [
+            SendUserPropertiesResult(savedProperties: [], propertyErrors: []),
+            SendUserPropertiesResult(savedProperties: [], propertyErrors: []),
+        ]
+        let switchingManager = UserPropertiesManager(
+            requestProcessor: processor,
+            propertiesStorage: storage,
+            delayCalculator: IncrementalDelayCalculator(),
+            userIdProvider: switchConfig,
+            userManager: gatedUserManager,
+            integrationsInfoCollector: integrationsCollector,
+            logger: LoggerWrapper()
+        )
+        storage.save(Qonversion.UserProperty(key: "old_user_key", value: "1"))
+
+        let sending = Task { try? await switchingManager.sendProperties() }
+        await waitUntil { gatedUserManager.obtainUserCalls == 1 }
+        await switchingManager.userWillChange()
+        switchConfig.userId = "new-uid"
+        switchingManager.userDidChange()
+        await gatedUserManager.openGate()
+        _ = await sending.value
+        await pollUntil { !self.sentPropertyUserIds(processor).isEmpty }
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        XCTAssertEqual(
+            sentPropertyUserIds(processor),
+            ["old-uid"],
+            "the batch leaves under the uid that queued it, and only once — the handoff owns it after the switch"
+        )
+    }
+
+    private func sentPropertyUserIds(_ processor: MockRequestProcessor) -> [String] {
+        return processor.processedRequests.compactMap { request in
+            guard case let .sendProperties(userId, _, _, _) = request else { return nil }
+            return userId
+        }
+    }
+
     func testForceSendPropertiesStopsAfterAFailedSend() async throws {
         propertiesStorage.save(Qonversion.UserProperty(key: "first", value: "1"))
         requestProcessor.error = MockError.stubbed
@@ -416,6 +523,87 @@ private final class PropertiesAsyncGate: @unchecked Sendable {
     private let storage = PropertiesGateStorage()
     func open() async { await storage.open() }
     func wait() async { await storage.wait() }
+}
+
+/// A user gate that suspends until the test opens it, so a test can act while
+/// a send is parked inside `obtainUser`.
+private final class GatedUserManager: UserManagerInterface, @unchecked Sendable {
+
+    var user: Qonversion.User?
+
+    private let gate = PropertiesAsyncGate()
+    private let callsLock = NSLock()
+    private var calls: Int = 0
+
+    var obtainUserCalls: Int {
+        callsLock.lock()
+        defer { callsLock.unlock() }
+        return calls
+    }
+
+    func openGate() async {
+        await gate.open()
+    }
+
+    private func recordCall() {
+        callsLock.lock()
+        calls += 1
+        callsLock.unlock()
+    }
+
+    @discardableResult
+    func obtainUser() async throws -> Qonversion.User {
+        recordCall()
+
+        await gate.wait()
+        guard let user else { throw MockError.noStub }
+        return user
+    }
+
+    @discardableResult
+    func identify(_ externalId: String) async throws -> Qonversion.User {
+        throw MockError.noStub
+    }
+
+    func logout() async {}
+
+    func awaitUserStability() async throws {}
+
+    func switchToUser(with uid: String) async throws {}
+
+    func userInfo() async throws -> Qonversion.User {
+        throw MockError.noStub
+    }
+}
+
+/// Hands the same property back after every clear — what a host re-setting a
+/// property on a timer looks like to the manager.
+private final class RepopulatingPropertiesStorage: PropertiesStorage, @unchecked Sendable {
+
+    private let inner = UserPropertiesStorage()
+    private let property: Qonversion.UserProperty
+
+    init(property: Qonversion.UserProperty) {
+        self.property = property
+        inner.save(property)
+    }
+
+    func save(_ userProperty: Qonversion.UserProperty) {
+        inner.save(userProperty)
+    }
+
+    func clear(properties: [Qonversion.UserProperty]) {
+        inner.clear(properties: properties)
+        inner.save(property)
+    }
+
+    func clear() {
+        inner.clear()
+    }
+
+    func all() -> [Qonversion.UserProperty] {
+        return inner.all()
+    }
 }
 
 /// A one-shot "it finished" marker: lets a test bound an await that would
@@ -697,6 +885,40 @@ final class UserPropertiesUserSwitchTests: XCTestCase {
         XCTAssertLessThan(elapsed, 1, "the user switch must not wait for the properties post at all")
         XCTAssertEqual(graph.config.userId, newUid, "the identify must have switched the user")
         XCTAssertTrue(batchAfterSwitch.isEmpty, "the batch is handed over before the switch returns; the new user starts clean")
+    }
+
+    func testTheHandedOverPostDoesNotDeleteAnIdenticalPropertyOfTheNewUser() async throws {
+        // The handoff took its batch out of the storage before posting it, so
+        // anything the storage holds when the post lands belongs to the NEW
+        // user. Clearing by key+value there deletes the incoming user's own
+        // property whenever it happens to carry the same value — the ordinary
+        // "set the email, identify, set the email again" sequence.
+        let graph: Graph = try makeGraph(originalUid: oldUid)
+        _ = try await graph.userManager.obtainUser()
+        let handoffPost = PropertiesAsyncGate()
+        graph.processor.onProcess = { await handoffPost.wait() }
+        graph.processor.results = [
+            SendUserPropertiesResult(savedProperties: [], propertyErrors: []),
+            SendUserPropertiesResult(savedProperties: [], propertyErrors: []),
+        ]
+        let sharedProperty = Qonversion.UserProperty(key: "_q_email", value: "same@qonversion.io")
+        graph.propertiesManager.setCustomUserProperty(key: sharedProperty.key, value: sharedProperty.value)
+
+        _ = try await graph.userManager.identify("external-id")
+        XCTAssertEqual(graph.config.userId, newUid, "the identify must have switched the user")
+        graph.propertiesManager.setCustomUserProperty(key: sharedProperty.key, value: sharedProperty.value)
+        await handoffPost.open()
+        await pollUntil { graph.processor.results.count == 1 }
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        XCTAssertEqual(graph.propertiesStorage.all(), [sharedProperty], "the new user's property must survive the handed-over post")
+        graph.processor.onProcess = nil
+        try await graph.propertiesManager.sendProperties(force: true)
+        XCTAssertEqual(
+            sentPropertyUserIds(graph.processor),
+            [oldUid, newUid],
+            "each user's property leaves under its own uid"
+        )
     }
 
     func testTheHandedOverBatchIsDeliveredUnderTheOldUidAfterTheSwitch() async throws {


### PR DESCRIPTION
The user-switch handoff no longer clears the properties storage after its post: it took its batch out before the switch, so anything left belongs to the incoming user — an identical key+value pair re-set by that user was being deleted silently, and its retry ladder reset with it. postBatch now takes the owner instead of a scheduling flag, and both effects hang off it.

The scheduled sender binds the uid to the batch it snapshotted, before the user gate, and abandons the post when the uid moved across it: misattribution across a switch was prevented only by cooperative cancellation.

forceSendProperties owns the exact key+value pairs pending when it was called, and drains at most three rounds: bounding by keys alone let a host rewriting a property on a timer spin the loop forever — with NoCodes awaiting it before showing a screen.

CrashReportsSender passes the user gate before the first request, like every other sender: a crash on the first launch carried a uid the backend never saw, which the endpoint will answer with a 4xx that drops the report.