### PR TITLE
fix(storage): drop the previous project's cache when the api key changes

### DIFF
--- a/Qonversion.xcodeproj/project.pbxproj
+++ b/Qonversion.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		D300000000000000000000B1 /* JSONDecoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = D300000000000000000000A1 /* JSONDecoding.swift */; };
 		D400000000000000000000B1 /* LegacyPurchasesQueueMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D400000000000000000000A1 /* LegacyPurchasesQueueMigration.swift */; };
 		D500000000000000000000B1 /* LegacyEntitlementsMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D500000000000000000000A1 /* LegacyEntitlementsMigration.swift */; };
+		DA00000000000000000000B1 /* ApiKeyChangeCleaner.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA00000000000000000000A1 /* ApiKeyChangeCleaner.swift */; };
 		D600000000000000000000B1 /* CrashReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D600000000000000000000A1 /* CrashReport.swift */; };
 		D700000000000000000000B1 /* CrashReportFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D700000000000000000000A1 /* CrashReportFilter.swift */; };
 		D800000000000000000000B1 /* CrashReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D800000000000000000000A1 /* CrashReporter.swift */; };
@@ -285,6 +286,7 @@
 		D300000000000000000000A1 /* JSONDecoding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONDecoding.swift; sourceTree = "<group>"; };
 		D400000000000000000000A1 /* LegacyPurchasesQueueMigration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyPurchasesQueueMigration.swift; sourceTree = "<group>"; };
 		D500000000000000000000A1 /* LegacyEntitlementsMigration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyEntitlementsMigration.swift; sourceTree = "<group>"; };
+		DA00000000000000000000A1 /* ApiKeyChangeCleaner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApiKeyChangeCleaner.swift; sourceTree = "<group>"; };
 		D600000000000000000000A1 /* CrashReport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CrashReport.swift; sourceTree = "<group>"; };
 		D700000000000000000000A1 /* CrashReportFilter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CrashReportFilter.swift; sourceTree = "<group>"; };
 		D800000000000000000000A1 /* CrashReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CrashReporter.swift; sourceTree = "<group>"; };
@@ -750,6 +752,7 @@
 				70CD92CC2BC6E22B0039D65C /* LocalStorage.swift */,
 				D400000000000000000000A1 /* LegacyPurchasesQueueMigration.swift */,
 				D500000000000000000000A1 /* LegacyEntitlementsMigration.swift */,
+				DA00000000000000000000A1 /* ApiKeyChangeCleaner.swift */,
 				70CD92CD2BC6E22B0039D65C /* LocalStorageInterface.swift */,
 			);
 			path = LocalStorage;
@@ -1207,6 +1210,7 @@
 				D300000000000000000000B1 /* JSONDecoding.swift in Sources */,
 				D400000000000000000000B1 /* LegacyPurchasesQueueMigration.swift in Sources */,
 				D500000000000000000000B1 /* LegacyEntitlementsMigration.swift in Sources */,
+				DA00000000000000000000B1 /* ApiKeyChangeCleaner.swift in Sources */,
 				D600000000000000000000B1 /* CrashReport.swift in Sources */,
 				D700000000000000000000B1 /* CrashReportFilter.swift in Sources */,
 				D800000000000000000000B1 /* CrashReporter.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -162,8 +162,8 @@ for product in products {
     product.subscription?.promotionalOffers      // promo offers configured in App Store Connect
 
     // The raw store product, when you need the full StoreKit API
-    product.storeProduct       // StoreKit.Product (iOS 15+)
-    product.skProduct          // SKProduct (older systems)
+    product.storeProduct         // StoreKit.Product?, nil until the store answers
+    product.isStoreProductLinked // whether the store product is attached
 }
 ```
 
@@ -178,7 +178,7 @@ switch eligibility["pro_monthly"] {
 case .eligible:                 break // show the trial CTA
 case .ineligible:               break // trial already consumed — show the regular price
 case .nonIntroOrTrialProduct:   break // no intro offer configured
-case .unknown, .none:           break // store can't answer (e.g. iOS < 15)
+case .unknown, .none:           break // the store did not answer, or the id is not in your catalog
 }
 ```
 

--- a/Sources/Assemblies/MiscAssembly.swift
+++ b/Sources/Assemblies/MiscAssembly.swift
@@ -13,10 +13,6 @@ fileprivate enum IntConstants: UInt {
     case maxRequestsPerSecond = 5
 }
 
-fileprivate enum StringConstants: String {
-    case requestsStorageKey = "requests"
-}
-
 final class MiscAssembly {
     
     let apiKey: String
@@ -100,7 +96,7 @@ final class MiscAssembly {
 
         // Scoped by apiKey: the replayed requests are stamped with the CURRENT
         // Authorization, so another project's queue must never leak into it.
-        let storeKey: String = InternalConstants.storagePrefix.rawValue + StringConstants.requestsStorageKey.rawValue + "." + apiKey
+        let storeKey: String = SDKStorageKeys.requests(forApiKey: apiKey)
         let requestsStorage = RequestsStorage(userDefaults: userDefaults, storeKey: storeKey)
         requestsStorageInstance = requestsStorage
 

--- a/Sources/Assemblies/QonversionAssembly.swift
+++ b/Sources/Assemblies/QonversionAssembly.swift
@@ -52,6 +52,15 @@ final class QonversionAssembly {
         self.servicesAssembly = ServicesAssembly(apiKey: apiKey, miscAssembly: miscAssembly, baseURL: baseURL)
         self.miscAssembly.servicesAssembly = self.servicesAssembly
 
+        // Strictly before the uid seeding and the legacy migrations below: a
+        // project switch must not be able to resurrect data those steps would
+        // have just written.
+        let apiKeyChangeCleaner = ApiKeyChangeCleaner(
+            localStorage: miscAssembly.localStorage(),
+            logger: miscAssembly.loggerWrapper()
+        )
+        apiKeyChangeCleaner.run(apiKey: apiKey)
+
         // Resolves the anonymous user id (persisted or generated) into InternalConfig.
         _ = servicesAssembly.userService()
 

--- a/Sources/Other/LocalStorage/ApiKeyChangeCleaner.swift
+++ b/Sources/Other/LocalStorage/ApiKeyChangeCleaner.swift
@@ -1,0 +1,43 @@
+//
+//  ApiKeyChangeCleaner.swift
+//  Qonversion
+//
+
+import Foundation
+
+/// Drops the previous project's cached state when the SDK is initialized with
+/// a different project key.
+struct ApiKeyChangeCleaner {
+
+    private let localStorage: LocalStorageInterface
+    private let logger: LoggerWrapper
+
+    init(localStorage: LocalStorageInterface, logger: LoggerWrapper) {
+        self.localStorage = localStorage
+        self.logger = logger
+    }
+
+    @discardableResult
+    func run(apiKey: String) -> Bool {
+        // No stored key means a fresh install OR an install upgrading from the
+        // Objective-C SDK, which never wrote one — neither may be wiped.
+        guard let storedApiKey: String = localStorage.string(forKey: SDKStorageKeys.apiKey) else {
+            localStorage.set(string: apiKey, forKey: SDKStorageKeys.apiKey)
+            return false
+        }
+        guard storedApiKey != apiKey else { return false }
+
+        for key in SDKStorageKeys.unscoped {
+            localStorage.removeObject(forKey: key)
+        }
+        // Per-key by construction, so they could be left behind — but nothing
+        // will ever read the previous project's copies again.
+        localStorage.removeObject(forKey: SDKStorageKeys.products(forApiKey: storedApiKey))
+        localStorage.removeObject(forKey: SDKStorageKeys.requests(forApiKey: storedApiKey))
+
+        localStorage.set(string: apiKey, forKey: SDKStorageKeys.apiKey)
+        logger.info("The project key changed — the previous project's cached data was dropped.")
+
+        return true
+    }
+}

--- a/Sources/StorageConstants.swift
+++ b/Sources/StorageConstants.swift
@@ -9,3 +9,39 @@ enum StorageConstants: String {
     case prefix = "storage.qonversion.io."
     case unprocessedRequests
 }
+
+/// Every key this SDK persists into the host-configured UserDefaults suite.
+/// The owning types keep their own file-private copies of these strings —
+/// both sides have to move together, or a project switch silently stops
+/// dropping a cache.
+enum SDKStorageKeys {
+
+    // Written regardless of the project key, which is what makes a project
+    // switch undetectable without an explicit stored key to compare against.
+    static let unscoped: [String] = [
+        "qonversion.keys.entitlements",
+        "qonversion.keys.entitlementsTimestamp",
+        "qonversion.keys.entitlementsBackendTimestamp",
+        "qonversion.keys.productsPermissions",
+        "qonversion.keys.user",
+        "qonversion.keys.identityExternalId",
+        "qonversion.keys.userId",
+        "qonversion.keys.originalUserId",
+        "qonversion.keys.purchaseAssociations",
+        "qonversion.keys.surfacedTransactions",
+        "qonversion.keys.historicalDataSynced",
+        "qonversion.keys.crashReports",
+        InternalConstants.storagePrefix.rawValue + "device"
+    ]
+
+    // The project key this install last ran with.
+    static var apiKey: String { "qonversion.keys.apiKey" }
+
+    static func products(forApiKey apiKey: String) -> String {
+        return "qonversion.keys.products." + apiKey
+    }
+
+    static func requests(forApiKey apiKey: String) -> String {
+        return InternalConstants.storagePrefix.rawValue + "requests." + apiKey
+    }
+}

--- a/Tests/QonversionUnitTests/ApiKeyChangeCleanerTests.swift
+++ b/Tests/QonversionUnitTests/ApiKeyChangeCleanerTests.swift
@@ -1,0 +1,232 @@
+//
+//  ApiKeyChangeCleanerTests.swift
+//  QonversionUnitTests
+//
+//  A project (apiKey) change is otherwise undetectable: almost every cache
+//  key is unscoped, so the previous project's entitlements would be served to
+//  the new one and the device row would never be created.
+//
+
+import XCTest
+@testable import Qonversion
+
+final class ApiKeyChangeCleanerTests: XCTestCase {
+
+    private let entitlementsKey = "qonversion.keys.entitlements"
+    private let userIdKey = "qonversion.keys.userId"
+    private let originalUserIdKey = "qonversion.keys.originalUserId"
+    private let userKey = "qonversion.keys.user"
+    private let deviceKey = "io.qonversion.sdk.storage.device"
+    private let storedApiKeyKey = "qonversion.keys.apiKey"
+
+    private var defaults: UserDefaults!
+    private var storage: LocalStorage!
+
+    override func setUp() {
+        super.setUp()
+        defaults = TestDefaults.makeIsolated()
+        storage = makeStorage(over: defaults)
+    }
+
+    override func tearDown() {
+        storage = nil
+        defaults = nil
+        super.tearDown()
+    }
+
+    private func makeStorage(over userDefaults: UserDefaults) -> LocalStorage {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .qonversionTolerant
+
+        return LocalStorage(userDefaults: userDefaults, encoder: encoder, decoder: decoder)
+    }
+
+    private func makeCleaner() -> ApiKeyChangeCleaner {
+        let logger = LoggerWrapper()
+
+        return ApiKeyChangeCleaner(localStorage: storage, logger: logger)
+    }
+
+    private func seedProjectData(apiKey: String) throws {
+        try storage.set(["premium": Qonversion.Entitlement(id: "premium", active: true, source: .appStore)], forKey: entitlementsKey)
+        storage.set(double: 100, forKey: "qonversion.keys.entitlementsTimestamp")
+        storage.set(double: 100, forKey: "qonversion.keys.entitlementsBackendTimestamp")
+        try storage.set(["pro": ["premium"]], forKey: "qonversion.keys.productsPermissions")
+        try storage.set(["id": "QON_old"], forKey: userKey)
+        storage.set(string: "external_1", forKey: "qonversion.keys.identityExternalId")
+        storage.set(string: "QON_old", forKey: userIdKey)
+        storage.set(string: "QON_original", forKey: originalUserIdKey)
+        try storage.set(["com.app.pro": ["contextKeys": ["paywall"]]], forKey: "qonversion.keys.purchaseAssociations")
+        try storage.set(["tx_1"], forKey: "qonversion.keys.surfacedTransactions")
+        storage.set(bool: true, forKey: "qonversion.keys.historicalDataSynced")
+        try storage.set(["report"], forKey: "qonversion.keys.crashReports")
+        try storage.set(["id": "device_1"], forKey: deviceKey)
+        try storage.set(["catalog"], forKey: "qonversion.keys.products." + apiKey)
+        try storage.set(["queued"], forKey: "io.qonversion.sdk.storage.requests." + apiKey)
+    }
+
+    private func storedSdkKeys() -> [String] {
+        let allKeys: [String] = Array(defaults.dictionaryRepresentation().keys)
+
+        return allKeys.filter { $0.hasPrefix("qonversion.keys.") || $0.hasPrefix("io.qonversion.sdk.storage.") }.sorted()
+    }
+
+    // MARK: - Nothing to clean
+
+    func testTheFirstRunStoresTheKeyAndWipesNothing() throws {
+        try seedProjectData(apiKey: "key-a")
+
+        let wiped: Bool = makeCleaner().run(apiKey: "key-a")
+
+        XCTAssertFalse(wiped)
+        XCTAssertEqual(storage.string(forKey: userIdKey), "QON_old", "a fresh install has no stored key — an upgrade must keep its data")
+        XCTAssertEqual(storage.string(forKey: storedApiKeyKey), "key-a")
+    }
+
+    func testTheSameKeyAcrossLaunchesWipesNothing() throws {
+        _ = makeCleaner().run(apiKey: "key-a")
+        try seedProjectData(apiKey: "key-a")
+
+        let wiped: Bool = makeCleaner().run(apiKey: "key-a")
+
+        XCTAssertFalse(wiped)
+        XCTAssertNotNil(try storage.object(forKey: entitlementsKey, dataType: [String: Qonversion.Entitlement].self))
+        XCTAssertEqual(storage.string(forKey: userIdKey), "QON_old")
+        XCTAssertNotNil(storage.data(forKey: deviceKey))
+    }
+
+    // MARK: - A changed key
+
+    func testAChangedKeyDropsEverySdkOwnedKey() throws {
+        _ = makeCleaner().run(apiKey: "key-a")
+        try seedProjectData(apiKey: "key-a")
+
+        let wiped: Bool = makeCleaner().run(apiKey: "key-b")
+
+        XCTAssertTrue(wiped)
+        XCTAssertEqual(storedSdkKeys(), [storedApiKeyKey], "only the new project key may survive a project switch")
+    }
+
+    func testAChangedKeyDropsThePreviousProjectsScopedCaches() throws {
+        _ = makeCleaner().run(apiKey: "key-a")
+        try seedProjectData(apiKey: "key-a")
+
+        _ = makeCleaner().run(apiKey: "key-b")
+
+        XCTAssertNil(storage.data(forKey: "qonversion.keys.products.key-a"))
+        XCTAssertNil(storage.data(forKey: "io.qonversion.sdk.storage.requests.key-a"))
+    }
+
+    func testTheNewKeyIsStoredAfterTheWipe() throws {
+        _ = makeCleaner().run(apiKey: "key-a")
+        try seedProjectData(apiKey: "key-a")
+
+        _ = makeCleaner().run(apiKey: "key-b")
+
+        XCTAssertEqual(storage.string(forKey: storedApiKeyKey), "key-b", "without this the next launch would wipe again")
+        XCTAssertFalse(makeCleaner().run(apiKey: "key-b"), "the switch is done — the next launch must not wipe")
+    }
+
+    func testTheHostsOwnValuesInTheSuiteAreLeftAlone() throws {
+        // The configured suite may be the host's standard defaults: only the
+        // enumerated SDK keys may be removed.
+        _ = makeCleaner().run(apiKey: "key-a")
+        defaults.set("host value", forKey: "com.app.host.setting")
+        defaults.set(42, forKey: "someHostCounter")
+
+        _ = makeCleaner().run(apiKey: "key-b")
+
+        XCTAssertEqual(defaults.string(forKey: "com.app.host.setting"), "host value")
+        XCTAssertEqual(defaults.integer(forKey: "someHostCounter"), 42)
+    }
+}
+
+/// The wipe has to happen before anything reads or seeds storage, and it must
+/// not fire on the very first run of an install upgrading from the previous
+/// SDK generation.
+final class ApiKeyChangeAssemblyOrderingTests: XCTestCase {
+
+    private let legacySuiteName = "qonversion.localstorage.main"
+    private let legacyUserIdKey = "com.qonversion.keys.storedUserID"
+    private let legacyRelationKey = "com.qonversion.keys.products.permissions.relation"
+
+    private var legacyDefaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        legacyDefaults = UserDefaults(suiteName: legacySuiteName)
+        legacyDefaults.removePersistentDomain(forName: legacySuiteName)
+    }
+
+    override func tearDown() {
+        legacyDefaults.removePersistentDomain(forName: legacySuiteName)
+        legacyDefaults = nil
+        super.tearDown()
+    }
+
+    private func makeStorage(over userDefaults: UserDefaults) -> LocalStorage {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .qonversionTolerant
+
+        return LocalStorage(userDefaults: userDefaults, encoder: encoder, decoder: decoder)
+    }
+
+    func testAProjectSwitchStartsTheNextLaunchFromScratch() throws {
+        let defaults: UserDefaults = TestDefaults.makeIsolated()
+        _ = QonversionAssembly(apiKey: "key-a", userDefaults: defaults)
+        let storage: LocalStorage = makeStorage(over: defaults)
+        let firstUserId: String? = storage.string(forKey: "qonversion.keys.userId")
+        try storage.set(["premium": Qonversion.Entitlement(id: "premium", active: true, source: .appStore)], forKey: "qonversion.keys.entitlements")
+        try storage.set(["id": "device_1"], forKey: "io.qonversion.sdk.storage.device")
+
+        _ = QonversionAssembly(apiKey: "key-b", userDefaults: defaults)
+
+        XCTAssertNil(try storage.object(forKey: "qonversion.keys.entitlements", dataType: [String: Qonversion.Entitlement].self),
+                     "the previous project's entitlements must never be served to the new one")
+        XCTAssertNil(storage.data(forKey: "io.qonversion.sdk.storage.device"),
+                     "the device row belongs to the previous project — it must be created anew")
+        XCTAssertNotNil(firstUserId)
+        // A fresh uid, not merely a missing one: the wipe has to happen before
+        // the uid seeding, or the new project runs the whole session on the
+        // previous project's uid.
+        let secondUserId: String? = storage.string(forKey: "qonversion.keys.userId")
+        XCTAssertEqual(secondUserId?.hasPrefix("QON_"), true)
+        XCTAssertNotEqual(secondUserId, firstUserId)
+        XCTAssertEqual(storage.string(forKey: "qonversion.keys.originalUserId"), secondUserId)
+        XCTAssertNil(storage.string(forKey: "qonversion.keys.identityExternalId"))
+    }
+
+    func testAFirstRunStillMigratesThePreviousSdkGeneration() throws {
+        // No stored key at all: an install upgrading from the Objective-C SDK
+        // must keep its user and its offline entitlements cache.
+        let defaults: UserDefaults = TestDefaults.makeIsolated()
+        legacyDefaults.set("QON_legacy_user", forKey: legacyUserIdKey)
+        let relation: Data = try NSKeyedArchiver.archivedData(withRootObject: ["pro": ["premium"]], requiringSecureCoding: false)
+        legacyDefaults.set(relation, forKey: legacyRelationKey)
+
+        _ = QonversionAssembly(apiKey: "key-a", userDefaults: defaults)
+
+        let storage: LocalStorage = makeStorage(over: defaults)
+        XCTAssertEqual(storage.string(forKey: "qonversion.keys.userId"), "QON_legacy_user")
+        let migratedRelation: [String: [String]]? = try storage.object(forKey: "qonversion.keys.productsPermissions", dataType: [String: [String]].self)
+        XCTAssertEqual(migratedRelation, ["pro": ["premium"]])
+    }
+
+    func testAKeyChangeCannotResurrectTheMigratedLegacyCache() throws {
+        let defaults: UserDefaults = TestDefaults.makeIsolated()
+        legacyDefaults.set("QON_legacy_user", forKey: legacyUserIdKey)
+        let relation: Data = try NSKeyedArchiver.archivedData(withRootObject: ["pro": ["premium"]], requiringSecureCoding: false)
+        legacyDefaults.set(relation, forKey: legacyRelationKey)
+        _ = QonversionAssembly(apiKey: "key-a", userDefaults: defaults)
+
+        _ = QonversionAssembly(apiKey: "key-b", userDefaults: defaults)
+
+        let storage: LocalStorage = makeStorage(over: defaults)
+        XCTAssertNil(try storage.object(forKey: "qonversion.keys.productsPermissions", dataType: [String: [String]].self))
+        XCTAssertNotEqual(storage.string(forKey: "qonversion.keys.userId"), "QON_legacy_user")
+    }
+}

--- a/Tests/QonversionUnitTests/EntitiesDecodingTests.swift
+++ b/Tests/QonversionUnitTests/EntitiesDecodingTests.swift
@@ -766,14 +766,6 @@ final class EntitiesDecodingTests: XCTestCase {
         XCTAssertTrue(Qonversion.Transaction.Offer.hasLegacyOfferData(id: "offer_1", type: .promotional))
     }
 
-    func testTransactionWithoutStoreKitDataHasNoOffer() {
-        // The wire-only transaction (offline replay, local calculation) has
-        // no StoreKit object behind it and therefore no offer.
-        let transaction = Qonversion.Transaction(id: "t1", productId: "com.app.pro")
-
-        XCTAssertNil(transaction.offer)
-    }
-
     // MARK: - Product
 
     func testProductDecodingUsesV4Keys() throws {

--- a/Tests/QonversionUnitTests/EntitlementsManagerTests.swift
+++ b/Tests/QonversionUnitTests/EntitlementsManagerTests.swift
@@ -152,17 +152,14 @@ final class EntitlementsManagerTests: XCTestCase {
         let entitlements = try await manager.entitlements()
 
         XCTAssertEqual(entitlements["premium"]?.active, true)
-        XCTAssertTrue(facade.finishedTransactions.isEmpty)
+        XCTAssertEqual(service.entitlementsCalls, [uid], "the fallback answers a FAILED request — it may not replace it")
     }
 
     func testErrorIsRethrownWhenTheLocalFallbackHasNothingToServe() async {
         service.error = QonversionError(type: .critical)
         facade.currentEntitlementsResult = []
 
-        do {
-            _ = try await manager.entitlements()
-            XCTFail("Expected the error to be rethrown when there is nothing to serve")
-        } catch { }
+        await assertNothingServed(.critical)
     }
 
     func testGateFailureIsAnsweredFromTheLocalFallbackWithoutServiceCall() async throws {
@@ -182,9 +179,11 @@ final class EntitlementsManagerTests: XCTestCase {
         facade.currentEntitlementsResult = []
 
         do {
-            _ = try await manager.entitlements()
-            XCTFail("Expected the gate error to be rethrown")
-        } catch { }
+            let entitlements: [String: Qonversion.Entitlement] = try await manager.entitlements()
+            XCTFail("Expected the gate error to be rethrown, got \(entitlements)")
+        } catch {
+            XCTAssertEqual(error as? MockError, MockError.stubbed, "the gate's own error must reach the caller unwrapped")
+        }
 
         XCTAssertTrue(service.entitlementsCalls.isEmpty)
     }
@@ -237,8 +236,11 @@ final class EntitlementsManagerTests: XCTestCase {
 
         service.error = QonversionError(type: .internal)
         setupLocalCalculationContext()
-        _ = await servedEntitlements()
+        let served: [String: Qonversion.Entitlement] = await servedEntitlements()
 
+        // Without this the test cannot tell "the fallback ran and left the
+        // clock alone" from "the call threw before touching it".
+        XCTAssertEqual(served["premium"]?.active, true)
         XCTAssertEqual(storage.double(forKey: "qonversion.keys.entitlementsBackendTimestamp"), afterBackend)
     }
 

--- a/Tests/QonversionUnitTests/IntegrationTests.swift
+++ b/Tests/QonversionUnitTests/IntegrationTests.swift
@@ -361,23 +361,21 @@ final class IntegrationTests: XCTestCase {
 
     // MARK: - 8. intro eligibility over the real facade and manager
 
-    func testEligibilityFlowsThroughTheRealGraph() async throws {
+    func testTheEligibilityCallLoadsTheCatalogAndAnswersForEveryRequestedId() async throws {
+        // Scope, honestly: StoreKit.Product cannot be constructed outside a
+        // real StoreKit session, so no id can resolve past .unknown here. The
+        // resolution itself is pinned in ProductsManagerTests (over the
+        // injectable check seam) and in the StoreKitTest layer over an
+        // SKTestSession. What IS reachable here is that the real manager loads
+        // the real backend catalog once and answers for every requested id,
+        // including one that is not in the catalog at all.
         world.stubHappyUser()
         world.network.stub("GET", "/v4/products", body: #"{"object": "list", "data": [{"id": "pro", "apple_product_id": "com.app.pro"}]}"#)
 
         let result = try await world.productsManager.checkTrialIntroEligibility(productIds: ["pro", "missing"])
 
-        // Honest scope, deliberately left as-is: StoreKit.Product cannot be
-        // constructed outside a real StoreKit session, so over the object
-        // graph both ids can only resolve to .unknown. The eligibility
-        // resolution itself is pinned in ProductsManagerTests (over the
-        // injectable check seam) and in the StoreKitTest layer, which runs the
-        // real StoreKit over an SKTestSession. What this smoke test pins is
-        // the part that IS reachable here: the real manager consulted the real
-        // backend catalog first, and an id absent from it does not fail the
-        // call.
         XCTAssertEqual(world.network.recordedRequests("GET", "/v4/products").count, 1)
-        XCTAssertEqual(result["pro"], .unknown)
-        XCTAssertEqual(result["missing"], .unknown)
+        XCTAssertEqual(Set(result.keys), ["pro", "missing"], "an id the catalog does not know may not be dropped from the answer")
+        XCTAssertNil(result["never_requested"])
     }
 }


### PR DESCRIPTION
Only two persisted keys were scoped by apiKey (the products catalog and the replay queue); everything else — entitlements and their timestamps, the product mapping, the user, the uid pair, the identity, the purchase bookkeeping, the crash reports and the device record — was unscoped, so a project key change was undetectable: the new project got the old project's entitlements and its device row was never created.

The api key is now persisted under its own key and compared at initialize. A different stored key wipes the enumerated SDK-owned keys (plus the previous key's own scoped copies) before anything reads them; no stored key at all means a fresh install or an upgrade from the Objective-C SDK, and is left alone. The check runs strictly before the uid seeding and the legacy migrations, so a project switch cannot resurrect what those just wrote.

Also:
- README: the products snippet documented a non-existent skProduct/SKProduct accessor and an "iOS < 15" eligibility note; StoreKit 1 is absent and the deployment floor is iOS 15.
- Repaired six tests that could not fail: an always-nil offer assertion, an untouched-mock assertion, a discarded serve result, two "…IsRethrown…" tests with bare catch blocks, and an eligibility integration test whose values were forced by early-return guards.