### PR TITLE
feat(entities): bury offerings, localize originalAppVersion, tolerate…

### DIFF
--- a/Qonversion.xcodeproj/project.pbxproj
+++ b/Qonversion.xcodeproj/project.pbxproj
@@ -105,6 +105,8 @@
 		70CD93222BC6E22B0039D65C /* StoreKitFacade.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70CD92DC2BC6E22B0039D65C /* StoreKitFacade.swift */; };
 		A200000000000000000000B1 /* StoreKitPurchaseOutcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = A200000000000000000000A1 /* StoreKitPurchaseOutcome.swift */; };
 		70CD93232BC6E22B0039D65C /* StoreKitFacadeInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70CD92DD2BC6E22B0039D65C /* StoreKitFacadeInterface.swift */; };
+		A200000000000000000000C2 /* AppTransactionReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A200000000000000000000C1 /* AppTransactionReader.swift */; };
+		A200000000000000000000D2 /* AppTransactionReaderInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = A200000000000000000000D1 /* AppTransactionReaderInterface.swift */; };
 		70CD93242BC6E22B0039D65C /* StoreKitMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70CD92DE2BC6E22B0039D65C /* StoreKitMapper.swift */; };
 		70CD93252BC6E22B0039D65C /* StoreKitMapperInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70CD92DF2BC6E22B0039D65C /* StoreKitMapperInterface.swift */; };
 		70CD93292BC6E22B0039D65C /* StoreKitWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70CD92E32BC6E22B0039D65C /* StoreKitWrapper.swift */; };
@@ -345,6 +347,8 @@
 		70CD92DC2BC6E22B0039D65C /* StoreKitFacade.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreKitFacade.swift; sourceTree = "<group>"; };
 		A200000000000000000000A1 /* StoreKitPurchaseOutcome.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreKitPurchaseOutcome.swift; sourceTree = "<group>"; };
 		70CD92DD2BC6E22B0039D65C /* StoreKitFacadeInterface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreKitFacadeInterface.swift; sourceTree = "<group>"; };
+		A200000000000000000000C1 /* AppTransactionReader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppTransactionReader.swift; sourceTree = "<group>"; };
+		A200000000000000000000D1 /* AppTransactionReaderInterface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppTransactionReaderInterface.swift; sourceTree = "<group>"; };
 		70CD92DE2BC6E22B0039D65C /* StoreKitMapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreKitMapper.swift; sourceTree = "<group>"; };
 		70CD92DF2BC6E22B0039D65C /* StoreKitMapperInterface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreKitMapperInterface.swift; sourceTree = "<group>"; };
 		70CD92E32BC6E22B0039D65C /* StoreKitWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreKitWrapper.swift; sourceTree = "<group>"; };
@@ -837,6 +841,8 @@
 		70CD92E62BC6E22B0039D65C /* StoreKit */ = {
 			isa = PBXGroup;
 			children = (
+				A200000000000000000000C1 /* AppTransactionReader.swift */,
+				A200000000000000000000D1 /* AppTransactionReaderInterface.swift */,
 				70CD92DC2BC6E22B0039D65C /* StoreKitFacade.swift */,
 				A200000000000000000000A1 /* StoreKitPurchaseOutcome.swift */,
 				70CD92DD2BC6E22B0039D65C /* StoreKitFacadeInterface.swift */,
@@ -1247,6 +1253,8 @@
 				70CD93202BC6E22B0039D65C /* UserService.swift in Sources */,
 				70EA73552BD12CA500B0DFDA /* Product.swift in Sources */,
 				70CD93232BC6E22B0039D65C /* StoreKitFacadeInterface.swift in Sources */,
+				A200000000000000000000C2 /* AppTransactionReader.swift in Sources */,
+				A200000000000000000000D2 /* AppTransactionReaderInterface.swift in Sources */,
 				70CD93192BC6E22B0039D65C /* LocalStorageInterface.swift in Sources */,
 				70EA735D2BD6B66300B0DFDA /* ProductsManagerInterface.swift in Sources */,
 				A700000000000000000000B1 /* ProductsDataSource.swift in Sources */,

--- a/Sources/Entities/Product.swift
+++ b/Sources/Entities/Product.swift
@@ -19,10 +19,7 @@ extension Qonversion {
         
         /// The AppStore product identifier.
         public let storeId: String
-        
-        /// The Qonversion offering identifier if product linked to an offering or nil.
-        public let offeringId: String?
-        
+
         /// The localized display name of the product, if it exists.
         public var displayName: String? { storeProduct?.displayName }
 
@@ -101,22 +98,19 @@ extension Qonversion {
             let storeIdentifier: String? = try container.decodeIfPresent(String.self, forKey: .legacyStoreId)
                 ?? container.decodeIfPresent(String.self, forKey: .storeId)
             storeId = storeIdentifier ?? ""
-            offeringId = try container.decodeIfPresent(String.self, forKey: .offeringId)
         }
-        
+
         /// Only the wire fields round-trip — StoreKit enrichment is runtime
         /// state and is re-applied after decoding.
         public func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(qonversionId, forKey: .qonversionId)
             try container.encode(storeId, forKey: .storeId)
-            try container.encodeIfPresent(offeringId, forKey: .offeringId)
         }
 
-        init(qonversionId: String, storeId: String, offeringId: String?) {
+        init(qonversionId: String, storeId: String) {
             self.qonversionId = qonversionId
             self.storeId = storeId
-            self.offeringId = offeringId
         }
         
         // MARK: - Nested structures and enums
@@ -411,7 +405,6 @@ extension Qonversion {
             case storeId = "apple_product_id"
             /// The fallback file's spelling of `storeId` — see init(from:).
             case legacyStoreId = "store_id"
-            case offeringId = "offering_id"
         }
     }
 }

--- a/Sources/Entities/RemoteConfig.swift
+++ b/Sources/Entities/RemoteConfig.swift
@@ -96,10 +96,10 @@ extension Qonversion {
         /// Experiment info
         public let experiment: Experiment?
 
-        /// Remote configuration source
-        public let source: Source
+        /// Remote configuration source, or nil when the backend reports none.
+        public let source: Source?
 
-        init(payload: [String: String]?, experiment: Experiment?, source: Source) {
+        init(payload: [String: String]?, experiment: Experiment?, source: Source?) {
             self.payload = payload
             self.experiment = experiment
             self.source = source
@@ -116,7 +116,10 @@ extension Qonversion {
             // Absent keys must decode like explicit nulls — a config without
             // an experiment is the normal shape, not a decode failure.
             experiment = try container.decodeIfPresent(Experiment.self, forKey: .experiment)
-            source = try container.decode(Source.self, forKey: .source)
+            // The backend serializes the source from a pointer without
+            // omitempty, so an unassigned config arrives with an explicit
+            // null — that is a config without a source, not a broken payload.
+            source = try container.decodeIfPresent(Source.self, forKey: .source)
         }
         
         // MARK: - Private

--- a/Sources/Entities/RemoteConfigList.swift
+++ b/Sources/Entities/RemoteConfigList.swift
@@ -61,7 +61,7 @@ extension Qonversion.RemoteConfigList {
     
     private func findRemoteConfig(for contextKey: String?) -> Qonversion.RemoteConfig? {
         return remoteConfigs.first { config in
-            return (contextKey == nil && config.source.contextKey == nil) || config.source.contextKey == contextKey
+            return (contextKey == nil && config.source?.contextKey == nil) || config.source?.contextKey == contextKey
         }
     }
 }

--- a/Sources/Entities/User.swift
+++ b/Sources/Entities/User.swift
@@ -21,29 +21,24 @@ extension Qonversion {
             case creationDate = "created_at"
             case identityId = "identity_id"
             case environment
-            case appleExtra = "apple_extra"
+            // Written and read by the local store only — the backend neither
+            // serves nor accepts this field.
+            case originalAppVersion = "original_app_version"
         }
 
-        private struct AppleExtra: Codable {
-            let originalApplicationVersion: String?
-
-            private enum CodingKeys: String, CodingKey {
-                case originalApplicationVersion = "original_application_version"
-            }
-        }
-        
         /// Qonversion User ID
         public let id: String
-        
+
         /// Date when the user was created
         public let creationDate: Date?
 
         /// The integrator's identity linked to the user, if any
         public let identityId: String?
 
-        /// The app version the user originally purchased from the App Store —
+        /// The app version the user originally downloaded from the App Store —
         /// useful to grandfather users of older versions. Nil when the store
-        /// has not reported it (yet).
+        /// does not report it: below iOS 16, macOS 13, tvOS 16 or watchOS 9,
+        /// and whenever the store cannot be reached.
         public let originalAppVersion: String?
         
         let environment: User.Environment
@@ -64,8 +59,7 @@ extension Qonversion {
             // Tolerant: an unknown environment value must not fail the decode.
             let rawEnvironment = try container.decodeIfPresent(String.self, forKey: .environment)
             environment = rawEnvironment.flatMap { User.Environment(rawValue: $0) } ?? .production
-            let appleExtra: AppleExtra? = try? container.decodeIfPresent(AppleExtra.self, forKey: .appleExtra)
-            originalAppVersion = appleExtra?.originalApplicationVersion
+            originalAppVersion = try? container.decodeIfPresent(String.self, forKey: .originalAppVersion)
         }
 
         public func encode(to encoder: Encoder) throws {
@@ -74,9 +68,11 @@ extension Qonversion {
             try container.encodeIfPresent(creationDate, forKey: .creationDate)
             try container.encodeIfPresent(identityId, forKey: .identityId)
             try container.encode(environment, forKey: .environment)
-            if let originalAppVersion {
-                try container.encode(AppleExtra(originalApplicationVersion: originalAppVersion), forKey: .appleExtra)
-            }
+            try container.encodeIfPresent(originalAppVersion, forKey: .originalAppVersion)
+        }
+
+        func with(originalAppVersion: String) -> User {
+            User(id: id, creationDate: creationDate, identityId: identityId, environment: environment, originalAppVersion: originalAppVersion)
         }
     }
 }

--- a/Sources/Managers/PurchasesManager/PurchasesManager.swift
+++ b/Sources/Managers/PurchasesManager/PurchasesManager.swift
@@ -600,7 +600,7 @@ extension PurchasesManager: StoreKitFacadeDelegate {
         let intent: Qonversion.PromoPurchaseIntent = Qonversion.PromoPurchaseIntent(productId: storeProductId) { [weak self] options in
             guard let self else { throw QonversionError.initializationError() }
 
-            return try await self.purchase(Qonversion.Product(qonversionId: storeProductId, storeId: storeProductId, offeringId: nil), options: options)
+            return try await self.purchase(Qonversion.Product(qonversionId: storeProductId, storeId: storeProductId), options: options)
         }
 
         promoIntentsMulticast.yield(intent)

--- a/Sources/Managers/RemoteConfig/RemoteConfigManager.swift
+++ b/Sources/Managers/RemoteConfig/RemoteConfigManager.swift
@@ -193,7 +193,7 @@ final class RemoteConfigManager: RemoteConfigManagerInterface, @unchecked Sendab
 
             logger.warning("Remote config list request failed, using the bundled fallback file: " + error.message)
             let matching: [Qonversion.RemoteConfig] = allConfigs.filter { config in
-                if let contextKey: String = config.source.contextKey {
+                if let contextKey: String = config.source?.contextKey {
                     return contextKeys.contains(contextKey)
                 }
                 return includeEmptyContextKey
@@ -243,7 +243,7 @@ final class RemoteConfigManager: RemoteConfigManagerInterface, @unchecked Sendab
     private func fallbackRemoteConfig(for key: String) -> Qonversion.RemoteConfig? {
         guard let configs: [Qonversion.RemoteConfig] = fallbackService.obtainFallbackData()?.remoteConfigs else { return nil }
 
-        return configs.first { ($0.source.contextKey ?? Constants.emptyContextKey.rawValue) == key }
+        return configs.first { ($0.source?.contextKey ?? Constants.emptyContextKey.rawValue) == key }
     }
 
     private func currentGeneration() -> Int {
@@ -265,7 +265,7 @@ final class RemoteConfigManager: RemoteConfigManagerInterface, @unchecked Sendab
         guard generation == cacheGeneration else { return }
 
         remoteConfigList.remoteConfigs.forEach { remoteConfig in
-            let contextKey: String = remoteConfig.source.contextKey ?? Constants.emptyContextKey.rawValue
+            let contextKey: String = remoteConfig.source?.contextKey ?? Constants.emptyContextKey.rawValue
             loadedConfigs[contextKey] = remoteConfig
         }
     }

--- a/Sources/Managers/UserManager/UserManager.swift
+++ b/Sources/Managers/UserManager/UserManager.swift
@@ -20,6 +20,7 @@ actor UserManager: UserManagerInterface {
     private let internalConfig: InternalConfig
     private let userChangesNotifier: UserChangesNotifierInterface
     private let logger: LoggerWrapper
+    private let appTransactionReader: AppTransactionReaderInterface
 
     /// The shared "promise": creation of the backend user plus, when an
     /// identify is pending, the identity request. Waiters await this task and
@@ -44,12 +45,13 @@ actor UserManager: UserManagerInterface {
         let identityError: Error?
     }
 
-    init(userService: UserServiceInterface, localStorage: LocalStorageInterface, internalConfig: InternalConfig, userChangesNotifier: UserChangesNotifierInterface, logger: LoggerWrapper) {
+    init(userService: UserServiceInterface, localStorage: LocalStorageInterface, internalConfig: InternalConfig, userChangesNotifier: UserChangesNotifierInterface, logger: LoggerWrapper, appTransactionReader: AppTransactionReaderInterface = AppTransactionReader()) {
         self.userService = userService
         self.localStorage = localStorage
         self.internalConfig = internalConfig
         self.userChangesNotifier = userChangesNotifier
         self.logger = logger
+        self.appTransactionReader = appTransactionReader
     }
 
     @discardableResult
@@ -201,7 +203,8 @@ actor UserManager: UserManagerInterface {
         try await obtainUser()
 
         do {
-            let user: Qonversion.User = try await userService.user()
+            let fetched: Qonversion.User = try await userService.user()
+            let user: Qonversion.User = await stamped(fetched)
             persist(user)
             cachedUser = user
 
@@ -218,8 +221,18 @@ actor UserManager: UserManagerInterface {
             guard let local: Qonversion.User = currentUser() else { throw error.classifiedForPublicAPI }
 
             logger.warning("The user request failed, answering from the persisted user: " + error.message)
-            return local
+            return await stamped(local)
         }
+    }
+
+    /// The original app version is device-local: the backend never serves it,
+    /// so it is resolved from the store and stamped onto the user on the way
+    /// out. A store that cannot answer leaves whatever the user already
+    /// carries, which is the value persisted by an earlier successful read.
+    private func stamped(_ user: Qonversion.User) async -> Qonversion.User {
+        guard let originalAppVersion: String = await appTransactionReader.originalAppVersion() else { return user }
+
+        return user.with(originalAppVersion: originalAppVersion)
     }
 
     /// Cancellation reaches the SDK in more than one shape: a task cancelled

--- a/Sources/StoreKit/AppTransactionReader.swift
+++ b/Sources/StoreKit/AppTransactionReader.swift
@@ -1,0 +1,61 @@
+//
+//  AppTransactionReader.swift
+//  Qonversion
+//
+
+import Foundation
+import StoreKit
+
+/// Reads the original app version from the StoreKit app transaction.
+///
+/// The value never changes for an install, and the underlying read may hit the
+/// network, so it is resolved once per process: the first caller starts the
+/// read, concurrent callers join it, and everyone afterwards gets the settled
+/// answer without touching StoreKit again. A failed read settles as "unknown"
+/// rather than retrying — the field is informational and must never cost the
+/// host a stalled user request.
+///
+/// The store read is injectable so the resolution rules can be tested without
+/// a StoreKit session, mirroring `AdvertisingIdReader.RawIdentifierReader`.
+actor AppTransactionReader: AppTransactionReaderInterface {
+
+    typealias OriginalAppVersionReader = @Sendable () async throws -> String?
+
+    private let readOriginalAppVersion: OriginalAppVersionReader
+
+    /// Double optional: the outer level marks "already resolved", the inner one
+    /// carries the answer, which is legitimately nil on old systems.
+    private var resolved: String??
+    private var inFlight: Task<String?, Never>?
+
+    init(originalAppVersionReader: @escaping OriginalAppVersionReader = AppTransactionReader.storeOriginalAppVersion) {
+        self.readOriginalAppVersion = originalAppVersionReader
+    }
+
+    func originalAppVersion() async -> String? {
+        if let resolved { return resolved }
+        if let inFlight { return await inFlight.value }
+
+        let read: OriginalAppVersionReader = readOriginalAppVersion
+        let task = Task<String?, Never> { try? await read() }
+        inFlight = task
+
+        let version: String? = await task.value
+        resolved = .some(version)
+        inFlight = nil
+
+        return version
+    }
+
+    /// The StoreKit 2 app transaction is unavailable below iOS 16, macOS 13,
+    /// tvOS 16 and watchOS 9 — there the version is simply unknown.
+    @Sendable
+    static func storeOriginalAppVersion() async throws -> String? {
+        guard #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, visionOS 1.0, *) else { return nil }
+
+        let result: VerificationResult<AppTransaction> = try await AppTransaction.shared
+        guard case .verified(let appTransaction) = result else { return nil }
+
+        return appTransaction.originalAppVersion
+    }
+}

--- a/Sources/StoreKit/AppTransactionReaderInterface.swift
+++ b/Sources/StoreKit/AppTransactionReaderInterface.swift
@@ -1,0 +1,14 @@
+//
+//  AppTransactionReaderInterface.swift
+//  Qonversion
+//
+
+import Foundation
+
+/// Supplies the app version the user originally downloaded from the App Store.
+protocol AppTransactionReaderInterface: Sendable {
+
+    /// The original app version, or nil when the store does not report one.
+    /// Never throws: an unknown version is a valid answer.
+    func originalAppVersion() async -> String?
+}

--- a/Tests/QonversionUnitTests/AppTransactionReaderTests.swift
+++ b/Tests/QonversionUnitTests/AppTransactionReaderTests.swift
@@ -1,0 +1,95 @@
+//
+//  AppTransactionReaderTests.swift
+//  QonversionUnitTests
+//
+//  Contract tests for the original app version seam: the store is read once
+//  per process, and no store failure ever reaches the caller.
+//
+
+import XCTest
+@testable import Qonversion
+
+final class AppTransactionReaderTests: XCTestCase {
+
+    /// Counts the store reads a reader performs.
+    private final class ReadCounter: @unchecked Sendable {
+        private let lock = NSLock()
+        private var count = 0
+
+        func increment() {
+            lock.lock()
+            count += 1
+            lock.unlock()
+        }
+
+        var value: Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return count
+        }
+    }
+
+    func testAnswersTheVersionTheStoreReports() async {
+        let reader = AppTransactionReader { "1.0.3" }
+
+        let version = await reader.originalAppVersion()
+
+        XCTAssertEqual(version, "1.0.3")
+    }
+
+    func testAStoreFailureBecomesNilInsteadOfThrowing() async {
+        let reader = AppTransactionReader { throw MockError.stubbed }
+
+        let version = await reader.originalAppVersion()
+
+        XCTAssertNil(version)
+    }
+
+    func testTheStoreIsReadOnlyOnce() async {
+        let counter = ReadCounter()
+        let reader = AppTransactionReader {
+            counter.increment()
+            return "1.0.3"
+        }
+
+        _ = await reader.originalAppVersion()
+        _ = await reader.originalAppVersion()
+        let third = await reader.originalAppVersion()
+
+        XCTAssertEqual(third, "1.0.3")
+        XCTAssertEqual(counter.value, 1)
+    }
+
+    func testAFailedReadIsNotRetried() async {
+        // The version is informational: retrying on every user request would
+        // spend a store round trip per call for a field nobody blocks on.
+        let counter = ReadCounter()
+        let reader = AppTransactionReader {
+            counter.increment()
+            throw MockError.stubbed
+        }
+
+        _ = await reader.originalAppVersion()
+        _ = await reader.originalAppVersion()
+
+        XCTAssertEqual(counter.value, 1)
+    }
+
+    func testConcurrentCallersShareOneRead() async {
+        let counter = ReadCounter()
+        let reader = AppTransactionReader {
+            counter.increment()
+            try await Task.sleep(nanoseconds: 50_000_000)
+            return "1.0.3"
+        }
+
+        async let first = reader.originalAppVersion()
+        async let second = reader.originalAppVersion()
+        async let third = reader.originalAppVersion()
+
+        let versions = await [first, second, third]
+
+        XCTAssertEqual(versions, ["1.0.3", "1.0.3", "1.0.3"])
+        XCTAssertEqual(counter.value, 1)
+    }
+}

--- a/Tests/QonversionUnitTests/EntitiesDecodingTests.swift
+++ b/Tests/QonversionUnitTests/EntitiesDecodingTests.swift
@@ -112,11 +112,31 @@ final class EntitiesDecodingTests: XCTestCase {
         let remoteConfig = try decode(Qonversion.RemoteConfig.self, json)
 
         // "uid" maps to identifier, snake_case fields map to camelCase properties.
-        XCTAssertEqual(remoteConfig.source.identifier, "source_uid")
-        XCTAssertEqual(remoteConfig.source.name, "Source name")
-        XCTAssertEqual(remoteConfig.source.type, .experimentControlGroup)
-        XCTAssertEqual(remoteConfig.source.assignmentType, .manual)
-        XCTAssertEqual(remoteConfig.source.contextKey, "main")
+        XCTAssertEqual(remoteConfig.source?.identifier, "source_uid")
+        XCTAssertEqual(remoteConfig.source?.name, "Source name")
+        XCTAssertEqual(remoteConfig.source?.type, .experimentControlGroup)
+        XCTAssertEqual(remoteConfig.source?.assignmentType, .manual)
+        XCTAssertEqual(remoteConfig.source?.contextKey, "main")
+    }
+
+    func testRemoteConfigDecodesWithANullSource() throws {
+        // The backend serializes source from a pointer without omitempty, so
+        // an unassigned config arrives as an explicit null. That is a config
+        // without a source, never a broken payload.
+        let json = #"{"payload": {"key": "value"}, "experiment": null, "source": null}"#
+
+        let remoteConfig = try decode(Qonversion.RemoteConfig.self, json)
+
+        XCTAssertNil(remoteConfig.source)
+        XCTAssertEqual(remoteConfig.payload?["key"] as? String, "value")
+    }
+
+    func testRemoteConfigDecodesWithAMissingSource() throws {
+        let json = #"{"payload": {"key": "value"}}"#
+
+        let remoteConfig = try decode(Qonversion.RemoteConfig.self, json)
+
+        XCTAssertNil(remoteConfig.source)
     }
 
     func testRemoteConfigDecodingNullPayloadBecomesNil() throws {
@@ -133,7 +153,7 @@ final class EntitiesDecodingTests: XCTestCase {
 
         let remoteConfig = try decode(Qonversion.RemoteConfig.self, json)
 
-        XCTAssertNil(remoteConfig.source.contextKey)
+        XCTAssertNil(remoteConfig.source?.contextKey)
     }
 
     func testRemoteConfigSourceNullContextKeyBecomesNil() throws {
@@ -141,7 +161,7 @@ final class EntitiesDecodingTests: XCTestCase {
 
         let remoteConfig = try decode(Qonversion.RemoteConfig.self, json)
 
-        XCTAssertNil(remoteConfig.source.contextKey)
+        XCTAssertNil(remoteConfig.source?.contextKey)
     }
 
     func testOneMalformedEntitlementDoesNotNullTheWholeList() throws {
@@ -170,7 +190,7 @@ final class EntitiesDecodingTests: XCTestCase {
 
         let remoteConfig = try decode(Qonversion.RemoteConfig.self, json)
 
-        XCTAssertNil(remoteConfig.source.contextKey)
+        XCTAssertNil(remoteConfig.source?.contextKey)
     }
 
 
@@ -195,8 +215,8 @@ final class EntitiesDecodingTests: XCTestCase {
 
         let config = try JSONDecoder.qonversionTest.decode(Qonversion.RemoteConfig.self, from: Data(json.utf8))
 
-        XCTAssertEqual(config.source.type, .unknown)
-        XCTAssertEqual(config.source.assignmentType, .unknown)
+        XCTAssertEqual(config.source?.type, .unknown)
+        XCTAssertEqual(config.source?.assignmentType, .unknown)
     }
 
     func testUnknownExperimentGroupTypeFallsBackToUnknown() throws {
@@ -237,7 +257,7 @@ final class EntitiesDecodingTests: XCTestCase {
         let list = try decode(Qonversion.RemoteConfigList.self, json)
 
         XCTAssertEqual(list.remoteConfigs.count, 1)
-        XCTAssertEqual(list.remoteConfigs[0].source.identifier, "source_uid")
+        XCTAssertEqual(list.remoteConfigs[0].source?.identifier, "source_uid")
     }
 
     func testRemoteConfigListSkipsAMalformedRowOfTheBareArray() throws {
@@ -256,7 +276,7 @@ final class EntitiesDecodingTests: XCTestCase {
         let list = try decode(Qonversion.RemoteConfigList.self, json)
 
         XCTAssertEqual(list.remoteConfigs.count, 1)
-        XCTAssertEqual(list.remoteConfigs[0].source.identifier, "source_uid")
+        XCTAssertEqual(list.remoteConfigs[0].source?.identifier, "source_uid")
     }
 
     func testRemoteConfigListLookupByContextKeyAndEmptyContextKey() {
@@ -267,9 +287,9 @@ final class EntitiesDecodingTests: XCTestCase {
             Qonversion.RemoteConfig(payload: nil, experiment: nil, source: emptySource)
         ])
 
-        XCTAssertEqual(list.remoteConfig(for: "main")?.source.identifier, "rc_main")
+        XCTAssertEqual(list.remoteConfig(for: "main")?.source?.identifier, "rc_main")
         XCTAssertNil(list.remoteConfig(for: "unknown"))
-        XCTAssertEqual(list.remoteConfigForEmptyContextKey()?.source.identifier, "rc_empty")
+        XCTAssertEqual(list.remoteConfigForEmptyContextKey()?.source?.identifier, "rc_empty")
     }
 
     // MARK: - UserProperty
@@ -769,36 +789,32 @@ final class EntitiesDecodingTests: XCTestCase {
     // MARK: - Product
 
     func testProductDecodingUsesV4Keys() throws {
-        // v4 wire keys: id / apple_product_id / offering_id; extra fields are
-        // ignored and the store product stays unlinked.
-        let json = #"{"id": "main", "apple_product_id": "com.app.main", "offering_id": "offering_1", "type": "subscription", "created_at": "2024-01-01T00:00:00Z"}"#
+        // v4 wire keys: id / apple_product_id; extra fields are ignored and the
+        // store product stays unlinked.
+        let json = #"{"id": "main", "apple_product_id": "com.app.main", "type": "subscription", "created_at": "2024-01-01T00:00:00Z"}"#
 
         let product = try decode(Qonversion.Product.self, json)
 
         XCTAssertEqual(product.qonversionId, "main")
         XCTAssertEqual(product.storeId, "com.app.main")
-        XCTAssertEqual(product.offeringId, "offering_1")
         XCTAssertFalse(product.isStoreProductLinked)
         XCTAssertNil(product.displayName)
         XCTAssertNil(product.price)
         XCTAssertFalse(product.isStoreProductLinked)
     }
 
-    func testProductDecodesWithNullOfferingId() throws {
-        // A product outside any offering is valid: offeringId is optional.
-        let json = #"{"id": "main", "apple_product_id": "com.app.main", "offering_id": null}"#
+    func testProductIgnoresAnOfferingIdOnTheWire() throws {
+        // Offerings are gone platform-wide: the backend never answers
+        // offering_id, and a stray one must not reach any SDK surface.
+        let json = #"{"id": "main", "apple_product_id": "com.app.main", "offering_id": "offering_1"}"#
 
         let product = try decode(Qonversion.Product.self, json)
+        let encoded = try JSONEncoder().encode(product)
+        let fields = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
 
-        XCTAssertNil(product.offeringId)
-    }
-
-    func testProductDecodesWithMissingOfferingId() throws {
-        let json = #"{"id": "main", "apple_product_id": "com.app.main"}"#
-
-        let product = try decode(Qonversion.Product.self, json)
-
-        XCTAssertNil(product.offeringId)
+        XCTAssertEqual(product.qonversionId, "main")
+        XCTAssertEqual(product.storeId, "com.app.main")
+        XCTAssertFalse(fields.keys.contains("offering_id"))
     }
 }
 
@@ -854,30 +870,34 @@ final class ToleratedDecodingTests: XCTestCase {
 
     // MARK: - originalAppVersion
 
-    func testUserDecodesTheOriginalAppVersion() throws {
+    func testUserIgnoresAppleExtraOnTheWire() throws {
+        // The backend does not serve apple_extra: originalAppVersion is read
+        // from StoreKit on the device, so a stray field must not feed it.
         let json = #"{"id": "QON_abc", "apple_extra": {"original_application_version": "1.0.3"}}"#
-
-        let user = try sdkDecoder().decode(Qonversion.User.self, from: Data(json.utf8))
-
-        XCTAssertEqual(user.originalAppVersion, "1.0.3")
-    }
-
-    func testUserToleratesAMissingAppleExtra() throws {
-        let json = #"{"id": "QON_abc"}"#
 
         let user = try sdkDecoder().decode(Qonversion.User.self, from: Data(json.utf8))
 
         XCTAssertNil(user.originalAppVersion)
     }
 
-    func testUserOriginalAppVersionSurvivesTheStorageRoundtrip() throws {
-        let json = #"{"id": "QON_abc", "apple_extra": {"original_application_version": "1.0.3"}}"#
-        let decoder: JSONDecoder = sdkDecoder()
-        let user = try decoder.decode(Qonversion.User.self, from: Data(json.utf8))
+    func testUserEncodingCarriesNoAppleExtra() throws {
+        let user = Qonversion.User(id: "QON_abc", originalAppVersion: "1.0.3")
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
 
-        let restored = try decoder.decode(Qonversion.User.self, from: try encoder.encode(user))
+        let fields = try XCTUnwrap(JSONSerialization.jsonObject(with: try encoder.encode(user)) as? [String: Any])
+
+        XCTAssertFalse(fields.keys.contains("apple_extra"))
+    }
+
+    func testUserOriginalAppVersionSurvivesTheStorageRoundtrip() throws {
+        // The locally resolved version is persisted with the user, so a
+        // cached user carries it without a second StoreKit read.
+        let user = Qonversion.User(id: "QON_abc", originalAppVersion: "1.0.3")
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+
+        let restored = try sdkDecoder().decode(Qonversion.User.self, from: try encoder.encode(user))
 
         XCTAssertEqual(restored.originalAppVersion, "1.0.3")
     }
@@ -916,6 +936,6 @@ final class ToleratedDecodingTests: XCTestCase {
 
         let list = try sdkDecoder().decode(Qonversion.RemoteConfigList.self, from: Data(json.utf8))
 
-        XCTAssertEqual(list.remoteConfigs.map { $0.source.identifier }, ["s1"])
+        XCTAssertEqual(list.remoteConfigs.map { $0.source?.identifier }, ["s1"])
     }
 }

--- a/Tests/QonversionUnitTests/EntitlementsCalculatorTests.swift
+++ b/Tests/QonversionUnitTests/EntitlementsCalculatorTests.swift
@@ -16,7 +16,7 @@ final class EntitlementsCalculatorTests: XCTestCase {
     private let now = Date(timeIntervalSince1970: 1_700_000_000)
 
     private func makeProduct(qonversionId: String = "pro", storeId: String = "com.app.pro", periodUnit: Qonversion.Product.SubscriptionPeriod.Unit? = .month, periodValue: Int = 1) -> Qonversion.Product {
-        var product = Qonversion.Product(qonversionId: qonversionId, storeId: storeId, offeringId: nil)
+        var product = Qonversion.Product(qonversionId: qonversionId, storeId: storeId)
         if let periodUnit {
             product.subscription = Qonversion.Product.SubscriptionInfo(
                 subscriptionGroupId: "group",
@@ -39,7 +39,7 @@ final class EntitlementsCalculatorTests: XCTestCase {
             id: "t1", productId: "com.app.pro",
             purchaseDate: Date(timeIntervalSince1970: 1_700_000_000)
         )
-        var product = Qonversion.Product(qonversionId: "pro", storeId: "com.app.pro", offeringId: nil)
+        var product = Qonversion.Product(qonversionId: "pro", storeId: "com.app.pro")
         let period = Qonversion.Product.SubscriptionPeriod(unit: .year, value: 1)
         product.subscription = Qonversion.Product.SubscriptionInfo(subscriptionGroupId: "g", subscriptionPeriod: period)
 

--- a/Tests/QonversionUnitTests/EntitlementsManagerTests.swift
+++ b/Tests/QonversionUnitTests/EntitlementsManagerTests.swift
@@ -92,7 +92,7 @@ final class EntitlementsManagerTests: XCTestCase {
 
     private func setupLocalCalculationContext() {
         // A month subscription bought recently + mapping — the local path can grant "premium".
-        var product = Qonversion.Product(qonversionId: "pro", storeId: "com.app.pro", offeringId: nil)
+        var product = Qonversion.Product(qonversionId: "pro", storeId: "com.app.pro")
         product.subscription = Qonversion.Product.SubscriptionInfo(
             subscriptionGroupId: "g",
             subscriptionPeriod: Qonversion.Product.SubscriptionPeriod(unit: .month, value: 1)

--- a/Tests/QonversionUnitTests/FallbackServiceTests.swift
+++ b/Tests/QonversionUnitTests/FallbackServiceTests.swift
@@ -41,7 +41,7 @@ final class FallbackServiceTests: XCTestCase {
         {
             "products": [
                 {"id": "pro", "apple_product_id": "com.app.pro"},
-                {"id": "lite", "apple_product_id": "com.app.lite", "offering_id": "main"}
+                {"id": "lite", "apple_product_id": "com.app.lite"}
             ],
             "products_permissions": {"pro": ["premium"], "lite": ["basic"]}
         }
@@ -51,7 +51,7 @@ final class FallbackServiceTests: XCTestCase {
         let fallback = service.obtainFallbackData()
 
         XCTAssertEqual(fallback?.products?.map(\.qonversionId), ["pro", "lite"])
-        XCTAssertEqual(fallback?.products?.last?.offeringId, "main")
+        XCTAssertEqual(fallback?.products?.last?.storeId, "com.app.lite")
         XCTAssertEqual(fallback?.productsPermissions, ["pro": ["premium"], "lite": ["basic"]])
     }
 
@@ -77,9 +77,9 @@ final class FallbackServiceTests: XCTestCase {
         let fallback = service.obtainFallbackData()
 
         XCTAssertEqual(fallback?.remoteConfigs?.count, 2)
-        XCTAssertEqual(fallback?.remoteConfigs?.first?.source.contextKey, "main")
+        XCTAssertEqual(fallback?.remoteConfigs?.first?.source?.contextKey, "main")
         XCTAssertEqual(fallback?.remoteConfigs?.first?.payload?["title"] as? String, "Fallback title")
-        XCTAssertNil(fallback?.remoteConfigs?.last?.source.contextKey)
+        XCTAssertNil(fallback?.remoteConfigs?.last?.source?.contextKey)
     }
 
     // MARK: - the shipped ObjC contract
@@ -152,7 +152,7 @@ final class FallbackServiceTests: XCTestCase {
         let fallback = service.obtainFallbackData()
 
         XCTAssertEqual(fallback?.products?.map(\.qonversionId), ["pro"])
-        XCTAssertEqual(fallback?.remoteConfigs?.map { $0.source.identifier }, ["src-1"])
+        XCTAssertEqual(fallback?.remoteConfigs?.map { $0.source?.identifier }, ["src-1"])
     }
 
     func testOneMalformedPermissionsRelationDoesNotKillTheOthers() throws {

--- a/Tests/QonversionUnitTests/IntroEligibilityTests.swift
+++ b/Tests/QonversionUnitTests/IntroEligibilityTests.swift
@@ -47,7 +47,7 @@ final class IntroEligibilityTests: XCTestCase {
     // MARK: - Helpers
 
     private func makeProduct(qonversionId: String, storeId: String) -> Qonversion.Product {
-        return Qonversion.Product(qonversionId: qonversionId, storeId: storeId, offeringId: nil)
+        return Qonversion.Product(qonversionId: qonversionId, storeId: storeId)
     }
 
     private func makeIntroOffer() -> Qonversion.Product.SubscriptionOffer {

--- a/Tests/QonversionUnitTests/Mocks.swift
+++ b/Tests/QonversionUnitTests/Mocks.swift
@@ -988,3 +988,16 @@ final class MockDeviceService: DeviceServiceInterface {
         return updateResult ?? device
     }
 }
+
+// MARK: - App transaction
+
+final class MockAppTransactionReader: AppTransactionReaderInterface, @unchecked Sendable {
+
+    var originalAppVersionResult: String?
+    private(set) var callsCount = 0
+
+    func originalAppVersion() async -> String? {
+        callsCount += 1
+        return originalAppVersionResult
+    }
+}

--- a/Tests/QonversionUnitTests/ProductsManagerTests.swift
+++ b/Tests/QonversionUnitTests/ProductsManagerTests.swift
@@ -61,7 +61,7 @@ final class ProductsManagerTests: XCTestCase {
     // MARK: - Helpers
 
     private func makeProduct(qonversionId: String = "q_main", storeId: String = "store_main") -> Qonversion.Product {
-        return Qonversion.Product(qonversionId: qonversionId, storeId: storeId, offeringId: nil)
+        return Qonversion.Product(qonversionId: qonversionId, storeId: storeId)
     }
 
     func testConcurrentProductsCallsShareOneRound() async throws {
@@ -829,7 +829,7 @@ final class ProductsStorefrontTests: XCTestCase {
     }
 
     func testStorefrontChangeDropsTheEnrichedCatalog() async throws {
-        productsService.productsResult = [Qonversion.Product(qonversionId: "q", storeId: "s", offeringId: nil)]
+        productsService.productsResult = [Qonversion.Product(qonversionId: "q", storeId: "s")]
         _ = try await manager.products()
         XCTAssertFalse(manager.loadedProducts.isEmpty)
 
@@ -846,7 +846,7 @@ final class ProductsStorefrontTests: XCTestCase {
         // offers belong to the old storefront and must never land in the cache
         // the change just dropped.
         let gate = ProductsAsyncGate()
-        productsService.productsResult = [Qonversion.Product(qonversionId: "q", storeId: "s", offeringId: nil)]
+        productsService.productsResult = [Qonversion.Product(qonversionId: "q", storeId: "s")]
         productsService.onProducts = { await gate.wait() }
         manager.startObservingStorefrontChanges()
         await waitUntil { self.storeKitFacade.hasStorefrontSubscriber }
@@ -863,7 +863,7 @@ final class ProductsStorefrontTests: XCTestCase {
 
     func testALoadStartedAfterTheChangeIsNotJoinedToThePreChangeOne() async throws {
         let gate = ProductsAsyncGate()
-        productsService.productsResult = [Qonversion.Product(qonversionId: "q", storeId: "s", offeringId: nil)]
+        productsService.productsResult = [Qonversion.Product(qonversionId: "q", storeId: "s")]
         productsService.onProducts = { await gate.wait() }
         manager.startObservingStorefrontChanges()
         await waitUntil { self.storeKitFacade.hasStorefrontSubscriber }

--- a/Tests/QonversionUnitTests/ProductsServiceTests.swift
+++ b/Tests/QonversionUnitTests/ProductsServiceTests.swift
@@ -16,8 +16,8 @@ final class ProductsServiceTests: XCTestCase {
         let service = ProductsService(requestProcessor: processor, internalConfig: config)
 
         let stubProducts: [Qonversion.Product] = [
-            Qonversion.Product(qonversionId: "main", storeId: "com.app.main", offeringId: "offering_1"),
-            Qonversion.Product(qonversionId: "secondary", storeId: "com.app.secondary", offeringId: nil)
+            Qonversion.Product(qonversionId: "main", storeId: "com.app.main"),
+            Qonversion.Product(qonversionId: "secondary", storeId: "com.app.secondary")
         ]
         processor.results = [ListEnvelope<Qonversion.Product>(data: stubProducts)]
 
@@ -27,9 +27,8 @@ final class ProductsServiceTests: XCTestCase {
         XCTAssertEqual(products.count, 2)
         XCTAssertEqual(products[0].qonversionId, "main")
         XCTAssertEqual(products[0].storeId, "com.app.main")
-        XCTAssertEqual(products[0].offeringId, "offering_1")
         XCTAssertEqual(products[1].qonversionId, "secondary")
-        XCTAssertNil(products[1].offeringId)
+        XCTAssertEqual(products[1].storeId, "com.app.secondary")
     }
 
     func testProductsReturnsEmptyArrayFromProcessor() async throws {

--- a/Tests/QonversionUnitTests/PurchasesManagerTests.swift
+++ b/Tests/QonversionUnitTests/PurchasesManagerTests.swift
@@ -68,7 +68,7 @@ final class PurchasesManagerTests: XCTestCase {
     }
 
     private func makeProduct(storeId: String = "com.app.pro") -> Qonversion.Product {
-        Qonversion.Product(qonversionId: "pro", storeId: storeId, offeringId: nil)
+        Qonversion.Product(qonversionId: "pro", storeId: storeId)
     }
 
     private func makeTransaction(id: String, productId: String = "com.app.pro", purchaseDate: Date? = nil, jws: String? = "jws-proof") -> Qonversion.Transaction {

--- a/Tests/QonversionUnitTests/QonversionFacadeTests.swift
+++ b/Tests/QonversionUnitTests/QonversionFacadeTests.swift
@@ -127,7 +127,7 @@ final class QonversionFacadeTests: XCTestCase {
 
     func testPurchaseThrowsInitializationErrorBeforeInitialize() async {
         do {
-            _ = try await Qonversion.shared.purchase(Qonversion.Product(qonversionId: "p", storeId: "s", offeringId: nil))
+            _ = try await Qonversion.shared.purchase(Qonversion.Product(qonversionId: "p", storeId: "s"))
             XCTFail("Expected initialization error")
         } catch let error as QonversionError {
             XCTAssertEqual(error.type, .sdkInitializationError)
@@ -206,7 +206,7 @@ final class QonversionFacadeTests: XCTestCase {
               let userManager = assembly.userManager() as? UserManager else {
             return XCTFail("Unexpected assembly types")
         }
-        productsManager.loadedProducts = [Qonversion.Product(qonversionId: "q", storeId: "s", offeringId: nil)]
+        productsManager.loadedProducts = [Qonversion.Product(qonversionId: "q", storeId: "s")]
 
         // Move away from the original anonymous user first — a logout on the
         // original user is deliberately a no-op.

--- a/Tests/QonversionUnitTests/RemoteConfigManagerTests.swift
+++ b/Tests/QonversionUnitTests/RemoteConfigManagerTests.swift
@@ -75,7 +75,7 @@ final class RemoteConfigManagerTests: XCTestCase {
 
         let config = try await manager.loadRemoteConfig(contextKey: "main")
 
-        XCTAssertEqual(config.source.identifier, "fallback-main")
+        XCTAssertEqual(config.source?.identifier, "fallback-main")
     }
 
     func testFallbackMatchesTheEmptyContextKey() async throws {
@@ -84,7 +84,7 @@ final class RemoteConfigManagerTests: XCTestCase {
 
         let config = try await manager.loadRemoteConfig(contextKey: nil)
 
-        XCTAssertEqual(config.source.identifier, "fallback-empty")
+        XCTAssertEqual(config.source?.identifier, "fallback-empty")
     }
 
     func testNonRetriableLoadFailureIgnoresTheFallbackFile() async {
@@ -120,7 +120,7 @@ final class RemoteConfigManagerTests: XCTestCase {
 
         let config = try await manager.loadRemoteConfig(contextKey: "main")
 
-        XCTAssertEqual(config.source.identifier, "fallback-main")
+        XCTAssertEqual(config.source?.identifier, "fallback-main")
     }
 
     func testListLoadFailureFallsBackToAllBundledConfigs() async throws {
@@ -129,7 +129,7 @@ final class RemoteConfigManagerTests: XCTestCase {
 
         let list = try await manager.loadRemoteConfigList()
 
-        XCTAssertEqual(list.remoteConfigs.map { $0.source.identifier }, ["fallback-main", "fallback-empty"])
+        XCTAssertEqual(list.remoteConfigs.map { $0.source?.identifier }, ["fallback-main", "fallback-empty"])
     }
 
     func testListWithContextKeysFallsBackFiltered() async throws {
@@ -139,8 +139,8 @@ final class RemoteConfigManagerTests: XCTestCase {
         let withEmpty = try await manager.loadRemoteConfigList(contextKeys: ["main"], includeEmptyContextKey: true)
         let withoutEmpty = try await manager.loadRemoteConfigList(contextKeys: ["main"], includeEmptyContextKey: false)
 
-        XCTAssertEqual(withEmpty.remoteConfigs.map { $0.source.identifier }, ["fallback-main", "fallback-empty"])
-        XCTAssertEqual(withoutEmpty.remoteConfigs.map { $0.source.identifier }, ["fallback-main"])
+        XCTAssertEqual(withEmpty.remoteConfigs.map { $0.source?.identifier }, ["fallback-main", "fallback-empty"])
+        XCTAssertEqual(withoutEmpty.remoteConfigs.map { $0.source?.identifier }, ["fallback-main"])
     }
 
     func testAttachInvalidatesTheCachedConfigs() async throws {
@@ -152,7 +152,7 @@ final class RemoteConfigManagerTests: XCTestCase {
         remoteConfigService.remoteConfigResult = makeRemoteConfig(contextKey: "main", identifier: "after-attach")
         let config = try await manager.loadRemoteConfig(contextKey: "main")
 
-        XCTAssertEqual(config.source.identifier, "after-attach", "attach exists to change the config — the cache must not survive it")
+        XCTAssertEqual(config.source?.identifier, "after-attach", "attach exists to change the config — the cache must not survive it")
     }
 
     func testInFlightPreAttachResponseCannotRepopulateTheInvalidatedCache() async throws {
@@ -170,7 +170,7 @@ final class RemoteConfigManagerTests: XCTestCase {
         remoteConfigService.remoteConfigResult = makeRemoteConfig(contextKey: "main", identifier: "post-attach")
         let config = try await manager.loadRemoteConfig(contextKey: "main")
 
-        XCTAssertEqual(config.source.identifier, "post-attach", "the pre-attach response must not survive the invalidation")
+        XCTAssertEqual(config.source?.identifier, "post-attach", "the pre-attach response must not survive the invalidation")
     }
 
     func testLoadWaitsForUserStability() async throws {
@@ -220,7 +220,7 @@ final class RemoteConfigManagerTests: XCTestCase {
 
         let config = try await manager.loadRemoteConfig(contextKey: "main")
 
-        XCTAssertEqual(config.source.contextKey, "main")
+        XCTAssertEqual(config.source?.contextKey, "main")
     }
 
     func testCachedLoadStillWaitsForStabilityButSkipsTheGateAndTheFlush() async throws {
@@ -246,7 +246,7 @@ final class RemoteConfigManagerTests: XCTestCase {
 
         let config = try await manager.loadRemoteConfig(contextKey: "main")
 
-        XCTAssertEqual(config.source.identifier, "new-user-config")
+        XCTAssertEqual(config.source?.identifier, "new-user-config")
     }
 
     func testIdentifyFailureDuringTheStabilityGateFailsTheLoad() async {
@@ -326,7 +326,7 @@ final class RemoteConfigManagerTests: XCTestCase {
         let results: [Qonversion.RemoteConfig] = try await [first, second, third]
 
         XCTAssertEqual(remoteConfigService.loadRemoteConfigContextKeys.count, 1, "concurrent callers must share one request")
-        XCTAssertEqual(results.map { $0.source.identifier }, ["shared", "shared", "shared"])
+        XCTAssertEqual(results.map { $0.source?.identifier }, ["shared", "shared", "shared"])
     }
 
     func testConcurrentLoadsOfDifferentContextKeysDoNotShareARequest() async throws {
@@ -349,8 +349,8 @@ final class RemoteConfigManagerTests: XCTestCase {
 
         XCTAssertEqual(remoteConfigService.loadRemoteConfigContextKeys.count, 1)
         XCTAssertEqual(remoteConfigService.loadRemoteConfigContextKeys.first, "main")
-        XCTAssertEqual(first.source.identifier, "source-id")
-        XCTAssertEqual(second.source.identifier, "source-id")
+        XCTAssertEqual(first.source?.identifier, "source-id")
+        XCTAssertEqual(second.source?.identifier, "source-id")
     }
 
     func testLoadRemoteConfigCachesNilContextKeyUnderEmptyKey() async throws {
@@ -403,7 +403,7 @@ final class RemoteConfigManagerTests: XCTestCase {
         let list = try await manager.loadRemoteConfigList()
 
         XCTAssertEqual(remoteConfigService.loadListCallsCount, 1)
-        XCTAssertEqual(list.remoteConfigs.map { $0.source.identifier }, ["id-a", "id-empty"])
+        XCTAssertEqual(list.remoteConfigs.map { $0.source?.identifier }, ["id-a", "id-empty"])
 
         // Loaded list entries are cached by their source contextKey (nil -> ""), so
         // subsequent single loads do not hit the service at all.
@@ -411,8 +411,8 @@ final class RemoteConfigManagerTests: XCTestCase {
         let cachedEmpty = try await manager.loadRemoteConfig(contextKey: nil)
 
         XCTAssertTrue(remoteConfigService.loadRemoteConfigContextKeys.isEmpty)
-        XCTAssertEqual(cachedA.source.identifier, "id-a")
-        XCTAssertEqual(cachedEmpty.source.identifier, "id-empty")
+        XCTAssertEqual(cachedA.source?.identifier, "id-a")
+        XCTAssertEqual(cachedEmpty.source?.identifier, "id-empty")
     }
 
     func testCachedNamedKeysStillFetchWhenTheEmptyKeyIsRequestedButNotCached() async throws {
@@ -445,7 +445,7 @@ final class RemoteConfigManagerTests: XCTestCase {
         let list = try await manager.loadRemoteConfigList(contextKeys: ["a", "a"], includeEmptyContextKey: true)
 
         XCTAssertTrue(remoteConfigService.loadListContextKeysArgs.isEmpty, "duplicate keys must not fake a miss, a full cache serves locally")
-        XCTAssertEqual(list.remoteConfigs.map { $0.source.identifier }, ["id-a", "id-empty"])
+        XCTAssertEqual(list.remoteConfigs.map { $0.source?.identifier }, ["id-a", "id-empty"])
     }
 
     func testLoadRemoteConfigListWithContextKeysForwardsToServiceWhenNotFullyCached() async throws {
@@ -512,7 +512,7 @@ final class RemoteConfigManagerTests: XCTestCase {
         remoteConfigService.remoteConfigResult = makeRemoteConfig(contextKey: "main", identifier: "new-user-config")
         let fresh = try await manager.loadRemoteConfig(contextKey: "main")
 
-        XCTAssertEqual(fresh.source.identifier, "new-user-config")
+        XCTAssertEqual(fresh.source?.identifier, "new-user-config")
         XCTAssertEqual(remoteConfigService.loadRemoteConfigContextKeys.count, 2)
     }
 
@@ -538,7 +538,7 @@ final class RemoteConfigManagerTests: XCTestCase {
         let fresh: Qonversion.RemoteConfig = try await freshLoad
         _ = try? await staleLoad
 
-        XCTAssertEqual(fresh.source.identifier, "new-user-config")
+        XCTAssertEqual(fresh.source?.identifier, "new-user-config")
         XCTAssertEqual(remoteConfigService.loadRemoteConfigContextKeys.count, 2, "the new user must start its own request")
     }
 

--- a/Tests/QonversionUnitTests/RemoteConfigServiceTests.swift
+++ b/Tests/QonversionUnitTests/RemoteConfigServiceTests.swift
@@ -77,7 +77,7 @@ final class RemoteConfigServiceTests: XCTestCase {
 
         let list = try await service.loadRemoteConfigList()
 
-        XCTAssertEqual(list.remoteConfigs.map { $0.source.identifier }, ["good", "also-good"],
+        XCTAssertEqual(list.remoteConfigs.map { $0.source?.identifier }, ["good", "also-good"],
                        "a single bad row must degrade the list, not null it")
     }
 
@@ -87,7 +87,7 @@ final class RemoteConfigServiceTests: XCTestCase {
 
         let list = try await service.loadRemoteConfigList(contextKeys: ["a"], includeEmptyContextKey: false)
 
-        XCTAssertEqual(list.remoteConfigs.map { $0.source.identifier }, ["good"])
+        XCTAssertEqual(list.remoteConfigs.map { $0.source?.identifier }, ["good"])
     }
 
     func testAnAllMalformedListStillFails() async {
@@ -272,8 +272,8 @@ final class RemoteConfigServiceTests: XCTestCase {
         let remoteConfig = try await service.loadRemoteConfig(contextKey: "main")
 
         XCTAssertEqual(processor.processedRequests, [Request.remoteConfig(userId: userId, contextKey: "main")])
-        XCTAssertEqual(remoteConfig.source.identifier, "rc_main")
-        XCTAssertEqual(remoteConfig.source.contextKey, "main")
+        XCTAssertEqual(remoteConfig.source?.identifier, "rc_main")
+        XCTAssertEqual(remoteConfig.source?.contextKey, "main")
         XCTAssertEqual(remoteConfig.payload?["key"] as? String, "value")
     }
 
@@ -309,8 +309,8 @@ final class RemoteConfigServiceTests: XCTestCase {
 
         XCTAssertEqual(processor.processedRequests, [Request.allRemoteConfigList(userId: userId)])
         XCTAssertEqual(list.remoteConfigs.count, 2)
-        XCTAssertEqual(list.remoteConfigs[0].source.identifier, "rc_1")
-        XCTAssertEqual(list.remoteConfigs[1].source.identifier, "rc_2")
+        XCTAssertEqual(list.remoteConfigs[0].source?.identifier, "rc_1")
+        XCTAssertEqual(list.remoteConfigs[1].source?.identifier, "rc_2")
     }
 
     func testLoadRemoteConfigListWrapsErrorIntoLoadingRemoteConfigListFailed() async {
@@ -338,7 +338,7 @@ final class RemoteConfigServiceTests: XCTestCase {
             [Request.remoteConfigList(userId: userId, contextKeys: ["a", "b"], includeEmptyContextKey: true)]
         )
         XCTAssertEqual(list.remoteConfigs.count, 1)
-        XCTAssertEqual(list.remoteConfigs[0].source.contextKey, "a")
+        XCTAssertEqual(list.remoteConfigs[0].source?.contextKey, "a")
     }
 
     func testLoadRemoteConfigListWithContextKeysWrapsErrorIntoLoadingRemoteConfigListFailed() async {

--- a/Tests/QonversionUnitTests/UserManagerTests.swift
+++ b/Tests/QonversionUnitTests/UserManagerTests.swift
@@ -24,6 +24,7 @@ final class UserManagerTests: XCTestCase {
     private var notifier: UserChangesNotifier!
     private var observer: UserChangeObserverSpy!
     private var manager: UserManager!
+    private var appTransactionReader: MockAppTransactionReader!
 
     private let anonUid = "QON_anon_uid"
 
@@ -34,6 +35,7 @@ final class UserManagerTests: XCTestCase {
         config = InternalConfig(userId: anonUid)
         notifier = UserChangesNotifier()
         observer = UserChangeObserverSpy()
+        appTransactionReader = MockAppTransactionReader()
         notifier.add(observer: observer)
         storage.set(string: anonUid, forKey: UserServiceStorageKeys.originalUserIdKey.rawValue)
         manager = makeManager()
@@ -41,6 +43,7 @@ final class UserManagerTests: XCTestCase {
 
     override func tearDown() {
         manager = nil
+        appTransactionReader = nil
         observer = nil
         notifier = nil
         config = nil
@@ -50,7 +53,7 @@ final class UserManagerTests: XCTestCase {
     }
 
     private func makeManager() -> UserManager {
-        UserManager(userService: service, localStorage: storage, internalConfig: config, userChangesNotifier: notifier, logger: LoggerWrapper())
+        UserManager(userService: service, localStorage: storage, internalConfig: config, userChangesNotifier: notifier, logger: LoggerWrapper(), appTransactionReader: appTransactionReader)
     }
 
     private func makeUser(id: String, environment: String = "sandbox") throws -> Qonversion.User {
@@ -569,6 +572,53 @@ final class UserManagerTests: XCTestCase {
         let user = try await manager.userInfo()
 
         XCTAssertEqual(user.id, anonUid, "the persisted user answers offline")
+    }
+
+    // MARK: - originalAppVersion
+
+    func testUserInfoStampsTheOriginalAppVersionFromTheStore() async throws {
+        // The backend never serves this field — the SDK resolves it on the
+        // device and stamps it onto the user it hands back.
+        appTransactionReader.originalAppVersionResult = "1.0.3"
+        service.createUserResult = try makeUser(id: anonUid)
+        service.userResult = try makeUser(id: anonUid)
+
+        let user = try await manager.userInfo()
+
+        XCTAssertEqual(user.originalAppVersion, "1.0.3")
+    }
+
+    func testUserInfoLeavesTheOriginalAppVersionNilWhenTheStoreCannotAnswer() async throws {
+        appTransactionReader.originalAppVersionResult = nil
+        service.createUserResult = try makeUser(id: anonUid)
+        service.userResult = try makeUser(id: anonUid)
+
+        let user = try await manager.userInfo()
+
+        XCTAssertNil(user.originalAppVersion)
+    }
+
+    func testUserInfoStampsThePersistedUserWhenTheFetchFails() async throws {
+        appTransactionReader.originalAppVersionResult = "1.0.3"
+        service.createUserResult = try makeUser(id: anonUid)
+        service.userResult = try makeUser(id: anonUid)
+        _ = try await manager.userInfo()
+        service.userError = QonversionError(type: .internal)
+
+        let user = try await manager.userInfo()
+
+        XCTAssertEqual(user.originalAppVersion, "1.0.3", "the cached user carries the version too")
+    }
+
+    func testTheStampedOriginalAppVersionIsPersisted() async throws {
+        appTransactionReader.originalAppVersionResult = "1.0.3"
+        service.createUserResult = try makeUser(id: anonUid)
+        service.userResult = try makeUser(id: anonUid)
+
+        _ = try await manager.userInfo()
+
+        let persisted = try XCTUnwrap(try storage.object(forKey: "qonversion.keys.user", dataType: Qonversion.User.self))
+        XCTAssertEqual(persisted.originalAppVersion, "1.0.3")
     }
 
     // MARK: - cancellation never escapes unclassified

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -145,6 +145,13 @@ own `type`, `apiCode` and `apiType`. `.loadingRemoteConfigFailed` and
 `.loadingRemoteConfigListFailed` are now what they say — the failure could not
 be classified.
 
+### Remote config source is optional
+
+`RemoteConfig.source` is now `Source?`. The backend reports no source for an
+unassigned config, and treating that as a malformed payload used to fail the
+whole decode — one sourceless config took the entire list down with it. Unwrap
+it (`config.source?.contextKey`) where you read it.
+
 ### visionOS purchases
 
 visionOS has no scene-less StoreKit purchase call: the system needs to know
@@ -175,7 +182,7 @@ of crashing. Nothing changes on iOS, macOS, tvOS or watchOS.
 
 | API | Replacement |
 |---|---|
-| `offerings(completion)` | Removed — offerings are deprecated product-wide. Manage paywall products with [Remote Configs](https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs). |
+| `offerings(completion)` and `Product.offeringId` | Removed — offerings are gone product-wide and the backend no longer returns them. Manage paywall products with [Remote Configs](https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs). |
 | `purchase(productID, completion)` and other deprecated purchase variants | `purchase(_:options:)` with a `Qonversion.Product` |
 | `attribution(data, fromProvider)` | Removed — was already a deprecated no-op; attribution works automatically |
 | `setNotificationsToken` / `handleNotification` | Removed — were deprecated automation APIs |
@@ -204,6 +211,13 @@ split your data by build type on the SDK's word.
 
 `Qonversion.User` exposes `originalAppVersion` — the app version the user
 originally downloaded from the App Store, for grandfathering older installs.
+
+The SDK resolves it on the device from the StoreKit 2 app transaction; the
+backend neither serves nor accepts the field. It is read once per process and
+persisted with the user, so `userInfo()` carries it whether the user came from
+the network or from the local cache. Expect `nil` below iOS 16, macOS 13,
+tvOS 16 or watchOS 9, and whenever the store cannot be reached — a missing
+version is never an error, so plan the grandfathering branch for `nil`.
 
 ## Purchase and deferred purchase provenance
 


### PR DESCRIPTION
… a null config source

Aligns the entities with the agreed v4 backend contract.

Offerings are gone platform-wide and the backend will never answer offering_id, so `Product.offeringId` and its wire key are removed. A stray offering_id on the wire is now ignored instead of surfacing.

`originalAppVersion` no longer travels on the wire: the apple_extra decode and encode are gone, and the value is resolved on the device from the StoreKit 2 app transaction, which is unavailable below iOS 16, macOS 13, tvOS 16 and watchOS 9. The store read sits behind an injectable seam that resolves once per process and turns every failure into nil, and `userInfo()` stamps the result onto both the fetched and the cached user. The version persists with the user under a local-only key, so `identify()` and the offline path carry it too.

`RemoteConfig.source` becomes optional. The backend serializes it from a pointer without omitempty, so an unassigned config arrives as an explicit null — which used to fail the decode and take the whole config list down with it.