### PR TITLE
feat(api): align device, crash and No-Codes wires with the backend co…

### DIFF
--- a/Qonversion.xcodeproj/project.pbxproj
+++ b/Qonversion.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		D700000000000000000000B1 /* CrashReportFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D700000000000000000000A1 /* CrashReportFilter.swift */; };
 		D800000000000000000000B1 /* CrashReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D800000000000000000000A1 /* CrashReporter.swift */; };
 		D900000000000000000000B1 /* CrashReportsStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D900000000000000000000A1 /* CrashReportsStorage.swift */; };
+		D9CA00000000000000000B1 /* CrashReportsTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9CA00000000000000000A1 /* CrashReportsTransport.swift */; };
 		C200000000000000000000B1 /* PromoPurchaseIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C200000000000000000000A1 /* PromoPurchaseIntent.swift */; };
 		C300000000000000000000B1 /* StoredRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C300000000000000000000A1 /* StoredRequest.swift */; };
 		B100000000000000000000B1 /* UserChangesNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000000000000000000A1 /* UserChangesNotifier.swift */; };
@@ -292,6 +293,7 @@
 		D700000000000000000000A1 /* CrashReportFilter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CrashReportFilter.swift; sourceTree = "<group>"; };
 		D800000000000000000000A1 /* CrashReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CrashReporter.swift; sourceTree = "<group>"; };
 		D900000000000000000000A1 /* CrashReportsStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CrashReportsStorage.swift; sourceTree = "<group>"; };
+		D9CA00000000000000000A1 /* CrashReportsTransport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CrashReportsTransport.swift; sourceTree = "<group>"; };
 		C200000000000000000000A1 /* PromoPurchaseIntent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PromoPurchaseIntent.swift; sourceTree = "<group>"; };
 		C300000000000000000000A1 /* StoredRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoredRequest.swift; sourceTree = "<group>"; };
 		B100000000000000000000A1 /* UserChangesNotifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserChangesNotifier.swift; sourceTree = "<group>"; };
@@ -776,6 +778,7 @@
 				D700000000000000000000A1 /* CrashReportFilter.swift */,
 				D800000000000000000000A1 /* CrashReporter.swift */,
 				D900000000000000000000A1 /* CrashReportsStorage.swift */,
+				D9CA00000000000000000A1 /* CrashReportsTransport.swift */,
 			);
 			path = CrashReporting;
 			sourceTree = "<group>";
@@ -1218,6 +1221,7 @@
 				D700000000000000000000B1 /* CrashReportFilter.swift in Sources */,
 				D800000000000000000000B1 /* CrashReporter.swift in Sources */,
 				D900000000000000000000B1 /* CrashReportsStorage.swift in Sources */,
+				D9CA00000000000000000B1 /* CrashReportsTransport.swift in Sources */,
 				C200000000000000000000B1 /* PromoPurchaseIntent.swift in Sources */,
 				C300000000000000000000B1 /* StoredRequest.swift in Sources */,
 				B100000000000000000000B1 /* UserChangesNotifier.swift in Sources */,

--- a/Sources/Assemblies/QonversionAssembly.swift
+++ b/Sources/Assemblies/QonversionAssembly.swift
@@ -110,16 +110,15 @@ final class QonversionAssembly {
         #endif
     }
 
-    /// Ships the reports the previous launch left behind. Fails soft — the
-    /// endpoint is a proposal, see ``CrashReporter``.
+    /// Ships the reports the previous launch left behind. Fails soft, and goes
+    /// to the sdk-logs host rather than the API — see ``CrashReportsTransport``.
     func sendStoredCrashReports() async {
-        let deviceInfoCollector: DeviceInfoCollectorInterface = servicesAssembly.deviceInfoCollector()
         let sender = CrashReportsSender(
             storage: crashReportsStorage(),
-            requestProcessor: servicesAssembly.requestProcessor(),
+            transport: servicesAssembly.crashReportsTransport(),
             userIdProvider: miscAssembly.internalConfig,
             userManager: userManager(),
-            platform: deviceInfoCollector.headerDeviceInfo().osName
+            device: servicesAssembly.sdkLogDevice()
         )
 
         await sender.sendStoredReports()

--- a/Sources/Assemblies/ServicesAssembly.swift
+++ b/Sources/Assemblies/ServicesAssembly.swift
@@ -147,6 +147,23 @@ final class ServicesAssembly {
         return processor
     }
     
+    /// Crash reports go to a different host than everything else, with none of
+    /// the API processor's machinery — see ``CrashReportsTransport``.
+    func crashReportsTransport() -> CrashReportsTransportInterface {
+        return CrashReportsTransport(networkProvider: networkProvider())
+    }
+
+    func sdkLogDevice() -> SdkLogDevice {
+        let deviceInfo: HeaderDeviceInfo = deviceInfoCollector().headerDeviceInfo()
+
+        return SdkLogDevice.make(
+            deviceInfo: deviceInfo,
+            projectKey: apiKey,
+            sdkVersion: SDKVersion.current,
+            userDefaults: miscAssembly.userDefaults
+        )
+    }
+
     func miscAssemblyLogger() -> LoggerWrapper {
         return miscAssembly.loggerWrapper()
     }

--- a/Sources/Entities/Device.swift
+++ b/Sources/Entities/Device.swift
@@ -8,43 +8,88 @@
 
 import Foundation
 
+/// The device record, in the exact shape both sides of the contract implement.
+/// The endpoint echoes the object back, so one key set serves encoding and
+/// decoding; the decode is tolerant because a truncated echo must not cost the
+/// SDK the record it just created.
 struct Device: Equatable, Codable {
-    
-    let manufacturer: String
+
     let osName: String
     let osVersion: String
     let model: String?
     let appVersion: String?
     let country: String?
     let language: String?
-    let timezone: String?
     let advertisingId: String?
     let vendorId: String?
+    /// Unix seconds on the wire.
     let installDate: TimeInterval
 
+    enum CodingKeys: String, CodingKey {
+        case osName = "os_name"
+        case osVersion = "os_version"
+        case model
+        case appVersion = "app_version"
+        case country
+        case language
+        case advertisingId = "advertising_id"
+        case vendorId = "vendor_id"
+        case installDate = "install_date"
+    }
+
     init(
-        manufacturer: String,
         osName: String,
         osVersion: String,
         model: String?,
         appVersion: String?,
         country: String?,
         language: String?,
-        timezone: String,
         advertisingId: String?,
         vendorId: String?,
         installDate: TimeInterval
     ) {
-        self.manufacturer = manufacturer
         self.osName = osName
         self.osVersion = osVersion
         self.model = model
         self.appVersion = appVersion
         self.country = country
         self.language = language
-        self.timezone = timezone
         self.advertisingId = advertisingId
         self.vendorId = vendorId
         self.installDate = installDate
+    }
+
+    init(from decoder: Decoder) throws {
+        let container: KeyedDecodingContainer<CodingKeys> = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.osName = try container.decodeIfPresent(String.self, forKey: .osName) ?? ""
+        self.osVersion = try container.decodeIfPresent(String.self, forKey: .osVersion) ?? ""
+        self.model = try container.decodeIfPresent(String.self, forKey: .model)
+        self.appVersion = try container.decodeIfPresent(String.self, forKey: .appVersion)
+        self.country = try container.decodeIfPresent(String.self, forKey: .country)
+        self.language = try container.decodeIfPresent(String.self, forKey: .language)
+        self.advertisingId = try container.decodeIfPresent(String.self, forKey: .advertisingId)
+        self.vendorId = try container.decodeIfPresent(String.self, forKey: .vendorId)
+        self.installDate = try container.decodeIfPresent(TimeInterval.self, forKey: .installDate) ?? 0
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container: KeyedEncodingContainer<CodingKeys> = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(osName, forKey: .osName)
+        try container.encode(osVersion, forKey: .osVersion)
+        try container.encodeIfPresent(model, forKey: .model)
+        try container.encodeIfPresent(appVersion, forKey: .appVersion)
+        try container.encodeIfPresent(country, forKey: .country)
+        try container.encodeIfPresent(language, forKey: .language)
+        try container.encodeIfPresent(advertisingId, forKey: .advertisingId)
+        try container.encodeIfPresent(vendorId, forKey: .vendorId)
+        // An interval that is not representable as seconds falls through to the
+        // Double encoding, which reports the failure instead of trapping.
+        if let seconds: Int = Int(exactly: installDate.rounded(.down)) {
+            try container.encode(seconds, forKey: .installDate)
+        } else {
+            try container.encode(installDate, forKey: .installDate)
+        }
     }
 }

--- a/Sources/NetworkLayer/Request/Request.swift
+++ b/Sources/NetworkLayer/Request/Request.swift
@@ -36,7 +36,6 @@ extension Request {
         case detachUserFromExperiment
         case attachUserToRemoteConfig
         case detachUserFromRemoteConfig
-        case sdkCrash
     }
 
     /// Identifies the payload for the offline replay dedup: the same failed
@@ -98,7 +97,6 @@ extension Request {
         case .detachUserFromExperiment: return .detachUserFromExperiment
         case .attachUserToRemoteConfig: return .attachUserToRemoteConfig
         case .detachUserFromRemoteConfig: return .detachUserFromRemoteConfig
-        case .sdkCrash: return .sdkCrash
         }
     }
 }
@@ -127,10 +125,6 @@ enum Request : Hashable {
     case detachUserFromExperiment(userId: String, experimentId: String, endpoint: String = "v4/experiments/%@/users/%@", type: RequestType = .delete)
     case attachUserToRemoteConfig(userId: String, remoteConfigId: String, endpoint: String = "v4/remote-configurations/%@/users/%@", type: RequestType = .post)
     case detachUserFromRemoteConfig(userId: String, remoteConfigId: String, endpoint: String = "v4/remote-configurations/%@/users/%@", type: RequestType = .delete)
-    /// A crash inside the SDK, reported on the launch after it happened.
-    /// PROPOSED contract — the endpoint does not exist on the backend yet, so
-    /// the send is expected to fail and must do so softly. See CrashReporter.
-    case sdkCrash(endpoint: String = "v4/sdk-crashes", body: RequestBodyDict, type: RequestType = .post)
 
     func convertToURLRequest(_ baseUrl: String) -> URLRequest? {
         // RFC 3986 unreserved characters: everything else in a dynamic path
@@ -236,9 +230,6 @@ enum Request : Hashable {
         case let .detachUserFromExperiment(userId, experimentId, endpoint, type):
             let urlString = String(format: endpoint, arguments: [escaped(experimentId), escaped(userId)])
             return defaultRequest(urlString: urlString, body: nil, type: type)
-
-        case let .sdkCrash(endpoint, body, type):
-            return defaultRequest(urlString: endpoint, body: body, type: type)
         }
     }
 
@@ -308,11 +299,6 @@ enum Request : Hashable {
         case let .appleSearchAds(userId, endpoint, body, type):
             hasher.combine("appleSearchAds")
             hasher.combine(userId)
-            hasher.combine(endpoint)
-            hasher.combine(body)
-            hasher.combine(type)
-        case let .sdkCrash(endpoint, body, type):
-            hasher.combine("sdkCrash")
             hasher.combine(endpoint)
             hasher.combine(body)
             hasher.combine(type)

--- a/Sources/NetworkLayer/RequestProcessor/RequestProcessor.swift
+++ b/Sources/NetworkLayer/RequestProcessor/RequestProcessor.swift
@@ -143,7 +143,7 @@ class RequestProcessor: RequestProcessorInterface, @unchecked Sendable {
     /// Requests the SDK emits on its own schedule, which the host cannot spam.
     /// Offer signing is deliberately not here: it is public API, so its rate is
     /// the host's to set.
-    static let rateLimitExemptKinds: [Request.Kind] = [.sendProperties, .sdkCrash]
+    static let rateLimitExemptKinds: [Request.Kind] = [.sendProperties]
 
     static let attemptHeader: String = "Attempt"
     static let triggerHeader: String = "Trigger"

--- a/Sources/NoCodes/Entities/NoCodesScreen.swift
+++ b/Sources/NoCodes/Entities/NoCodesScreen.swift
@@ -11,7 +11,9 @@ import Foundation
 public struct NoCodesScreen: Decodable, Sendable {
   public let id: String
   let html: String
-  public let contextKey: String
+  /// The context key the screen is published under, or `nil` when the backend
+  /// sent none for it.
+  public let contextKey: String?
   /// Typed default variables of the screen configured in the builder: authored custom
   /// variables and product slots. Read them by ``NoCodesScreenVariable/key`` (may be empty).
   public let defaultVariables: [NoCodesScreenVariable]
@@ -36,7 +38,7 @@ public struct NoCodesScreen: Decodable, Sendable {
   }
 
   /// Internal initializer for creating a screen with modified HTML (e.g., with preloaded images).
-  init(id: String, html: String, contextKey: String, defaultVariables: [NoCodesScreenVariable] = []) {
+  init(id: String, html: String, contextKey: String?, defaultVariables: [NoCodesScreenVariable] = []) {
     self.id = id
     self.html = html
     self.contextKey = contextKey
@@ -47,15 +49,17 @@ public struct NoCodesScreen: Decodable, Sendable {
     if var arrayContainer = try? decoder.unkeyedContainer(),
        let screenContainer = try? arrayContainer.nestedContainer(keyedBy: CodingKeys.self) {
       id = try screenContainer.decode(String.self, forKey: .id)
+      // `body` is the screen: a null one is nothing to render, and the decode
+      // has to say so. `context_key` may legitimately be absent.
       html = try screenContainer.decode(String.self, forKey: .body)
-      contextKey = try screenContainer.decode(String.self, forKey: .context_key)
+      contextKey = try screenContainer.decodeIfPresent(String.self, forKey: .context_key)
       // Older payloads and bundled fallbacks may omit `variables`; default to empty.
       defaultVariables = (try? screenContainer.decodeIfPresent([NoCodesScreenVariable].self, forKey: .variables)) ?? []
     } else {
       let container = try decoder.container(keyedBy: ResponseCodingKeys.self)
       id = try container.decode(String.self, forKey: .id)
       html = try container.decode(String.self, forKey: .body)
-      contextKey = try container.decode(String.self, forKey: .context_key)
+      contextKey = try container.decodeIfPresent(String.self, forKey: .context_key)
       defaultVariables = (try? container.decodeIfPresent([NoCodesScreenVariable].self, forKey: .variables)) ?? []
     }
   }
@@ -88,6 +92,38 @@ public struct NoCodesScreen: Decodable, Sendable {
   func withHtml(_ newHtml: String) -> NoCodesScreen {
     return NoCodesScreen(id: id, html: newHtml, contextKey: contextKey, defaultVariables: defaultVariables)
   }
+}
+
+/// A list of screens that survives the rows it cannot use. A screen whose `body`
+/// is null cannot be rendered, and a gateway path can put a bare `null` in the
+/// array — either one would otherwise take every other screen down with it.
+struct NoCodesScreenList: Decodable {
+
+  let screens: [NoCodesScreen]
+
+  init(from decoder: Decoder) throws {
+    var container: UnkeyedDecodingContainer = try decoder.unkeyedContainer()
+    var screens: [NoCodesScreen] = []
+
+    while !container.isAtEnd {
+      if try container.decodeNil() { continue }
+
+      if let screen: NoCodesScreen = try? container.decode(NoCodesScreen.self) {
+        screens.append(screen)
+      } else {
+        // Skip the unusable row; the container must still advance.
+        _ = try? container.decode(SkippedScreen.self)
+      }
+    }
+
+    self.screens = screens
+  }
+}
+
+/// Consumes one arbitrary JSON value so the list can advance past it.
+private struct SkippedScreen: Decodable {
+
+  init(from decoder: Decoder) throws { }
 }
 
 /// A typed default variable of a No-Codes screen, configured in the builder and delivered

--- a/Sources/NoCodes/Services/NoCodesService.swift
+++ b/Sources/NoCodes/Services/NoCodesService.swift
@@ -68,9 +68,9 @@ final class NoCodesService: NoCodesServiceInterface, @unchecked Sendable {
     
     do {
       let request = Request.getScreenByContextKey(contextKey: contextKey)
-      let screens: [NoCodesScreen] = try await requestProcessor.process(request: request, responseType: [NoCodesScreen].self)
+      let list: NoCodesScreenList = try await requestProcessor.process(request: request, responseType: NoCodesScreenList.self)
       
-      guard let screen = screens.first else {
+      guard let screen = list.screens.first else {
         throw NoCodesError(type: .screenNotFound)
       }
 
@@ -97,7 +97,8 @@ final class NoCodesService: NoCodesServiceInterface, @unchecked Sendable {
 
   func preloadScreens() async throws -> [NoCodesScreen] {
     let request = Request.getPreloadScreens()
-    let screens: [NoCodesScreen] = try await requestProcessor.process(request: request, responseType: [NoCodesScreen].self)
+    let list: NoCodesScreenList = try await requestProcessor.process(request: request, responseType: NoCodesScreenList.self)
+    let screens: [NoCodesScreen] = list.screens
     
     // Preload images and replace URLs with base64 data URIs
     let processedScreens = await preloadImagesForScreens(screens)
@@ -153,7 +154,9 @@ final class NoCodesService: NoCodesServiceInterface, @unchecked Sendable {
   private func cacheScreen(_ screen: NoCodesScreen) {
     cacheQueue.async(flags: .barrier) {
       self.screensById[screen.id] = screen
-      self.screensByContextKey[screen.contextKey] = screen
+      if let contextKey: String = screen.contextKey {
+        self.screensByContextKey[contextKey] = screen
+      }
     }
   }
   
@@ -161,7 +164,9 @@ final class NoCodesService: NoCodesServiceInterface, @unchecked Sendable {
     cacheQueue.async(flags: .barrier) {
       screens.forEach { screen in
         self.screensById[screen.id] = screen
-        self.screensByContextKey[screen.contextKey] = screen
+        if let contextKey: String = screen.contextKey {
+          self.screensByContextKey[contextKey] = screen
+        }
       }
     }
   }

--- a/Sources/Other/CrashReporting/CrashReport.swift
+++ b/Sources/Other/CrashReporting/CrashReport.swift
@@ -82,20 +82,84 @@ struct CrashReport: Codable, Equatable {
     /// The ObjC SDK defaulted a missing reason to this exact string.
     static var unknownReason: String { "Unknown reason" }
 
-    func requestBody(userId: String, platform: String) -> RequestBodyDict {
+    /// The sdk-logs payload, in the ObjC SDK's key layout — that service has
+    /// received this exact shape for years and is the only consumer.
+    /// `sdk_version` and `occurred_at` are ours and ride inside the crash
+    /// payload, which the service stores as it arrives.
+    func requestBody(device: SdkLogDevice) -> RequestBodyDict {
         let exception: RequestBodyDict = [
+            "rawStackTrace": stackTrace.joined(separator: "\n"),
+            "elements": stackTrace as RequestBodyArray,
             "name": name,
-            "reason": reason,
-            "linkage": linkage.rawValue,
-            "stack_trace": stackTrace as RequestBodyArray
+            "message": reason,
+            "isSpm": linkage == .spm,
+            "title": name + ": " + reason,
+            "userInfo": RequestBodyDict(),
+            "sdk_version": sdkVersion,
+            "occurred_at": Int(occurredAt.timeIntervalSince1970)
         ]
 
         return [
-            "sdk_version": sdkVersion,
-            "platform": platform,
-            "occurred_at": Int(occurredAt.timeIntervalSince1970),
-            "user_id": userId,
+            "device": device.requestBodyValue,
             "exception": exception
+        ]
+    }
+}
+
+/// The envelope every sdk-logs payload carries. Its keys are fixed by the
+/// service, not by this SDK.
+struct SdkLogDevice: Equatable, Sendable {
+
+    private enum SourceOverrideKeys: String {
+        case source = "com.qonversion.keys.source"
+        case sourceVersion = "com.qonversion.keys.sourceVersion"
+    }
+
+    let platform: String
+    let platformVersion: String
+    let source: String
+    let sourceVersion: String
+    let projectKey: String
+    let uid: String
+
+    /// Resolves the source the same way the request headers do — the sdk-logs
+    /// service reads the two the same way, so they must not disagree. A version
+    /// override without a source override is a leftover the Objective-C SDK
+    /// wrote, not a cross-platform wrapper. `uid` is filled in by the sender,
+    /// once the user gate has run.
+    static func make(deviceInfo: HeaderDeviceInfo, projectKey: String, sdkVersion: String, userDefaults: UserDefaults) -> SdkLogDevice {
+        let sourceOverride: String? = userDefaults.string(forKey: SourceOverrideKeys.source.rawValue)
+        let versionOverride: String? = userDefaults.string(forKey: SourceOverrideKeys.sourceVersion.rawValue)
+
+        return SdkLogDevice(
+            platform: deviceInfo.osName,
+            platformVersion: deviceInfo.osVersion,
+            source: sourceOverride ?? "iOS",
+            sourceVersion: sourceOverride == nil ? sdkVersion : (versionOverride ?? sdkVersion),
+            projectKey: projectKey,
+            uid: ""
+        )
+    }
+
+    func withUid(_ uid: String) -> SdkLogDevice {
+        return SdkLogDevice(
+            platform: platform,
+            platformVersion: platformVersion,
+            source: source,
+            sourceVersion: sourceVersion,
+            projectKey: projectKey,
+            uid: uid
+        )
+    }
+
+    var requestBodyValue: RequestBodyDict {
+        return [
+            "platform": platform,
+            "platform_version": platformVersion,
+            "source": source,
+            "source_version": sourceVersion,
+            "project_key": projectKey,
+            "uid": uid
         ]
     }
 }

--- a/Sources/Other/CrashReporting/CrashReporter.swift
+++ b/Sources/Other/CrashReporting/CrashReporter.swift
@@ -11,10 +11,9 @@ import Foundation
 /// Mach handlers belong to the host app's own crash reporter, so real crashes
 /// (SIGSEGV, a Swift runtime trap) are not captured here.
 ///
-/// `POST v4/sdk-crashes` does not exist yet: the send fails on every launch,
-/// and nothing about it ever reaches the host. A failure the backend answered
-/// about the report itself drops it, everything else keeps it queued —
-/// ``CrashReportsSender/outcome(for:)``.
+/// Reports go to the sdk-logs service on the launch after the crash, never to
+/// the main API — see ``CrashReportsTransport``. Nothing about the send ever
+/// reaches the host.
 // @unchecked: the installed state is lock-guarded and the C handler captures nothing.
 final class CrashReporter: @unchecked Sendable {
 
@@ -80,57 +79,53 @@ final class CrashReporter: @unchecked Sendable {
     }
 }
 
-/// Ships the reports the previous launch left behind.
+/// Ships the reports the previous launch left behind to the sdk-logs service.
 struct CrashReportsSender {
 
     private let storage: CrashReportsStorage
-    private let requestProcessor: RequestProcessorInterface
+    private let transport: CrashReportsTransportInterface
     private let userIdProvider: UserIdProvider
     private let userManager: UserManagerInterface
-    private let platform: String
+    private let device: SdkLogDevice
 
-    init(storage: CrashReportsStorage, requestProcessor: RequestProcessorInterface, userIdProvider: UserIdProvider, userManager: UserManagerInterface, platform: String) {
+    init(storage: CrashReportsStorage, transport: CrashReportsTransportInterface, userIdProvider: UserIdProvider, userManager: UserManagerInterface, device: SdkLogDevice) {
         self.storage = storage
-        self.requestProcessor = requestProcessor
+        self.transport = transport
         self.userIdProvider = userIdProvider
         self.userManager = userManager
-        self.platform = platform
+        self.device = device
     }
 
-    /// Attempt budget per report: a payload the backend keeps refusing would
+    /// Attempt budget per report: a payload the service keeps refusing would
     /// otherwise hold a slot and one POST per launch forever.
     static var maxSendAttempts: Int { 5 }
 
-    /// Fails soft, one report at a time; ``outcome(for:)`` decides each verdict.
+    /// Fails soft, one report at a time. The service answers with nothing this
+    /// SDK can read, so the only verdicts are delivered and not delivered.
     func sendStoredReports() async {
         let reports: [CrashReport] = storage.all()
         guard !reports.isEmpty else { return }
 
-        // A crash on the first launch is reported before the user exists: the
-        // uid would be one the backend has never seen, and the 4xx it answers
-        // drops the report.
+        // A crash on the first launch is reported before the user exists, and
+        // the uid on the envelope would be one the backend has never seen.
         do {
             try await userManager.obtainUser()
         } catch {
             return
         }
 
-        let userId: String = userIdProvider.getUserId()
+        // The uid is only knowable once the gate above has run.
+        let device: SdkLogDevice = device.withUid(userIdProvider.getUserId())
         for report in reports {
-            let body: RequestBodyDict = report.requestBody(userId: userId, platform: platform)
-            let request = Request.sdkCrash(body: body)
-            do {
-                let _: EmptyApiResponse = try await requestProcessor.process(request: request, responseType: EmptyApiResponse.self)
+            switch await transport.send(body: report.requestBody(device: device)) {
+            case .delivered:
                 storage.remove(report)
-            } catch {
-                switch Self.outcome(for: error) {
-                case .drop:
-                    storage.remove(report)
-                case .keepAndStop:
-                    return
-                case .keepAndContinue:
-                    countAttempt(of: report)
-                }
+            case .rejected:
+                countAttempt(of: report)
+            case .notReached:
+                // The network is the problem, not this report: it keeps its
+                // budget, and the rest of the queue keeps its launch.
+                return
             }
         }
     }
@@ -144,69 +139,4 @@ struct CrashReportsSender {
             storage.replace(report, with: attempted)
         }
     }
-
-    /// What to do with a report whose send failed.
-    enum SendOutcome {
-        /// A resend cannot change the answer — stop wasting a launch on it.
-        case drop
-        /// The failure is about this report; the next one is still worth a try.
-        case keepAndContinue
-        /// The failure is about the environment, so every following send would
-        /// fail the same way.
-        case keepAndStop
-    }
-
-    /// Classifies a failed send by the HTTP status carried on the error, not by
-    /// the error type: the endpoint is unrouted today, and an unrouted path
-    /// answers a bare 404 with no error envelope, which arrives as `.unknown`.
-    /// A status-less failure defaults to keep.
-    static func outcome(for error: Error) -> SendOutcome {
-        // Cancellation is a mid-flight user switch: nothing was decided here,
-        // and the next send would be cancelled too.
-        guard !error.isCancellation else { return .keepAndStop }
-        guard let qonversionError = error as? QonversionError else { return .keepAndStop }
-
-        switch qonversionError.type {
-        // Raised before the request leaves the device, by state that applies to
-        // every report equally.
-        case .critical, .rateLimitExceeded:
-            return .keepAndStop
-        default:
-            break
-        }
-
-        guard let statusCode: Int = qonversionError.additionalInfo?[ErrorConstants.statusCodeKey.rawValue] as? Int else {
-            // No status, no verdict. `.invalidResponse` also arrives from a 2xx
-            // whose body failed to decode, so keeping can resend a report the
-            // backend took — deliberate: a duplicate costs less than a loss.
-            return .keepAndStop
-        }
-
-        // The key or the project is the problem, for every report equally.
-        if Self.environmentWideStatusCodes.contains(statusCode) {
-            return .keepAndStop
-        }
-        // The backend refused this report itself; a next launch changes nothing.
-        if Self.clientErrorRange.contains(statusCode) {
-            return .drop
-        }
-
-        // Answered but did not take it (5xx): reachable, so the next report is
-        // worth a try, and this one's attempt is counted.
-        return .keepAndContinue
-    }
-
-    /// ``ResponseCode`` does not name it because no other caller branches on it.
-    private static let tooManyRequestsStatusCode: Int = 429
-
-    /// Environment-wide 4xx — the revoked-key latch (401/402/403) and the
-    /// throttle (429) — carved out of the delete range below.
-    private static let environmentWideStatusCodes: Set<Int> = [
-        ResponseCode.unauthorized.rawValue,
-        ResponseCode.paymentRequired.rawValue,
-        ResponseCode.forbidden.rawValue,
-        tooManyRequestsStatusCode
-    ]
-
-    private static let clientErrorRange: ClosedRange<Int> = 400...499
 }

--- a/Sources/Other/CrashReporting/CrashReportsTransport.swift
+++ b/Sources/Other/CrashReporting/CrashReportsTransport.swift
@@ -1,0 +1,62 @@
+//
+//  CrashReportsTransport.swift
+//  Qonversion
+//
+
+import Foundation
+
+/// What one send of a crash report ended up as. The service answers with a
+/// body this SDK does not parse, so the status line is the whole verdict.
+enum CrashReportDelivery {
+    /// Any 2xx — the service took it.
+    case delivered
+    /// The service answered something else. It saw the payload; a resend is
+    /// unlikely to change that, so the report's attempt budget pays for it.
+    case rejected
+    /// No answer at all. Says nothing about the report, and every following
+    /// send this launch would fail the same way.
+    case notReached
+}
+
+protocol CrashReportsTransportInterface: Sendable {
+    func send(body: RequestBodyDict) async -> CrashReportDelivery
+}
+
+/// Ships crash payloads to the sdk-logs service, which is a different host from
+/// the main processor's: no project key header, no error envelope, no response
+/// to parse. Consequently none of the main processor's machinery — the critical
+/// error latch, the rate limiter, the offline replay queue — applies here.
+final class CrashReportsTransport: CrashReportsTransportInterface {
+
+    /// The host the ObjC SDK has always shipped crashes to.
+    static let defaultBaseURL: String = "https://sdk-logs.qonversion.io/"
+    private static let endpoint: String = "sdk.log"
+    private static let successRange: ClosedRange<Int> = 200...299
+
+    private let networkProvider: NetworkProviderInterface
+    private let baseURL: String
+
+    init(networkProvider: NetworkProviderInterface, baseURL: String = CrashReportsTransport.defaultBaseURL) {
+        self.networkProvider = networkProvider
+        self.baseURL = baseURL
+    }
+
+    func send(body: RequestBodyDict) async -> CrashReportDelivery {
+        guard let url = URL(string: baseURL + Self.endpoint),
+              let httpBody: Data = try? JSONSerialization.data(withJSONObject: body) else {
+            // Nothing sendable was built, and the next launch would build the
+            // same thing: spend an attempt rather than retry forever.
+            return .rejected
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = RequestType.post.rawValue
+        request.setValue("application/json", forHTTPHeaderField: Header.contentType.rawValue)
+        request.httpBody = httpBody
+
+        guard let (_, response) = try? await networkProvider.send(request: request) else { return .notReached }
+        guard let statusCode: Int = (response as? HTTPURLResponse)?.statusCode else { return .notReached }
+
+        return Self.successRange.contains(statusCode) ? .delivered : .rejected
+    }
+}

--- a/Sources/Services/Device/DeviceInfoCollector.swift
+++ b/Sources/Services/Device/DeviceInfoCollector.swift
@@ -46,26 +46,22 @@ final class DeviceInfoCollector: DeviceInfoCollectorInterface {
         // Built fresh on every call: advertisingId (ATT grant), locale and
         // appVersion change at runtime, and a cached snapshot would keep the
         // device update diff empty forever.
-        let manufacturer = "Apple"
         let appVersion: String? = Bundle.appVersion
         let osVersion: String = osVersion()
         let model: String? = deviceModel()
         let installDate: TimeInterval = installDate()
         let country: String? = country()
         let language: String? = language()
-        let timezone: String = TimeZone.current.identifier
         let advertisingId: String? = advertisingId()
         let vendorId: String? = vendorId()
 
         let deviceInfo = Device(
-            manufacturer: manufacturer,
             osName: OsName,
             osVersion: osVersion,
             model: model,
             appVersion: appVersion,
             country: country,
             language: language,
-            timezone: timezone,
             advertisingId: advertisingId,
             vendorId: vendorId,
             installDate: installDate

--- a/Tests/NoCodesTests/NoCodesScreenDecodingTests.swift
+++ b/Tests/NoCodesTests/NoCodesScreenDecodingTests.swift
@@ -64,6 +64,80 @@ final class NoCodesScreenDecodingTests: XCTestCase {
         XCTAssertEqual(screen.defaultVariable(forKey: "future")?.value.stringValue, "34")
     }
 
+    // MARK: - nulls the backend can emit
+
+    func testAScreenWithoutABodySkipsItselfOutOfTheList() throws {
+        // Go pointers without omitempty: a screen the builder never published
+        // arrives with `body: null`. It cannot be rendered — but the screens
+        // next to it can, and nulling the whole list loses them too.
+        let json = """
+        [{"id": "broken", "body": null, "context_key": "a"},
+         {"id": "good", "body": "<html>hi</html>", "context_key": "b"}]
+        """
+        let decoder = JSONDecoder()
+
+        let list: NoCodesScreenList = try decoder.decode(NoCodesScreenList.self, from: Data(json.utf8))
+
+        XCTAssertEqual(list.screens.map { $0.id }, ["good"])
+    }
+
+    func testANullEntryInTheListIsSkipped() throws {
+        // One gateway path yields a bare null element.
+        let json = """
+        [null, {"id": "good", "body": "<html>hi</html>", "context_key": "b"}]
+        """
+        let decoder = JSONDecoder()
+
+        let list: NoCodesScreenList = try decoder.decode(NoCodesScreenList.self, from: Data(json.utf8))
+
+        XCTAssertEqual(list.screens.map { $0.id }, ["good"])
+    }
+
+    func testAListOfOnlyBrokenScreensDecodesEmptyInsteadOfThrowing() throws {
+        let json = """
+        [null, {"id": "broken", "body": null, "context_key": "a"}]
+        """
+        let decoder = JSONDecoder()
+
+        let list: NoCodesScreenList = try decoder.decode(NoCodesScreenList.self, from: Data(json.utf8))
+
+        XCTAssertTrue(list.screens.isEmpty)
+    }
+
+    func testANullContextKeyDecodesAsAbsent() throws {
+        let json = """
+        {"id": "screen-5", "body": "<html></html>", "context_key": null}
+        """
+        let decoder = JSONDecoder()
+
+        let screen: NoCodesScreen = try decoder.decode(NoCodesScreen.self, from: Data(json.utf8))
+
+        XCTAssertEqual(screen.id, "screen-5")
+        XCTAssertNil(screen.contextKey)
+    }
+
+    func testAMissingContextKeyDecodesAsAbsent() throws {
+        let json = """
+        {"id": "screen-6", "body": "<html></html>"}
+        """
+        let decoder = JSONDecoder()
+
+        let screen: NoCodesScreen = try decoder.decode(NoCodesScreen.self, from: Data(json.utf8))
+
+        XCTAssertNil(screen.contextKey)
+    }
+
+    func testASingleScreenWithoutABodyStillFailsToDecode() throws {
+        // A screen without HTML is nothing to show: the single-screen fetch has
+        // to surface that, not hand back a blank screen.
+        let json = """
+        {"id": "screen-7", "body": null, "context_key": "a"}
+        """
+        let decoder = JSONDecoder()
+
+        XCTAssertThrowsError(try decoder.decode(NoCodesScreen.self, from: Data(json.utf8)))
+    }
+
     func testDecodesFallbackFileContract() throws {
         let json = """
         {"screens": {"main": {"id": "screen-4", "body": "<html></html>", "context_key": "main", "variables": []}}}

--- a/Tests/NoCodesTests/NoCodesServiceTests.swift
+++ b/Tests/NoCodesTests/NoCodesServiceTests.swift
@@ -103,7 +103,9 @@ private final class StubFallbackService: FallbackServiceInterface, @unchecked Se
         lock.lock()
         defer { lock.unlock() }
 
-        screensByContextKey[screen.contextKey] = screen
+        if let contextKey: String = screen.contextKey {
+          screensByContextKey[contextKey] = screen
+        }
         screensById[screen.id] = screen
     }
 
@@ -275,6 +277,57 @@ final class NoCodesServiceTests: XCTestCase {
         }
 
         XCTAssertEqual(error.type, .screenNotFound)
+    }
+
+    func testAContextKeyFetchSkipsTheUnusableScreensAndServesTheRest() async throws {
+        let processor = SpyRequestProcessor()
+        processor.enqueue(payload: """
+        [null,
+         {"id": "broken", "body": null, "context_key": "main"},
+         {"id": "good", "body": "<html>hi</html>", "context_key": "main"}]
+        """)
+        let service = NoCodesService(requestProcessor: processor)
+
+        let screen: NoCodesScreen = try await service.loadScreen(withContextKey: "main")
+
+        XCTAssertEqual(screen.id, "good")
+    }
+
+    func testAListOfOnlyUnusableScreensIsReportedAsScreenNotFound() async throws {
+        let processor = SpyRequestProcessor()
+        processor.enqueue(payload: #"[{"id": "broken", "body": null, "context_key": "main"}]"#)
+        let service = NoCodesService(requestProcessor: processor)
+
+        let error: NoCodesError = await captureError {
+            _ = try await service.loadScreen(withContextKey: "main")
+        }
+
+        XCTAssertEqual(error.type, .screenNotFound)
+    }
+
+    func testPreloadSkipsTheUnusableScreens() async throws {
+        let processor = SpyRequestProcessor()
+        processor.enqueue(payload: """
+        [{"id": "broken", "body": null, "context_key": "a"},
+         {"id": "good", "body": "<html>hi</html>", "context_key": "b"}]
+        """)
+        let service = NoCodesService(requestProcessor: processor)
+
+        let screens: [NoCodesScreen] = try await service.preloadScreens()
+
+        XCTAssertEqual(screens.map { $0.id }, ["good"])
+    }
+
+    func testAScreenWithoutAContextKeyIsStillServedAndCachedById() async throws {
+        let processor = SpyRequestProcessor()
+        processor.enqueue(payload: #"{"id": "screen-1", "body": "<html>hi</html>", "context_key": null}"#)
+        let service = NoCodesService(requestProcessor: processor)
+
+        let screen: NoCodesScreen = try await service.loadScreen(with: "screen-1")
+        _ = try await service.loadScreen(with: "screen-1")
+
+        XCTAssertNil(screen.contextKey)
+        XCTAssertEqual(processor.processedRequestsCount, 1, "the second load is served from the id cache")
     }
 
     func testOtherFailuresAreWrappedAsScreenLoadingFailed() async throws {

--- a/Tests/QonversionUnitTests/CrashReportingTests.swift
+++ b/Tests/QonversionUnitTests/CrashReportingTests.swift
@@ -279,18 +279,59 @@ final class CrashReportsStorageTests: XCTestCase {
         XCTAssertEqual(storage.all().map { $0.sendAttempts }, [1, 0])
     }
 
-    func testTheRequestBodyMatchesTheProposedContract() throws {
-        let body: RequestBodyDict = makeReport(id: "r1").requestBody(userId: "QON_u", platform: "iOS")
+    func testTheRequestBodyMatchesTheObjCSdkLogsEnvelope() throws {
+        // The receiving service is the one the ObjC SDK has always shipped to,
+        // and its envelope is the ObjC one, key for key.
+        let body: RequestBodyDict = makeReport(id: "r1").requestBody(device: Self.device)
 
-        XCTAssertEqual(body["sdk_version"] as? String, "6.0.0")
-        XCTAssertEqual(body["platform"] as? String, "iOS")
-        XCTAssertEqual(body["user_id"] as? String, "QON_u")
-        XCTAssertEqual(body["occurred_at"] as? Int, 1_700_000_000)
+        XCTAssertEqual(Set(body.keys), ["device", "exception"])
+
+        let device = try XCTUnwrap(body["device"] as? RequestBodyDict)
+        XCTAssertEqual(Set(device.keys), ["platform", "platform_version", "source", "source_version", "project_key", "uid"])
+        XCTAssertEqual(device["platform"] as? String, "iOS")
+        XCTAssertEqual(device["platform_version"] as? String, "17.0")
+        XCTAssertEqual(device["source"] as? String, "iOS")
+        XCTAssertEqual(device["source_version"] as? String, "6.0.0")
+        XCTAssertEqual(device["project_key"] as? String, "test-project-key")
+        XCTAssertEqual(device["uid"] as? String, "QON_u")
+
         let exception = try XCTUnwrap(body["exception"] as? RequestBodyDict)
         XCTAssertEqual(exception["name"] as? String, "NSInvalidArgumentException")
-        XCTAssertEqual(exception["linkage"] as? String, "spm")
-        XCTAssertEqual((exception["stack_trace"] as? RequestBodyArray)?.count, 1)
+        XCTAssertEqual(exception["message"] as? String, "-[NSNull length]: unrecognized selector sent to instance")
+        XCTAssertEqual(exception["title"] as? String, "NSInvalidArgumentException: -[NSNull length]: unrecognized selector sent to instance")
+        XCTAssertEqual(exception["rawStackTrace"] as? String, "0   Qonversion   0x01 sym + 1")
+        XCTAssertEqual(exception["elements"] as? [String], ["0   Qonversion   0x01 sym + 1"])
+        XCTAssertEqual(exception["isSpm"] as? Bool, true)
+        XCTAssertEqual(exception["userInfo"] as? RequestBodyDict, [:])
+        // Ours, carried inside the crash payload the service stores as-is.
+        XCTAssertEqual(exception["sdk_version"] as? String, "6.0.0")
+        XCTAssertEqual(exception["occurred_at"] as? Int, 1_700_000_000)
     }
+
+    func testTheRawStackTraceJoinsTheFramesTheWayObjCDid() throws {
+        let report = CrashReport(
+            id: "r1",
+            name: "NSRangeException",
+            reason: "out of bounds",
+            stackTrace: ["0 Qonversion 0x01 a + 1", "1 MyApp 0x02 b + 2"],
+            linkage: .framework
+        )
+
+        let body: RequestBodyDict = report.requestBody(device: Self.device)
+
+        let exception = try XCTUnwrap(body["exception"] as? RequestBodyDict)
+        XCTAssertEqual(exception["rawStackTrace"] as? String, "0 Qonversion 0x01 a + 1\n1 MyApp 0x02 b + 2")
+        XCTAssertEqual(exception["isSpm"] as? Bool, false)
+    }
+
+    static let device = SdkLogDevice(
+        platform: "iOS",
+        platformVersion: "17.0",
+        source: "iOS",
+        sourceVersion: "6.0.0",
+        projectKey: "test-project-key",
+        uid: "QON_u"
+    )
 }
 
 // MARK: - the handler and the send on the next launch
@@ -393,236 +434,112 @@ final class CrashReporterTests: XCTestCase {
 
     // MARK: - send on the next launch
 
-    private func makeSender(processor: RequestProcessorInterface) -> CrashReportsSender {
+    private func makeSender(transport: CrashReportsTransportInterface) -> CrashReportsSender {
         let userIdProvider = InternalConfig(userId: "QON_u")
 
         return CrashReportsSender(
             storage: storage,
-            requestProcessor: processor,
+            transport: transport,
             userIdProvider: userIdProvider,
             userManager: userManager,
-            platform: "iOS"
+            device: CrashReportsStorageTests.device
         )
+    }
+
+    /// The real transport over a stubbed socket: the URL, the method and the
+    /// status handling are the ones production would use.
+    private func makeTransport(networkProvider: MockNetworkProvider) -> CrashReportsTransport {
+        return CrashReportsTransport(networkProvider: networkProvider)
+    }
+
+    private func makeNetworkProvider(statusCode: Int) -> MockNetworkProvider {
+        let networkProvider = MockNetworkProvider()
+        networkProvider.response = HTTPURLResponse(url: URL(string: "https://sdk-logs.qonversion.io/sdk.log")!, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
+        networkProvider.responseData = Data()
+
+        return networkProvider
     }
 
     private func makeReport(id: String) -> CrashReport {
         return CrashReport(id: id, name: "NSInvalidArgumentException", reason: "boom", stackTrace: ["0 Qonversion 0x01 sym + 1"], linkage: .spm)
     }
 
+    // MARK: - the target
+
+    func testReportsGoToTheSdkLogsServiceNotTheApi() async throws {
+        storage.store(makeReport(id: "r1"))
+        let networkProvider = makeNetworkProvider(statusCode: 200)
+
+        await makeSender(transport: makeTransport(networkProvider: networkProvider)).sendStoredReports()
+
+        let request: URLRequest = try XCTUnwrap(networkProvider.sentRequests.first)
+        XCTAssertEqual(request.url?.absoluteString, "https://sdk-logs.qonversion.io/sdk.log")
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+        // The ObjC client sends Content-Type and nothing else: the project key
+        // travels in the body, not in an Authorization header.
+        XCTAssertNil(request.value(forHTTPHeaderField: "Authorization"))
+    }
+
+    func testTheSentBodyCarriesTheDeviceEnvelopeAndTheCrashPayload() async throws {
+        storage.store(makeReport(id: "r1"))
+        let networkProvider = makeNetworkProvider(statusCode: 200)
+
+        await makeSender(transport: makeTransport(networkProvider: networkProvider)).sendStoredReports()
+
+        let body: Data = try XCTUnwrap(networkProvider.sentRequests.first?.httpBody)
+        let decoded = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+        XCTAssertEqual(Set(decoded.keys), ["device", "exception"])
+        let device = try XCTUnwrap(decoded["device"] as? [String: Any])
+        // The uid is the one the gate resolved, not the placeholder the
+        // assembly built the envelope with.
+        XCTAssertEqual(device["uid"] as? String, "QON_u")
+        XCTAssertEqual(device["project_key"] as? String, "test-project-key")
+        let exception = try XCTUnwrap(decoded["exception"] as? [String: Any])
+        XCTAssertEqual(exception["name"] as? String, "NSInvalidArgumentException")
+    }
+
+    // MARK: - delivered or not, nothing in between
+
     func testStoredReportsAreSentAndDropped() async {
         storage.store(makeReport(id: "r1"))
         storage.store(makeReport(id: "r2"))
-        let processor = MockRequestProcessor()
-        processor.results = [EmptyApiResponse(), EmptyApiResponse()]
+        let networkProvider = makeNetworkProvider(statusCode: 200)
 
-        await makeSender(processor: processor).sendStoredReports()
+        await makeSender(transport: makeTransport(networkProvider: networkProvider)).sendStoredReports()
 
-        XCTAssertEqual(processor.processedRequests.count, 2)
-        guard case let .sdkCrash(endpoint, body, type) = processor.processedRequests[0] else {
-            return XCTFail("Expected an .sdkCrash request")
-        }
-        XCTAssertEqual(endpoint, "v4/sdk-crashes")
-        XCTAssertEqual(type, .post)
-        XCTAssertEqual(body["user_id"] as? String, "QON_u")
+        XCTAssertEqual(networkProvider.sentRequests.count, 2)
         XCTAssertTrue(storage.all().isEmpty, "a delivered report is not sent again")
     }
 
-    func testTheUserGateIsPassedBeforeTheFirstReportIsSent() async {
-        // A crash on the very first launch is reported before createUser ever
-        // ran: the uid on the report is then one the backend has never seen,
-        // and the send is refused with a 4xx that drops the report for good.
+    func testAnyTwoHundredCountsAsDelivered() async {
         storage.store(makeReport(id: "r1"))
-        storage.store(makeReport(id: "r2"))
-        let processor = MockRequestProcessor()
-        processor.results = [EmptyApiResponse(), EmptyApiResponse()]
-        processor.onProcess = { [weak self] in
-            guard let self, self.gateCallsAtFirstRequest < 0 else { return }
-            self.gateCallsAtFirstRequest = self.userManager.obtainUserCallsCount
-        }
+        // The service answers 204 as readily as 200, and its body is never
+        // parsed — the status line is the whole verdict.
+        let networkProvider = makeNetworkProvider(statusCode: 204)
 
-        await makeSender(processor: processor).sendStoredReports()
+        await makeSender(transport: makeTransport(networkProvider: networkProvider)).sendStoredReports()
 
-        XCTAssertEqual(gateCallsAtFirstRequest, 1, "the backend user must exist before a report carries its uid")
-        XCTAssertEqual(userManager.obtainUserCallsCount, 1, "one gate pass per launch, not one per report")
-        XCTAssertEqual(processor.processedRequests.count, 2)
+        XCTAssertTrue(storage.all().isEmpty)
     }
 
-    func testAFailingUserGateKeepsTheReportsForTheNextLaunch() async {
-        storage.store(makeReport(id: "r1"))
-        userManager.error = MockError.stubbed
-        let processor = MockRequestProcessor()
-
-        await makeSender(processor: processor).sendStoredReports()
-
-        XCTAssertTrue(processor.processedRequests.isEmpty, "no report may be sent under a uid the backend does not have")
-        XCTAssertEqual(storage.all().map { $0.id }, ["r1"], "a gate failure costs the report nothing")
-    }
-
-    func testAnEmptyQueueSendsNothing() async {
-        let processor = MockRequestProcessor()
-
-        await makeSender(processor: processor).sendStoredReports()
-
-        XCTAssertTrue(processor.processedRequests.isEmpty)
-    }
-
-    func testARevokedProjectKeyKeepsTheReportForTheNextLaunch() async {
-        // .critical is thrown by the revoked-key latch BEFORE the request ever
-        // leaves the device, so it says nothing about the report. Treating it
-        // as "the backend answered" destroys every stored report on one launch.
-        storage.store(makeReport(id: "r1"))
-        let processor = MockRequestProcessor()
-        processor.error = QonversionError(type: .critical)
-
-        await makeSender(processor: processor).sendStoredReports()
-
-        XCTAssertEqual(storage.all().map { $0.id }, ["r1"], "nothing was ever sent — the report is not delivered")
-    }
-
-    func testAThrottledSendKeepsTheReportForTheNextLaunch() async {
-        storage.store(makeReport(id: "r1"))
-        let processor = MockRequestProcessor()
-        processor.error = QonversionError(type: .rateLimitExceeded)
-
-        await makeSender(processor: processor).sendStoredReports()
-
-        XCTAssertEqual(storage.all().map { $0.id }, ["r1"], "the rate limiter refused to send it, the backend never saw it")
-    }
-
-    func testAnErrorWithoutAnHttpStatusKeepsTheReport() async {
-        // Nothing here proves the backend saw the report: a status-less
-        // failure is raised before the request leaves the device (a bad URL,
-        // the latch, the local limiter) or by transport. Deleting on the
-        // semantic type alone is what makes such a failure lose crash reports.
-        storage.store(makeReport(id: "r1"))
-        let processor = MockRequestProcessor()
-        processor.error = QonversionError(type: .invalidRequest)
-
-        await makeSender(processor: processor).sendStoredReports()
-
-        XCTAssertEqual(storage.all().map { $0.id }, ["r1"], "no status, no proof of delivery")
-    }
-
-    func testAConnectionFailureKeepsTheReportForTheNextLaunch() async {
-        // .networkConnectionFailed is the network layer's name for a request
-        // that never reached the backend. It is the most ordinary way a crash
-        // report's send fails — the user who crashed was offline — so it must
-        // fall to the KEEP default, never to the drop set.
-        storage.store(makeReport(id: "r1"))
-        let processor = MockRequestProcessor()
-        let connectionError: QonversionError = QonversionError(type: .networkConnectionFailed, error: URLError(.notConnectedToInternet))
-        processor.error = connectionError
-
-        await makeSender(processor: processor).sendStoredReports()
-
-        XCTAssertEqual(storage.all().map { $0.id }, ["r1"], "the request never reached the backend — the report is not delivered")
-    }
-
-    func testAKeptReportStopsTheLaunchInsteadOfBurningTheWholeQueue() async {
-        storage.store(makeReport(id: "r1"))
-        storage.store(makeReport(id: "r2"))
-        let processor = MockRequestProcessor()
-        processor.error = QonversionError(type: .critical)
-
-        await makeSender(processor: processor).sendStoredReports()
-
-        XCTAssertEqual(processor.processedRequests.count, 1, "one refusal is enough to know the rest will be refused too")
-        XCTAssertEqual(storage.all().map { $0.id }, ["r1", "r2"])
-    }
-
-    func testATransportFailureKeepsTheReportForTheNextLaunch() async {
-        storage.store(makeReport(id: "r1"))
-        let processor = MockRequestProcessor()
-        processor.error = QonversionError(type: .invalidResponse, error: URLError(.notConnectedToInternet))
-
-        await makeSender(processor: processor).sendStoredReports()
-
-        XCTAssertEqual(storage.all().map { $0.id }, ["r1"])
-    }
-
-    func testSendingNeverThrowsAtTheCaller() async {
-        storage.store(makeReport(id: "r1"))
-        let processor = MockRequestProcessor()
-        processor.error = MockError.stubbed
-
-        // No `try`: the API itself guarantees the host is never bothered.
-        await makeSender(processor: processor).sendStoredReports()
-
-        XCTAssertNotNil(storage.all().first)
-    }
-
-    // MARK: - the answers the real network layer actually produces
-    //
-    // The classification lives or dies on what a QonversionError CARRIES, not
-    // on what a hand-built one is labelled with. Every case below is driven
-    // through the real RequestProcessor and the real NetworkErrorHandler, so
-    // the type and the status are the ones production would see.
-
-    private func makeRealProcessor(networkProvider: MockNetworkProvider) -> RequestProcessor {
-        let responseDecoder = ResponseDecoder(decoder: JSONDecoder())
-        let criticalErrorCodes: [ResponseCode] = [.unauthorized, .paymentRequired, .forbidden]
-        let networkErrorHandler = NetworkErrorHandler(criticalErrorCodes: criticalErrorCodes, decoder: responseDecoder)
-
-        return RequestProcessor(
-            baseURL: "https://api.qonversion.io/",
-            networkProvider: networkProvider,
-            headersBuilder: MockHeadersBuilder(),
-            errorHandler: networkErrorHandler,
-            decoder: responseDecoder,
-            retriableRequestKinds: [],
-            requestsStorage: MockRequestsStorage(),
-            rateLimiter: MockRateLimiter(),
-            // The backoff is proven elsewhere; waiting it out here would only
-            // make the suite slow.
-            transportRetryDelayCeiling: 0
-        )
-    }
-
-    private func makeCrashResponse(statusCode: Int) -> HTTPURLResponse {
-        let url = URL(string: "https://api.qonversion.io/v4/sdk-crashes")!
-
-        return HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
-    }
-
-    private func makeNetworkProvider(statusCode: Int, body: Data = Data()) -> MockNetworkProvider {
-        let networkProvider = MockNetworkProvider()
-        networkProvider.response = makeCrashResponse(statusCode: statusCode)
-        networkProvider.responseData = body
-
-        return networkProvider
-    }
-
-    func testAnUnroutedGatewayNotFoundDropsTheReport() async {
-        // The motivating shape: `POST v4/sdk-crashes` does not exist yet, so
-        // the gateway answers 404 with no application error envelope at all.
-        // There is no `not_found` slug to classify it, so it arrives as
-        // .unknown — deleting only on .resourceNotFound leaves the queue
-        // pinned forever, one wasted POST per launch.
-        storage.store(makeReport(id: "r1"))
-        let networkProvider = makeNetworkProvider(statusCode: 404, body: Data("<html><body>404 Not Found</body></html>".utf8))
-
-        await makeSender(processor: makeRealProcessor(networkProvider: networkProvider)).sendStoredReports()
-
-        XCTAssertTrue(storage.all().isEmpty, "the gateway answered 404 — resending it every launch changes nothing")
-    }
-
-    func testAMalformedRequestRejectionDropsTheReport() async {
-        storage.store(makeReport(id: "r1"))
-        let body = Data(#"{"error": {"type": "request", "code": "invalid_data", "message": "bad body"}}"#.utf8)
-        let networkProvider = makeNetworkProvider(statusCode: 400, body: body)
-
-        await makeSender(processor: makeRealProcessor(networkProvider: networkProvider)).sendStoredReports()
-
-        XCTAssertTrue(storage.all().isEmpty, "the body will be just as invalid next launch")
-    }
-
-    func testAServerFailureFromTheBackendKeepsTheReport() async {
+    func testAnAnswerThatIsNotTwoHundredKeepsTheReport() async {
         storage.store(makeReport(id: "r1"))
         let networkProvider = makeNetworkProvider(statusCode: 500)
 
-        await makeSender(processor: makeRealProcessor(networkProvider: networkProvider)).sendStoredReports()
+        await makeSender(transport: makeTransport(networkProvider: networkProvider)).sendStoredReports()
 
-        XCTAssertEqual(storage.all().map { $0.id }, ["r1"], "5xx means the backend did not process it")
+        XCTAssertEqual(storage.all().map { $0.id }, ["r1"])
+        XCTAssertEqual(storage.all().map { $0.sendAttempts }, [1], "the service saw it and refused — that costs an attempt")
+    }
+
+    func testAClientRejectionAlsoKeepsTheReportUntilItsBudgetIsSpent() async {
+        storage.store(makeReport(id: "r1"))
+        let networkProvider = makeNetworkProvider(statusCode: 400)
+
+        await makeSender(transport: makeTransport(networkProvider: networkProvider)).sendStoredReports()
+
+        XCTAssertEqual(storage.all().map { $0.sendAttempts }, [1])
     }
 
     func testAnOfflineSendKeepsTheReport() async {
@@ -630,53 +547,42 @@ final class CrashReporterTests: XCTestCase {
         let networkProvider = MockNetworkProvider()
         networkProvider.error = URLError(.notConnectedToInternet)
 
-        await makeSender(processor: makeRealProcessor(networkProvider: networkProvider)).sendStoredReports()
+        await makeSender(transport: makeTransport(networkProvider: networkProvider)).sendStoredReports()
 
         XCTAssertEqual(storage.all().map { $0.id }, ["r1"], "no answer at all is not a rejection")
     }
 
-    func testARevokedKeyStatusKeepsTheReport() async {
+    func testAnOfflineLaunchDoesNotBurnTheAttemptBudget() async {
+        // A user offline for a week must not lose the crash report that week:
+        // the failures say nothing about the report, so they cost it nothing.
         storage.store(makeReport(id: "r1"))
-        let networkProvider = makeNetworkProvider(statusCode: 401)
-
-        await makeSender(processor: makeRealProcessor(networkProvider: networkProvider)).sendStoredReports()
-
-        XCTAssertEqual(storage.all().map { $0.id }, ["r1"], "the key is the problem, not the report")
-    }
-
-    func testAThrottlingStatusKeepsTheReport() async {
-        storage.store(makeReport(id: "r1"))
-        let networkProvider = makeNetworkProvider(statusCode: 429)
-
-        await makeSender(processor: makeRealProcessor(networkProvider: networkProvider)).sendStoredReports()
-
-        XCTAssertEqual(storage.all().map { $0.id }, ["r1"], "429 is a 4xx that says come back later")
-    }
-
-    // MARK: - one bad report must not starve the queue
-
-    func testAPerReportRejectionDoesNotStarveTheRestOfTheQueue() async {
-        // The first report is poison — the backend chokes on it every time.
-        // Stopping the launch there means the healthy second report is never
-        // sent, on this launch or any other.
-        storage.store(makeReport(id: "poison"))
-        storage.store(makeReport(id: "healthy"))
         let networkProvider = MockNetworkProvider()
-        networkProvider.responseData = Data()
-        networkProvider.response = makeCrashResponse(statusCode: 500)
-        networkProvider.onSend = { [weak networkProvider] in
-            guard let networkProvider else { return }
-            let isFirstSend: Bool = networkProvider.sentRequests.count == 1
-            networkProvider.response = self.makeCrashResponse(statusCode: isFirstSend ? 500 : 204)
+        networkProvider.error = URLError(.notConnectedToInternet)
+
+        for _ in 0...CrashReportsSender.maxSendAttempts {
+            await makeSender(transport: makeTransport(networkProvider: networkProvider)).sendStoredReports()
         }
 
-        await makeSender(processor: makeRealProcessor(networkProvider: networkProvider)).sendStoredReports()
-
-        XCTAssertEqual(networkProvider.sentRequests.count, 2, "the second report deserved its own attempt")
-        XCTAssertEqual(storage.all().map { $0.id }, ["poison"], "the healthy report was delivered and dropped")
+        XCTAssertEqual(storage.all().map { $0.sendAttempts }, [0], "only an answer from the service costs an attempt")
     }
 
-    func testAReportTheBackendKeepsRejectingIsEventuallyGivenUpOn() async {
+    func testAnUnreachableServiceStopsTheLaunch() async {
+        // Every following send would fail the same way, so trying them is
+        // pure waste.
+        storage.store(makeReport(id: "r1"))
+        storage.store(makeReport(id: "r2"))
+        let networkProvider = MockNetworkProvider()
+        networkProvider.error = URLError(.notConnectedToInternet)
+
+        await makeSender(transport: makeTransport(networkProvider: networkProvider)).sendStoredReports()
+
+        XCTAssertEqual(networkProvider.sentRequests.count, 1, "one failure is enough to know the network is down")
+        XCTAssertEqual(storage.all().map { $0.id }, ["r1", "r2"])
+    }
+
+    // MARK: - the attempt budget
+
+    func testAReportTheServiceKeepsRejectingIsEventuallyGivenUpOn() async {
         // A payload the service chokes on answers the same way every launch.
         // Without a budget it would hold one of the five slots and one POST per
         // launch for the lifetime of the install.
@@ -684,44 +590,139 @@ final class CrashReporterTests: XCTestCase {
         let networkProvider = makeNetworkProvider(statusCode: 500)
 
         for launch in 1..<CrashReportsSender.maxSendAttempts {
-            await makeSender(processor: makeRealProcessor(networkProvider: networkProvider)).sendStoredReports()
+            await makeSender(transport: makeTransport(networkProvider: networkProvider)).sendStoredReports()
 
             XCTAssertEqual(storage.all().map { $0.sendAttempts }, [launch], "launch \(launch) counts against the budget")
         }
-        await makeSender(processor: makeRealProcessor(networkProvider: networkProvider)).sendStoredReports()
+        await makeSender(transport: makeTransport(networkProvider: networkProvider)).sendStoredReports()
 
         XCTAssertTrue(storage.all().isEmpty, "the budget is spent — the slot goes back to the reports that can be delivered")
     }
 
-    func testAnOfflineLaunchDoesNotBurnTheAttemptBudget() async {
-        // A user who is offline for a week must not lose the crash report that
-        // week: the failures say nothing about the report, so they cost it
-        // nothing.
-        storage.store(makeReport(id: "r1"))
-        let networkProvider = MockNetworkProvider()
-        networkProvider.error = URLError(.notConnectedToInternet)
-
-        for _ in 0...CrashReportsSender.maxSendAttempts {
-            await makeSender(processor: makeRealProcessor(networkProvider: networkProvider)).sendStoredReports()
+    func testAPerReportRejectionDoesNotStarveTheRestOfTheQueue() async {
+        // The first report is poison — the service chokes on it every time.
+        // Stopping the launch there means the healthy second report is never
+        // sent, on this launch or any other.
+        storage.store(makeReport(id: "poison"))
+        storage.store(makeReport(id: "healthy"))
+        let networkProvider = makeNetworkProvider(statusCode: 500)
+        networkProvider.onSend = { [weak networkProvider] in
+            guard let networkProvider else { return }
+            let isFirstSend: Bool = networkProvider.sentRequests.count == 1
+            networkProvider.response = HTTPURLResponse(url: URL(string: "https://sdk-logs.qonversion.io/sdk.log")!, statusCode: isFirstSend ? 500 : 200, httpVersion: nil, headerFields: nil)!
         }
 
-        XCTAssertEqual(storage.all().map { $0.sendAttempts }, [0], "only an answer from the backend costs an attempt")
+        await makeSender(transport: makeTransport(networkProvider: networkProvider)).sendStoredReports()
+
+        XCTAssertEqual(networkProvider.sentRequests.count, 2, "the second report deserved its own attempt")
+        XCTAssertEqual(storage.all().map { $0.id }, ["poison"], "the healthy report was delivered and dropped")
     }
 
-    func testAnEnvironmentWideFailureStopsTheLaunch() async {
-        // Offline is not the report's fault and not the report's problem:
-        // every following send would fail the same way, so trying them is
-        // pure waste.
+    // MARK: - the user gate
+
+    func testTheUserGateIsPassedBeforeTheFirstReportIsSent() async {
         storage.store(makeReport(id: "r1"))
         storage.store(makeReport(id: "r2"))
+        let networkProvider = makeNetworkProvider(statusCode: 200)
+        networkProvider.onSend = { [weak self] in
+            guard let self, self.gateCallsAtFirstRequest < 0 else { return }
+            self.gateCallsAtFirstRequest = self.userManager.obtainUserCallsCount
+        }
+
+        await makeSender(transport: makeTransport(networkProvider: networkProvider)).sendStoredReports()
+
+        XCTAssertEqual(gateCallsAtFirstRequest, 1, "the backend user must exist before a report carries its uid")
+        XCTAssertEqual(userManager.obtainUserCallsCount, 1, "one gate pass per launch, not one per report")
+        XCTAssertEqual(networkProvider.sentRequests.count, 2)
+    }
+
+    func testAFailingUserGateKeepsTheReportsForTheNextLaunch() async {
+        storage.store(makeReport(id: "r1"))
+        userManager.error = MockError.stubbed
+        let networkProvider = makeNetworkProvider(statusCode: 200)
+
+        await makeSender(transport: makeTransport(networkProvider: networkProvider)).sendStoredReports()
+
+        XCTAssertTrue(networkProvider.sentRequests.isEmpty, "no report may be sent under a uid the backend does not have")
+        XCTAssertEqual(storage.all().map { $0.id }, ["r1"], "a gate failure costs the report nothing")
+    }
+
+    func testAnEmptyQueueSendsNothing() async {
+        let networkProvider = makeNetworkProvider(statusCode: 200)
+
+        await makeSender(transport: makeTransport(networkProvider: networkProvider)).sendStoredReports()
+
+        XCTAssertTrue(networkProvider.sentRequests.isEmpty)
+    }
+
+    func testSendingNeverThrowsAtTheCaller() async {
+        storage.store(makeReport(id: "r1"))
         let networkProvider = MockNetworkProvider()
-        networkProvider.error = URLError(.notConnectedToInternet)
+        networkProvider.error = MockError.stubbed
 
-        await makeSender(processor: makeRealProcessor(networkProvider: networkProvider)).sendStoredReports()
+        // No `try`: the API itself guarantees the host is never bothered.
+        await makeSender(transport: makeTransport(networkProvider: networkProvider)).sendStoredReports()
 
-        XCTAssertEqual(networkProvider.sentRequests.count, RequestProcessor.maxTransportRetries + 1,
-                       "one report's worth of transport retries, then the launch gives up")
-        XCTAssertEqual(storage.all().map { $0.id }, ["r1", "r2"])
+        XCTAssertNotNil(storage.all().first)
+    }
+}
+
+// MARK: - the source the envelope reports
+
+final class SdkLogDeviceTests: XCTestCase {
+
+    private let deviceInfo = HeaderDeviceInfo(appVersion: "1.2.3", country: "US", language: "en", osName: "iOS", osVersion: "17.0")
+
+    private func makeDevice(userDefaults: UserDefaults) -> SdkLogDevice {
+        return SdkLogDevice.make(deviceInfo: deviceInfo, projectKey: "key", sdkVersion: "6.0.0", userDefaults: userDefaults)
+    }
+
+    func testTheNativeSdkReportsItselfAsTheSource() {
+        let device: SdkLogDevice = makeDevice(userDefaults: TestDefaults.makeIsolated())
+
+        XCTAssertEqual(device.source, "iOS")
+        XCTAssertEqual(device.sourceVersion, "6.0.0")
+    }
+
+    func testACrossPlatformWrapperReportsItsOwnSource() {
+        let defaults: UserDefaults = TestDefaults.makeIsolated()
+        defaults.set("flutter", forKey: "com.qonversion.keys.source")
+        defaults.set("9.9.9", forKey: "com.qonversion.keys.sourceVersion")
+
+        let device: SdkLogDevice = makeDevice(userDefaults: defaults)
+
+        XCTAssertEqual(device.source, "flutter")
+        XCTAssertEqual(device.sourceVersion, "9.9.9")
+    }
+
+    func testALeftoverVersionWithoutASourceIsIgnored() {
+        // The Objective-C SDK persisted its own version under this key.
+        let defaults: UserDefaults = TestDefaults.makeIsolated()
+        defaults.set("5.0.0", forKey: "com.qonversion.keys.sourceVersion")
+
+        let device: SdkLogDevice = makeDevice(userDefaults: defaults)
+
+        XCTAssertEqual(device.source, "iOS")
+        XCTAssertEqual(device.sourceVersion, "6.0.0")
+    }
+
+    func testTheEnvelopeAgreesWithTheRequestHeaders() {
+        // Two implementations of one resolution rule: the sdk-logs service
+        // reads both, and they must never disagree.
+        let defaults: UserDefaults = TestDefaults.makeIsolated()
+        defaults.set("react-native", forKey: "com.qonversion.keys.source")
+        defaults.set("4.4.4", forKey: "com.qonversion.keys.sourceVersion")
+        let collector = MockDeviceInfoCollector()
+        let headersBuilder = HeadersBuilder(apiKey: "key", sdkVersion: "6.0.0", deviceInfoCollector: collector, userDefaults: defaults)
+        var request = URLRequest(url: URL(string: "https://api2.qonversion.io/")!)
+        headersBuilder.addHeaders(to: &request)
+
+        let device: SdkLogDevice = SdkLogDevice.make(deviceInfo: collector.headerDeviceInfo(), projectKey: "key", sdkVersion: "6.0.0", userDefaults: defaults)
+
+        XCTAssertEqual(device.source, request.value(forHTTPHeaderField: "Source"))
+        XCTAssertEqual(device.sourceVersion, request.value(forHTTPHeaderField: "Source-Version"))
+        XCTAssertEqual(device.platform, request.value(forHTTPHeaderField: "Platform"))
+        XCTAssertEqual(device.platformVersion, request.value(forHTTPHeaderField: "Platform-Version"))
     }
 }
 

--- a/Tests/QonversionUnitTests/DeviceManagerTests.swift
+++ b/Tests/QonversionUnitTests/DeviceManagerTests.swift
@@ -34,8 +34,8 @@ final class DeviceManagerTests: XCTestCase {
 
     func testUserChangeDropsTheStoredDeviceRecord() {
         deviceService.current = Device(
-            manufacturer: "Apple", osName: "iOS", osVersion: "17.0", model: "iPhone15,2",
-            appVersion: "1.0", country: "US", language: "en", timezone: "UTC",
+            osName: "iOS", osVersion: "17.0", model: "iPhone15,2",
+            appVersion: "1.0", country: "US", language: "en",
             advertisingId: nil, vendorId: "v", installDate: 1
         )
 
@@ -48,14 +48,12 @@ final class DeviceManagerTests: XCTestCase {
 
     private func makeTestDevice(osVersion: String = "17.0", advertisingId: String? = nil) -> Device {
         return Device(
-            manufacturer: "Apple",
             osName: "iOS",
             osVersion: osVersion,
             model: "iPhone15,2",
             appVersion: "1.2.3",
             country: "US",
             language: "en",
-            timezone: "America/New_York",
             advertisingId: advertisingId,
             vendorId: "vendor-id",
             installDate: 1_700_000_000

--- a/Tests/QonversionUnitTests/DeviceServiceTests.swift
+++ b/Tests/QonversionUnitTests/DeviceServiceTests.swift
@@ -33,14 +33,12 @@ final class DeviceServiceTests: XCTestCase {
         installDate: TimeInterval = 1_700_000_000
     ) -> Device {
         Device(
-            manufacturer: "Apple",
             osName: "iOS",
             osVersion: "17.0",
             model: model,
             appVersion: "1.2.3",
             country: "US",
             language: "en",
-            timezone: "America/New_York",
             advertisingId: advertisingId,
             vendorId: "vendor-id",
             installDate: installDate
@@ -95,17 +93,81 @@ final class DeviceServiceTests: XCTestCase {
         XCTAssertEqual(requestUserId, userId)
         XCTAssertEqual(endpoint, "v4/users/%@/device")
         XCTAssertEqual(type, .post)
-        XCTAssertEqual(body["manufacturer"] as? String, "Apple")
-        XCTAssertEqual(body["osName"] as? String, "iOS")
-        XCTAssertEqual(body["osVersion"] as? String, "17.0")
+        XCTAssertEqual(body["os_name"] as? String, "iOS")
+        XCTAssertEqual(body["os_version"] as? String, "17.0")
         XCTAssertEqual(body["model"] as? String, "iPhone15,2")
-        XCTAssertEqual(body["appVersion"] as? String, "1.2.3")
+        XCTAssertEqual(body["app_version"] as? String, "1.2.3")
         XCTAssertEqual(body["country"] as? String, "US")
         XCTAssertEqual(body["language"] as? String, "en")
-        XCTAssertEqual(body["timezone"] as? String, "America/New_York")
-        XCTAssertEqual(body["advertisingId"] as? String, "ad-id")
-        XCTAssertEqual(body["vendorId"] as? String, "vendor-id")
-        XCTAssertEqual(body["installDate"] as? TimeInterval, 1_700_000_000)
+        XCTAssertEqual(body["advertising_id"] as? String, "ad-id")
+        XCTAssertEqual(body["vendor_id"] as? String, "vendor-id")
+        XCTAssertEqual(body["install_date"] as? Int, 1_700_000_000)
+    }
+
+    func testTheWireBodyIsExactlyTheAgreedKeySet() async throws {
+        // The canonical device body. Any key added, renamed or dropped here is
+        // a contract break with the backend, which implements the same set.
+        let processor = MockRequestProcessor()
+        let service = makeService(processor: processor)
+        processor.results = [makeDevice()]
+
+        _ = try await service.create(device: makeDevice(advertisingId: "ad-id"))
+
+        guard case let .createDevice(_, _, body, _) = processor.processedRequests[0] else {
+            return XCTFail("Expected createDevice request")
+        }
+        let expectedKeys: Set<String> = [
+            "os_name",
+            "os_version",
+            "model",
+            "app_version",
+            "country",
+            "language",
+            "advertising_id",
+            "vendor_id",
+            "install_date"
+        ]
+        XCTAssertEqual(Set(body.keys), expectedKeys)
+    }
+
+    func testTheInstallDateTravelsAsUnixSeconds() async throws {
+        let processor = MockRequestProcessor()
+        let service = makeService(processor: processor)
+        processor.results = [makeDevice()]
+
+        _ = try await service.create(device: makeDevice(installDate: 1_700_000_000.75))
+
+        guard case let .createDevice(_, _, body, _) = processor.processedRequests[0] else {
+            return XCTFail("Expected createDevice request")
+        }
+        // An integer, not a fractional double: the backend column is seconds.
+        XCTAssertEqual(body["install_date"] as? Int, 1_700_000_000)
+    }
+
+    func testTheEchoedRecordDecodesFromTheSameKeys() throws {
+        // The endpoint answers with the object it was sent — same keys.
+        let echo = Data("""
+        {"os_name":"iOS","os_version":"17.0","model":"iPhone15,2","app_version":"1.2.3",\
+        "country":"US","language":"en","advertising_id":"ad-id","vendor_id":"vendor-id",\
+        "install_date":1700000000}
+        """.utf8)
+
+        let device: Device = try JSONDecoder().decode(Device.self, from: echo)
+
+        XCTAssertEqual(device.osName, "iOS")
+        XCTAssertEqual(device.advertisingId, "ad-id")
+        XCTAssertEqual(device.installDate, 1_700_000_000)
+    }
+
+    func testATruncatedEchoStillDecodes() throws {
+        // A record the SDK just created must not be lost to a partial answer.
+        let echo = Data(#"{"os_name":"iOS"}"#.utf8)
+
+        let device: Device = try JSONDecoder().decode(Device.self, from: echo)
+
+        XCTAssertEqual(device.osName, "iOS")
+        XCTAssertEqual(device.osVersion, "")
+        XCTAssertNil(device.vendorId)
     }
 
     func testCreateOmitsNilOptionalFieldsFromBody() async throws {
@@ -119,7 +181,7 @@ final class DeviceServiceTests: XCTestCase {
             return XCTFail("Expected createDevice request")
         }
         XCTAssertNil(body["model"])
-        XCTAssertNil(body["advertisingId"])
+        XCTAssertNil(body["advertising_id"])
     }
 
     func testCreateWrapsProcessorErrorIntoDeviceCreationFailed() async {
@@ -156,7 +218,7 @@ final class DeviceServiceTests: XCTestCase {
         XCTAssertEqual(requestUserId, userId)
         XCTAssertEqual(endpoint, "v4/users/%@/device")
         XCTAssertEqual(type, .put)
-        XCTAssertEqual(body["manufacturer"] as? String, "Apple")
+        XCTAssertEqual(body["os_name"] as? String, "iOS")
     }
 
     func testUpdateWrapsProcessorErrorIntoDeviceUpdateFailed() async {

--- a/Tests/QonversionUnitTests/EntitiesDecodingTests.swift
+++ b/Tests/QonversionUnitTests/EntitiesDecodingTests.swift
@@ -339,14 +339,12 @@ final class EntitiesDecodingTests: XCTestCase {
 
     private func makeDevice(model: String? = "iPhone15,2") -> Device {
         Device(
-            manufacturer: "Apple",
             osName: "iOS",
             osVersion: "17.0",
             model: model,
             appVersion: "1.2.3",
             country: "US",
             language: "en",
-            timezone: "America/New_York",
             advertisingId: nil,
             vendorId: "vendor-id",
             installDate: 1_700_000_000

--- a/Tests/QonversionUnitTests/HeadersBuilderTests.swift
+++ b/Tests/QonversionUnitTests/HeadersBuilderTests.swift
@@ -72,8 +72,8 @@ final class HeadersBuilderTests: XCTestCase {
 
     func testEmptyDeviceValuesAreOmittedNotSentAsEmptyStrings() {
         deviceInfoCollector.device = Device(
-            manufacturer: "Apple", osName: "tvOS", osVersion: "17.0", model: nil,
-            appVersion: nil, country: nil, language: nil, timezone: "UTC",
+            osName: "tvOS", osVersion: "17.0", model: nil,
+            appVersion: nil, country: nil, language: nil,
             advertisingId: nil, vendorId: nil, installDate: 0
         )
 

--- a/Tests/QonversionUnitTests/Mocks.swift
+++ b/Tests/QonversionUnitTests/Mocks.swift
@@ -911,14 +911,12 @@ final class MockEntitlementsManager: EntitlementsManagerInterface {
 final class MockDeviceInfoCollector: DeviceInfoCollectorInterface {
 
     var device = Device(
-        manufacturer: "Apple",
         osName: "iOS",
         osVersion: "17.0",
         model: "iPhone15,2",
         appVersion: "1.2.3",
         country: "US",
         language: "en",
-        timezone: "America/New_York",
         advertisingId: nil,
         vendorId: "vendor-id",
         installDate: 1_700_000_000

--- a/Tests/QonversionUnitTests/RequestProcessorTests.swift
+++ b/Tests/QonversionUnitTests/RequestProcessorTests.swift
@@ -700,15 +700,12 @@ final class RequestProcessorTests: XCTestCase {
     // MARK: - Rate limit exemptions
 
     func testSdkInitiatedRequestsAreExemptFromTheRateLimit() async {
-        // The legacy client rate-limited only what the host can spam. These
-        // two are emitted by the SDK itself — a properties flush, a crash
-        // upload — and dropping them loses data the host never asked for
-        // twice.
+        // The legacy client rate-limited only what the host can spam. A
+        // properties flush is emitted by the SDK itself, and dropping it loses
+        // data the host never asked for twice.
         let propertiesBody: RequestBodyDict = ["key": "value"]
-        let crashBody: RequestBodyDict = ["platform": "iOS"]
         let exempt: [Request] = [
-            .sendProperties(userId: "u", body: propertiesBody),
-            .sdkCrash(body: crashBody)
+            .sendProperties(userId: "u", body: propertiesBody)
         ]
 
         for request in exempt {


### PR DESCRIPTION
…ntract

Device: the body becomes snake_case with exactly os_name, os_version, model, app_version, country, language, advertising_id, vendor_id and install_date (unix seconds). manufacturer and timezone leave the wire and the struct — nothing read them locally. The echo decodes tolerantly, so a truncated answer cannot cost the SDK the record it just created.

Crash reports: v4/sdk-crashes will never exist. Reports now go to POST https://sdk-logs.qonversion.io/sdk.log, the service the Objective-C SDK has always used, in its exact envelope — device{platform, platform_version, source, source_version, project_key, uid} around an exception payload keyed the ObjC way. The transport is its own minimal sender on that host: Content-Type only, no response parsing, no critical latch and no rate limiter. The verdict is delivered (2xx, dropped) or not; an unreachable service still costs no attempt, so an offline week does not lose the report. The sdkCrash request kind is gone.

No-Codes: the backend emits `body: null` and `context_key: null` on screens, and one gateway path yields a `[null]` entry. Screen lists now decode lossily — an unusable screen skips itself instead of nulling the list — and context_key decodes as absent rather than throwing. A single screen without a body still fails, since there is nothing to render.