### PR TITLE
feat(api): align the user, network and purchase surface with the fina…

### DIFF
--- a/Sources/NetworkLayer/Error/QonversionErrorType.swift
+++ b/Sources/NetworkLayer/Error/QonversionErrorType.swift
@@ -49,8 +49,8 @@ public enum QonversionErrorType: Sendable {
     case purchaseSceneMissing
     /// The backend does not know the requested resource: an unknown user id,
     /// an unknown product, an unknown remote config, an unknown nested id.
-    /// Answers the `not_found`, `relation_not_found` and `user_not_found`
-    /// backend codes (HTTP 404).
+    /// Answers the `not_found` and `relation_not_found` backend codes
+    /// (HTTP 404).
     case resourceNotFound
     /// This device is not allowed to make payments (e.g. parental controls).
     /// Produced from StoreKit failures only — the backend has no code for it.
@@ -212,22 +212,19 @@ extension QonversionErrorType {
         case "invalid_data", "invalid_request", "validation_error", "invalid_entitlement_data":
             self = .invalidRequest
         // Nothing behind the id. `relation_not_found` is what a nested route
-        // answers for an unknown uid (404); `user_not_found` is the
-        // offer-signature service saying the same thing.
-        case "not_found", "relation_not_found", "user_not_found":
+        // answers for an unknown uid (404).
+        case "not_found", "relation_not_found":
             self = .resourceNotFound
-        // Throttling. `too_many_requests` is the gateway's slug (429);
-        // `rate_limit_exceeded` is the offer-signature passthrough.
-        case "too_many_requests", "rate_limit_exceeded":
+        // Throttling: the gateway's slug (429).
+        case "too_many_requests":
             self = .rateLimitExceeded
         // purchaseman rejected the purchase as fraudulent (422).
         case "purchase_fraud":
             self = .fraudPurchase
         // The project has no usable App Store credentials. The first two come
-        // from purchaseman, the rest from the offer-signature service, where
-        // the missing token / secret / settings all mean the same thing:
-        // the Dashboard project is not set up for this operation.
-        case "store_not_configured", "store_creds_failed", "token_not_found", "secrets_not_found", "settings_not_found":
+        // from purchaseman, `token_not_found` from the offer-signature
+        // service: the Dashboard project is not set up for this operation.
+        case "store_not_configured", "store_creds_failed", "token_not_found":
             self = .projectConfigError
         // The purchase-validation family (422): the App Store payload did not
         // parse into a subscription, carried an unexpected purchase type, or
@@ -242,6 +239,8 @@ extension QonversionErrorType {
             // control_unauthorized / control_forbidden are unmapped too: they
             // arrive on 401 / 403, which already classify as .critical and
             // must keep doing so (see the precedence in NetworkErrorHandler).
+            // user_not_found, rate_limit_exceeded, secrets_not_found and
+            // settings_not_found are absent on purpose: no backend emits them.
             return nil
         }
     }

--- a/Sources/NetworkLayer/Request/Request.swift
+++ b/Sources/NetworkLayer/Request/Request.swift
@@ -112,7 +112,9 @@ enum Request : Hashable {
     case createIdentity(endpoint: String = "v4/identities", body: RequestBodyDict, type: RequestType = .post)
     case entitlements(userId: String, endpoint: String = "v4/users/%@/entitlements", type: RequestType = .get)
     case createPurchase(userId: String, endpoint: String = "v4/users/%@/purchases", body: RequestBodyDict, type: RequestType = .post)
-    case signPromoOffer(userId: String, offerId: String, endpoint: String = "v4/users/%@/offers/%@/signatures", body: RequestBodyDict, type: RequestType = .post)
+    // v3: contract-identical to the v4 shape and already accepting the SDK's
+    // Bearer key — the backend is not porting it.
+    case signPromoOffer(userId: String, offerId: String, endpoint: String = "v3/users/%@/offers/%@/signatures", body: RequestBodyDict, type: RequestType = .post)
     case getProperties(userId: String, endpoint: String = "v4/users/%@/properties", type: RequestType = .get)
     case sendProperties(userId: String, endpoint: String = "v4/users/%@/properties", body: RequestBodyDict, type: RequestType = .post)
     case createDevice(userId: String, endpoint: String = "v4/users/%@/device", body: RequestBodyDict, type: RequestType = .post)
@@ -120,9 +122,11 @@ enum Request : Hashable {
     case appleSearchAds(userId: String, endpoint: String = "v4/users/%@/attribution", body: RequestBodyDict, type: RequestType = .post)
     case getProducts(endpoint: String = "v4/products", type: RequestType = .get)
     case entitlementDefinitions(endpoint: String = "v4/entitlements", type: RequestType = .get)
-    case remoteConfig(userId: String, contextKey: String?, endpoint: String = "v4/remote-config", type: RequestType = .get)
-    case remoteConfigList(userId: String, contextKeys: [String], includeEmptyContextKey: Bool, endpoint: String = "v4/remote-configs", type: RequestType = .get)
-    case allRemoteConfigList(userId: String, endpoint: String = "v4/remote-configs?all_context_keys=true", type: RequestType = .get)
+    // The three remote-config READS stay on v3 for the same reason; the
+    // attach/detach routes below are v4.
+    case remoteConfig(userId: String, contextKey: String?, endpoint: String = "v3/remote-config", type: RequestType = .get)
+    case remoteConfigList(userId: String, contextKeys: [String], includeEmptyContextKey: Bool, endpoint: String = "v3/remote-configs", type: RequestType = .get)
+    case allRemoteConfigList(userId: String, endpoint: String = "v3/remote-configs?all_context_keys=true", type: RequestType = .get)
     case attachUserToExperiment(userId: String, experimentId: String, groupId: String, endpoint: String = "v4/experiments/%@/users/%@", type: RequestType = .post)
     case detachUserFromExperiment(userId: String, experimentId: String, endpoint: String = "v4/experiments/%@/users/%@", type: RequestType = .delete)
     case attachUserToRemoteConfig(userId: String, remoteConfigId: String, endpoint: String = "v4/remote-configurations/%@/users/%@", type: RequestType = .post)

--- a/Sources/Services/PurchasesService/PurchasesService.swift
+++ b/Sources/Services/PurchasesService/PurchasesService.swift
@@ -81,10 +81,17 @@ final class PurchasesService: PurchasesServiceInterface {
         ]
         var body: RequestBodyDict = [
             "platform": "app_store",
-            "price": transaction.price.map { "\($0)" } ?? "",
-            "currency": transaction.currency?.identifier ?? "",
             "store_data": storeData,
         ]
+        // An unknown price or currency is omitted, never sent as "": the
+        // backend reads the empty string as a value and would record the
+        // purchase as costing nothing.
+        if let price: Decimal = transaction.price {
+            body["price"] = "\(price)"
+        }
+        if let currency: String = transaction.currency?.identifier, !currency.isEmpty {
+            body["currency"] = currency
+        }
         if let purchaseDate: Date = transaction.purchaseDate {
             // A fresh formatter per call: ISO8601DateFormatter is not Sendable.
             body["purchased_at"] = ISO8601DateFormatter().string(from: purchaseDate)

--- a/Sources/Services/UserService/UserService.swift
+++ b/Sources/Services/UserService/UserService.swift
@@ -22,6 +22,8 @@ fileprivate enum Constants: String {
     // That generation persisted everything into its own UserDefaults suite,
     // never into the standard/configured one — the migration must read there.
     case legacySuiteName = "qonversion.localstorage.main"
+    // The backend's answer (422) to a create carrying a uid it already knows.
+    case alreadyExistsApiCode = "already_exists"
 }
 
 // @unchecked: stateless — every dependency is thread-safe on its own.
@@ -49,16 +51,22 @@ final class UserService: UserServiceInterface, @unchecked Sendable {
     }
     
     func createUser() async throws -> Qonversion.User {
-        // The backend upserts by uid: a fresh install creates the user, a
-        // migrated install gets its existing user back.
         let userId: String = internalConfig.userId.isEmpty ? generateUserId() : internalConfig.userId
         do {
             let request = Request.createUser(body: ["id": userId])
             let user: Qonversion.User = try await requestProcessor.process(request: request, responseType: Qonversion.User.self, trigger: RequestTrigger.initialization)
-            
+
             return user
         } catch {
-            throw QonversionError(type: .userCreationFailed, message: nil, error: error)
+            // The uid is already taken — which is the normal state of an
+            // install upgraded from the previous SDK generation, since it
+            // adopts the uid that generation created. The user exists, so the
+            // pipeline continues with it instead of failing.
+            guard isAlreadyExists(error) else {
+                throw QonversionError(type: .userCreationFailed, message: nil, error: error)
+            }
+
+            return try await user()
         }
     }
     
@@ -103,7 +111,17 @@ final class UserService: UserServiceInterface, @unchecked Sendable {
 // MARK: - Private
 
 extension UserService {
-    
+
+    /// The conflict arrives wrapped by whichever layer failed, so the whole
+    /// error chain is inspected, not only its outermost link.
+    private func isAlreadyExists(_ error: Error) -> Bool {
+        guard let qonversionError = error as? QonversionError else { return false }
+        if qonversionError.apiCode == Constants.alreadyExistsApiCode.rawValue { return true }
+        guard let underlying: Error = qonversionError.error else { return false }
+
+        return isAlreadyExists(underlying)
+    }
+
     private func prepareUserId() {
         // An install updated from the previous SDK generation keeps its user:
         // the legacy uid moves to the new storage and the legacy key is cleaned.

--- a/Tests/QonversionUnitTests/IntegrationTests.swift
+++ b/Tests/QonversionUnitTests/IntegrationTests.swift
@@ -291,7 +291,7 @@ final class IntegrationTests: XCTestCase {
     func testPendingPropertiesReachTheBackendBeforeTheRemoteConfig() async throws {
         world.stubHappyUser()
         world.network.stub("POST", "/v4/users/*/properties", body: #"{"object": "list", "saved_properties": [], "property_errors": []}"#)
-        world.network.stub("GET", "/v4/remote-config", body: #"{"payload": {"k": "v"}, "source": {"uid": "s1", "name": "main", "type": "remote_configuration", "assignment_type": "auto", "context_key": null}}"#)
+        world.network.stub("GET", "/v3/remote-config", body: #"{"payload": {"k": "v"}, "source": {"uid": "s1", "name": "main", "type": "remote_configuration", "assignment_type": "auto", "context_key": null}}"#)
 
         world.userPropertiesManager.setUserProperty(key: .email, value: "a@b.com")
         _ = try await world.remoteConfigManager.loadRemoteConfig(contextKey: nil)

--- a/Tests/QonversionUnitTests/Mocks.swift
+++ b/Tests/QonversionUnitTests/Mocks.swift
@@ -33,7 +33,9 @@ enum TestDefaults {
 
 final class MockRequestProcessor: RequestProcessorInterface {
 
-    /// Stubbed results returned in order. Put decoded values of the expected response type here.
+    /// Stubbed results returned in order. Put decoded values of the expected
+    /// response type here; an Error entry is thrown when its turn comes, which
+    /// lets a test fail one request of a sequence and answer the next.
     var results: [Any] = []
     var error: Error?
     var onProcess: (() async -> Void)?
@@ -47,6 +49,7 @@ final class MockRequestProcessor: RequestProcessorInterface {
         if let error { throw error }
         guard !results.isEmpty else { throw MockError.noStub }
         let next = results.removeFirst()
+        if let stubbedError = next as? Error { throw stubbedError }
         guard let typed = next as? T else { throw MockError.typeMismatch }
         return typed
     }

--- a/Tests/QonversionUnitTests/NetworkErrorHandlerTests.swift
+++ b/Tests/QonversionUnitTests/NetworkErrorHandlerTests.swift
@@ -208,10 +208,8 @@ final class ApiErrorMappingTests: XCTestCase {
             // resource family
             ("not_found", .resourceNotFound),
             ("relation_not_found", .resourceNotFound),
-            ("user_not_found", .resourceNotFound),
             // throttling
             ("too_many_requests", .rateLimitExceeded),
-            ("rate_limit_exceeded", .rateLimitExceeded),
             // purchase passthrough
             ("purchase_fraud", .fraudPurchase),
             ("store_not_configured", .projectConfigError),
@@ -221,8 +219,6 @@ final class ApiErrorMappingTests: XCTestCase {
             ("conflicting_purchase_found", .receiptValidationError),
             // offer-signature passthrough
             ("token_not_found", .projectConfigError),
-            ("secrets_not_found", .projectConfigError),
-            ("settings_not_found", .projectConfigError),
         ]
 
         for expectation in expectations {
@@ -230,6 +226,19 @@ final class ApiErrorMappingTests: XCTestCase {
             let error = try XCTUnwrap(handler.extractError(from: response(statusCode: 400), body: body))
 
             XCTAssertEqual(error.type, expectation.type, "code \(expectation.code)")
+        }
+    }
+
+    func testSlugsNoBackendEmitsAreNotInTheVocabulary() throws {
+        // Verified against the backend sources: nothing produces these. They
+        // were mapped on an assumption; throttling really arrives as
+        // `too_many_requests`, which stays mapped above.
+        for code in ["user_not_found", "rate_limit_exceeded", "secrets_not_found", "settings_not_found"] {
+            let body = Data("{\"error\": {\"code\": \"\(code)\", \"message\": \"m\"}}".utf8)
+            let error = try XCTUnwrap(handler.extractError(from: response(statusCode: 400), body: body))
+
+            XCTAssertEqual(error.type, .unknown, "code \(code) must keep the status-derived type")
+            XCTAssertEqual(error.apiCode, code, "the slug still reaches the integrator")
         }
     }
 

--- a/Tests/QonversionUnitTests/PurchasesServiceTests.swift
+++ b/Tests/QonversionUnitTests/PurchasesServiceTests.swift
@@ -123,6 +123,69 @@ final class PurchasesServiceTests: XCTestCase {
         XCTAssertNil(body["screen_uid"])
     }
 
+    // MARK: - price / currency
+
+    /// An unknown price must be absent from the body, never an empty string:
+    /// the backend reads "" as a value and would record a zero-cost purchase.
+    func testSendWithoutPriceOmitsThePriceKey() async throws {
+        let processor = MockRequestProcessor()
+        processor.results = [PurchaseReportResponse(userId: nil)]
+        let service = makeService(processor)
+
+        try await service.send(makeTransaction(price: nil), userId: "QON_buyer")
+
+        guard case let .createPurchase(_, _, body, _) = processor.processedRequests.first else {
+            return XCTFail("Expected a createPurchase request")
+        }
+        XCTAssertNil(body["price"])
+        XCTAssertEqual(body["currency"] as? String, "USD", "a known currency still travels")
+    }
+
+    func testSendWithoutCurrencyOmitsTheCurrencyKey() async throws {
+        let processor = MockRequestProcessor()
+        processor.results = [PurchaseReportResponse(userId: nil)]
+        let service = makeService(processor)
+
+        try await service.send(makeTransaction(currencyId: nil), userId: "QON_buyer")
+
+        guard case let .createPurchase(_, _, body, _) = processor.processedRequests.first else {
+            return XCTFail("Expected a createPurchase request")
+        }
+        XCTAssertNil(body["currency"])
+        XCTAssertEqual(body["price"] as? String, "9.99", "a known price still travels")
+    }
+
+    /// An identifier that is present but empty is as unknown as a missing one.
+    func testSendWithEmptyCurrencyIdentifierOmitsTheCurrencyKey() async throws {
+        let processor = MockRequestProcessor()
+        processor.results = [PurchaseReportResponse(userId: nil)]
+        let service = makeService(processor)
+
+        try await service.send(makeTransaction(currencyId: ""), userId: "QON_buyer")
+
+        guard case let .createPurchase(_, _, body, _) = processor.processedRequests.first else {
+            return XCTFail("Expected a createPurchase request")
+        }
+        XCTAssertNil(body["currency"])
+    }
+
+    func testSendWithoutPriceAndCurrencyKeepsTheRestOfTheBody() async throws {
+        let processor = MockRequestProcessor()
+        processor.results = [PurchaseReportResponse(userId: nil)]
+        let service = makeService(processor)
+
+        try await service.send(makeTransaction(price: nil, currencyId: nil), userId: "QON_buyer")
+
+        guard case let .createPurchase(_, _, body, _) = processor.processedRequests.first else {
+            return XCTFail("Expected a createPurchase request")
+        }
+        XCTAssertNil(body["price"])
+        XCTAssertNil(body["currency"])
+        XCTAssertEqual(body["platform"] as? String, "app_store")
+        XCTAssertEqual(body["purchased_at"] as? String, "2023-11-14T22:13:20Z")
+        XCTAssertNotNil(body["store_data"])
+    }
+
     func testSendWithoutJwsSendsEmptyReceipt() async throws {
         let processor = MockRequestProcessor()
         processor.results = [PurchaseReportResponse(userId: nil)]

--- a/Tests/QonversionUnitTests/RemoteConfigServiceTests.swift
+++ b/Tests/QonversionUnitTests/RemoteConfigServiceTests.swift
@@ -145,10 +145,10 @@ final class RemoteConfigServiceTests: XCTestCase {
     }
 
     func testAnUnknownUserIsNotDisguisedAsAMissingConfiguration() async {
-        // `user_not_found` also classifies as .resourceNotFound, but it means
-        // the SDK asked about a user the backend does not have — a real error,
-        // not "this user has no config", and the integrator must be able to
-        // tell them apart.
+        // The remap is limited to the two codes that really mean "there is no
+        // configuration here". `user_not_found` is not one of them — and is
+        // not in the SDK's slug vocabulary at all, so it keeps the
+        // endpoint-specific type while carrying the backend code through.
         let service = makeLiveService(
             json: #"{"error": {"type": "resource", "code": "user_not_found", "message": "no such user"}}"#,
             status: 404
@@ -158,7 +158,8 @@ final class RemoteConfigServiceTests: XCTestCase {
             _ = try await service.loadRemoteConfig(contextKey: "main")
             XCTFail("Expected an error")
         } catch let error as QonversionError {
-            XCTAssertEqual(error.type, .resourceNotFound)
+            XCTAssertNotEqual(error.type, .remoteConfigurationNotAvailable)
+            XCTAssertEqual(error.type, .loadingRemoteConfigFailed)
             XCTAssertEqual(error.apiCode, "user_not_found")
         } catch {
             XCTFail("Expected QonversionError, got \(error)")

--- a/Tests/QonversionUnitTests/RequestTests.swift
+++ b/Tests/QonversionUnitTests/RequestTests.swift
@@ -131,14 +131,14 @@ final class RequestTests: XCTestCase {
 
     func testRemoteConfigWithoutContextKey() throws {
         let request = try XCTUnwrap(Request.remoteConfig(userId: "user1", contextKey: nil).convertToURLRequest(baseURL))
-        XCTAssertEqual(request.url?.absoluteString, "https://api.qonversion.io/v4/remote-config?user_id=user1")
+        XCTAssertEqual(request.url?.absoluteString, "https://api.qonversion.io/v3/remote-config?user_id=user1")
         XCTAssertEqual(request.httpMethod, "GET")
         XCTAssertNil(request.httpBody)
     }
 
     func testRemoteConfigWithContextKey() throws {
         let request = try XCTUnwrap(Request.remoteConfig(userId: "user1", contextKey: "main").convertToURLRequest(baseURL))
-        XCTAssertEqual(request.url?.absoluteString, "https://api.qonversion.io/v4/remote-config?user_id=user1&context_key=main")
+        XCTAssertEqual(request.url?.absoluteString, "https://api.qonversion.io/v3/remote-config?user_id=user1&context_key=main")
         XCTAssertEqual(request.httpMethod, "GET")
     }
 
@@ -149,7 +149,7 @@ final class RequestTests: XCTestCase {
         )
         XCTAssertEqual(
             request.url?.absoluteString,
-            "https://api.qonversion.io/v4/remote-configs?user_id=user1&with_empty_context_key=true&context_key=a&context_key=b"
+            "https://api.qonversion.io/v3/remote-configs?user_id=user1&with_empty_context_key=true&context_key=a&context_key=b"
         )
         XCTAssertEqual(request.httpMethod, "GET")
         XCTAssertNil(request.httpBody)
@@ -162,7 +162,7 @@ final class RequestTests: XCTestCase {
         )
         XCTAssertEqual(
             request.url?.absoluteString,
-            "https://api.qonversion.io/v4/remote-configs?user_id=user1&with_empty_context_key=false"
+            "https://api.qonversion.io/v3/remote-configs?user_id=user1&with_empty_context_key=false"
         )
     }
 
@@ -172,7 +172,7 @@ final class RequestTests: XCTestCase {
         // and user_id is appended with "&".
         XCTAssertEqual(
             request.url?.absoluteString,
-            "https://api.qonversion.io/v4/remote-configs?all_context_keys=true&user_id=user1"
+            "https://api.qonversion.io/v3/remote-configs?all_context_keys=true&user_id=user1"
         )
         XCTAssertEqual(request.httpMethod, "GET")
         XCTAssertNil(request.httpBody)
@@ -223,7 +223,7 @@ final class RequestTests: XCTestCase {
         let request = try XCTUnwrap(
             Request.signPromoOffer(userId: "user1", offerId: "offer1", body: body).convertToURLRequest(baseURL)
         )
-        XCTAssertEqual(request.url?.absoluteString, "https://api.qonversion.io/v4/users/user1/offers/offer1/signatures")
+        XCTAssertEqual(request.url?.absoluteString, "https://api.qonversion.io/v3/users/user1/offers/offer1/signatures")
         XCTAssertEqual(request.httpMethod, "POST")
         XCTAssertEqual(try bodyDict(request)["product"] as? String, "com.app.pro")
     }
@@ -242,7 +242,7 @@ final class RequestTests: XCTestCase {
         let request = try XCTUnwrap(
             Request.remoteConfig(userId: "u", contextKey: "a&b").convertToURLRequest(baseURL)
         )
-        XCTAssertEqual(request.url?.absoluteString, "https://api.qonversion.io/v4/remote-config?user_id=u&context_key=a%26b")
+        XCTAssertEqual(request.url?.absoluteString, "https://api.qonversion.io/v3/remote-config?user_id=u&context_key=a%26b")
     }
 
     // MARK: - Hashable

--- a/Tests/QonversionUnitTests/UserManagerTests.swift
+++ b/Tests/QonversionUnitTests/UserManagerTests.swift
@@ -162,6 +162,59 @@ final class UserManagerTests: XCTestCase {
         XCTAssertEqual(service.createUserCallsCount, 1)
     }
 
+    // MARK: - Migration from the previous SDK generation
+
+    /// The whole upgrade path over a REAL UserService: the install adopts the
+    /// legacy uid, the backend answers the create with `already_exists` (422),
+    /// and the gate still completes with that existing user.
+    func testObtainUserRecoversFromTheCreateConflictOfAMigratedInstall() async throws {
+        let legacyUid = "QON_legacy_uid"
+        let legacySuiteName = "qonversion.localstorage.main"
+        let legacyDefaults = UserDefaults(suiteName: legacySuiteName)
+        legacyDefaults?.removePersistentDomain(forName: legacySuiteName)
+        defer { legacyDefaults?.removePersistentDomain(forName: legacySuiteName) }
+
+        let migrationStorage = MockLocalStorage()
+        migrationStorage.set(string: legacyUid, forKey: "com.qonversion.keys.storedUserID")
+        let migrationConfig = InternalConfig(userId: "")
+        let processor = MockRequestProcessor()
+        let realService = UserService(requestProcessor: processor, localStorage: migrationStorage, internalConfig: migrationConfig)
+        let migrationManager = UserManager(
+            userService: realService,
+            localStorage: migrationStorage,
+            internalConfig: migrationConfig,
+            userChangesNotifier: notifier,
+            logger: LoggerWrapper()
+        )
+
+        XCTAssertEqual(migrationConfig.userId, legacyUid, "the legacy uid must be adopted before any request")
+
+        let conflict = QonversionError(
+            type: .unknown,
+            message: "user already exists",
+            error: nil,
+            additionalInfo: [ErrorConstants.statusCodeKey.rawValue: 422],
+            apiCode: "already_exists",
+            apiType: "logical"
+        )
+        processor.results = [conflict, try makeUser(id: legacyUid)]
+
+        let user = try await migrationManager.obtainUser()
+
+        XCTAssertEqual(user.id, legacyUid)
+        XCTAssertEqual(
+            processor.processedRequests,
+            [Request.createUser(body: ["id": legacyUid]), Request.getUser(id: legacyUid)]
+        )
+        XCTAssertEqual(migrationConfig.userId, legacyUid)
+
+        // The recovered user is cached: a second demand costs no request.
+        let cached = try await migrationManager.obtainUser()
+
+        XCTAssertEqual(cached.id, legacyUid)
+        XCTAssertEqual(processor.processedRequests.count, 2)
+    }
+
     // MARK: - Identity
 
     func testIdentifyAfterCreationLinksIdentity() async throws {

--- a/Tests/QonversionUnitTests/UserServiceTests.swift
+++ b/Tests/QonversionUnitTests/UserServiceTests.swift
@@ -219,8 +219,8 @@ final class UserServiceTests: XCTestCase {
 
         let user = try await service.createUser()
 
-        // The backend upserts by uid, so createUser keeps the current uid:
-        // a migrated install gets its existing user back instead of a new one.
+        // createUser posts the CURRENT uid instead of minting a new one — a
+        // migrated install must keep the user the previous SDK created.
         let idAfterCreate = config.userId
         XCTAssertEqual(idAfterInit, idAfterCreate)
         XCTAssertEqual(storage.string(forKey: userIdKey), idAfterCreate)
@@ -264,6 +264,103 @@ final class UserServiceTests: XCTestCase {
         } catch let error as QonversionError {
             XCTAssertEqual(error.type, .userCreationFailed)
             XCTAssertEqual(error.error as? MockError, .stubbed)
+        } catch {
+            XCTFail("Expected QonversionError, got \(error)")
+        }
+    }
+
+    // MARK: - createUser: the already_exists conflict
+
+    /// The backend answers a repeated uid with `already_exists` (422). Every
+    /// install upgraded from the previous SDK generation posts a uid the
+    /// backend already knows, so the conflict must resolve to that user.
+    private func alreadyExistsError(nested: Bool = false) -> QonversionError {
+        let apiError = QonversionError(
+            type: .unknown,
+            message: "user already exists",
+            error: nil,
+            additionalInfo: [ErrorConstants.statusCodeKey.rawValue: 422],
+            apiCode: "already_exists",
+            apiType: "logical"
+        )
+        guard nested else { return apiError }
+
+        return QonversionError(type: .internal, message: nil, error: apiError)
+    }
+
+    func testCreateUserFetchesTheExistingUserOnAlreadyExists() async throws {
+        let processor = MockRequestProcessor()
+        let storage = makeStorage()
+        storage.set(string: "QON_migrated_uid", forKey: userIdKey)
+        let config = InternalConfig(userId: "initial")
+        let service = UserService(requestProcessor: processor, localStorage: storage, internalConfig: config)
+
+        let existingUser = try decodeUserStub(id: "QON_migrated_uid", environment: "sandbox")
+        processor.results = [alreadyExistsError(), existingUser]
+
+        let user = try await service.createUser()
+
+        XCTAssertEqual(
+            processor.processedRequests,
+            [Request.createUser(body: ["id": "QON_migrated_uid"]), Request.getUser(id: "QON_migrated_uid")]
+        )
+        XCTAssertEqual(user.id, "QON_migrated_uid")
+        XCTAssertEqual(user.environment, .sandbox)
+        XCTAssertEqual(config.userId, "QON_migrated_uid")
+    }
+
+    /// The conflict arrives wrapped by whichever layer failed — the whole
+    /// error chain has to be inspected, not only its outermost link.
+    func testCreateUserFetchesTheExistingUserOnNestedAlreadyExists() async throws {
+        let processor = MockRequestProcessor()
+        let storage = makeStorage()
+        storage.set(string: "QON_migrated_uid", forKey: userIdKey)
+        let service = UserService(requestProcessor: processor, localStorage: storage, internalConfig: InternalConfig(userId: "initial"))
+
+        processor.results = [alreadyExistsError(nested: true), try decodeUserStub(id: "QON_migrated_uid")]
+
+        let user = try await service.createUser()
+
+        XCTAssertEqual(processor.processedRequests.count, 2)
+        XCTAssertEqual(user.id, "QON_migrated_uid")
+    }
+
+    func testCreateUserKeepsFailingOnAnyOtherApiCode() async {
+        let processor = MockRequestProcessor()
+        let storage = makeStorage()
+        storage.set(string: "QON_uid", forKey: userIdKey)
+        let service = UserService(requestProcessor: processor, localStorage: storage, internalConfig: InternalConfig(userId: "initial"))
+
+        let otherApiError = QonversionError(type: .invalidRequest, message: nil, error: nil, additionalInfo: nil, apiCode: "invalid_data", apiType: "request")
+        processor.results = [otherApiError, try? decodeUserStub(id: "QON_uid")]
+
+        do {
+            _ = try await service.createUser()
+            XCTFail("Expected an error")
+        } catch let error as QonversionError {
+            XCTAssertEqual(error.type, .userCreationFailed)
+            XCTAssertEqual((error.error as? QonversionError)?.apiCode, "invalid_data")
+            // Only the conflict slug recovers: no user fetch was attempted.
+            XCTAssertEqual(processor.processedRequests, [Request.createUser(body: ["id": "QON_uid"])])
+        } catch {
+            XCTFail("Expected QonversionError, got \(error)")
+        }
+    }
+
+    func testCreateUserSurfacesTheFetchFailureWhenTheConflictRecoveryFails() async {
+        let processor = MockRequestProcessor()
+        let storage = makeStorage()
+        storage.set(string: "QON_uid", forKey: userIdKey)
+        let service = UserService(requestProcessor: processor, localStorage: storage, internalConfig: InternalConfig(userId: "initial"))
+
+        processor.results = [alreadyExistsError(), MockError.stubbed]
+
+        do {
+            _ = try await service.createUser()
+            XCTFail("Expected an error")
+        } catch let error as QonversionError {
+            XCTAssertEqual(error.type, .userLoadingFailed)
+            XCTAssertEqual(processor.processedRequests.count, 2)
         } catch {
             XCTFail("Expected QonversionError, got \(error)")
         }

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -53,6 +53,14 @@ Every completion-handler API became `async`. Errors are thrown instead of passed
 | `isFallbackFileAccessible()` | unchanged |
 | `QONEnvironment` on the configuration | Removed — see [The environment flag is gone](#the-environment-flag-is-gone). |
 
+### `identify` accepts a restricted character set
+
+The external id must match `^[a-zA-Z0-9._-]+$` — the backend validates it as a
+path id. Anything outside that set (an `@` in an email, for example) is
+percent-encoded by the SDK and then rejected by the backend, so map such ids to
+a stable opaque value (a hash or your own internal id) before calling
+`identify`.
+
 ### Listeners became streams
 
 Delegate/listener protocols are gone. Both streams follow the style of StoreKit's `Transaction.updates`: every access returns an independent stream, subscribe from as many places as you need, and promo purchase intents arriving before your first subscription are buffered.
@@ -108,10 +116,10 @@ keeps the status-derived type and reaches you as `apiCode`:
 | Backend code | `QonversionErrorType` |
 |---|---|
 | `invalid_data`, `invalid_request`, `validation_error`, `invalid_entitlement_data` | `.invalidRequest` |
-| `not_found`, `relation_not_found`, `user_not_found` | `.resourceNotFound` |
-| `too_many_requests`, `rate_limit_exceeded` | `.rateLimitExceeded` |
+| `not_found`, `relation_not_found` | `.resourceNotFound` |
+| `too_many_requests` | `.rateLimitExceeded` |
 | `purchase_fraud` | `.fraudPurchase` |
-| `store_not_configured`, `store_creds_failed`, `token_not_found`, `secrets_not_found`, `settings_not_found` | `.projectConfigError` |
+| `store_not_configured`, `store_creds_failed`, `token_not_found` | `.projectConfigError` |
 | `subscription_period_parse_error`, `apple_purchase_type_error`, `conflicting_purchase_found` | `.receiptValidationError` |
 
 `.paymentNotAllowed` and `.storeProductNotAvailable` have no backend code — they


### PR DESCRIPTION
…l v4 contract

Recover from the create-user conflict. POST /v4/users answers a uid it already knows with `already_exists` (422). Every install upgraded from the previous SDK generation posts exactly such a uid, because it adopts the one that generation created — so the conflict means "this user exists", not a failure. UserService now fetches the user via GET /v4/users/{id} and the pipeline continues. Only that slug recovers; every other create failure keeps throwing.

Repoint three requests from v4 to v3. The remote-config read, the remote-config list (both query variants) and the offer-signature route are contract-identical on v3 and already accept the SDK's Bearer key, so the backend is not porting them. Experiments and remote-configuration attach/detach stay on v4.

Omit an unknown price or currency from the purchase body. They used to go on the wire as "", which the backend reads as a value and records as a zero-cost purchase; the keys are now simply absent when the transaction has no price.

Drop four slugs no backend emits from the error-code table: user_not_found, rate_limit_exceeded, secrets_not_found, settings_not_found. Throttling arrives as too_many_requests, which stays mapped. No behavior change for real traffic.

MIGRATION.md documents the character set identify() accepts and follows the error-code table.