### PR TITLE
fix: refresh entitlements after a reported purchase

### DIFF
--- a/Sources/Managers/EntitlementsManager/EntitlementsManager.swift
+++ b/Sources/Managers/EntitlementsManager/EntitlementsManager.swift
@@ -71,6 +71,22 @@ final class EntitlementsManager: EntitlementsManagerInterface, @unchecked Sendab
         return try await resolvedEntitlements().entitlements
     }
 
+    func invalidateFreshBackendCache() {
+        lock.lock()
+        defer { lock.unlock() }
+
+        let backendTimestamp: TimeInterval = localStorage.double(forKey: Constants.backendTimestampKey.rawValue)
+        guard backendTimestamp > 0 else { return }
+
+        // Expired, not removed: the cache LIFETIME is measured from this same
+        // key, and handing that clock to the local fallback — which refreshes
+        // its own timestamp on every failure — would keep a lapsed user premium.
+        let expired: TimeInterval = Date().timeIntervalSince1970 - Self.freshCacheLifetime - 1
+        guard expired < backendTimestamp else { return }
+
+        localStorage.set(double: expired, forKey: Constants.backendTimestampKey.rawValue)
+    }
+
     func resolvedEntitlements() async throws -> ResolvedEntitlements {
         // Inside the fresh window the cache is served as it is — no user gate,
         // no request, so a per-appearance gating check costs nothing.

--- a/Sources/Managers/EntitlementsManager/EntitlementsManagerInterface.swift
+++ b/Sources/Managers/EntitlementsManager/EntitlementsManagerInterface.swift
@@ -30,6 +30,12 @@ protocol EntitlementsManagerInterface {
     /// answered or the result was calculated locally.
     func resolvedEntitlements() async throws -> ResolvedEntitlements
 
+    /// Expires the short-lived window during which the last backend answer is
+    /// served without asking again, so the next resolution goes to the network.
+    /// Called by the flows that just reported a purchase — the cached
+    /// entitlements themselves are kept, so a failing fetch still degrades to them.
+    func invalidateFreshBackendCache()
+
     /// The production fault-tolerance path, reusable from the purchase and
     /// restore flows: calculates entitlements locally for the given
     /// transactions, merges them on top of the cached ones, persists the

--- a/Sources/Managers/PurchasesManager/PurchasesManager.swift
+++ b/Sources/Managers/PurchasesManager/PurchasesManager.swift
@@ -228,6 +228,10 @@ final class PurchasesManager: PurchasesManagerInterface, @unchecked Sendable {
             throw QonversionError(type: .purchaseReportingFailed, message: nil, error: error)
         }
 
+        // The report changed what the backend knows: without this the result
+        // is served from the pre-purchase fresh-cache window.
+        entitlementsManager.invalidateFreshBackendCache()
+
         // Finish strictly after the backend ack, and only when the SDK owns
         // the lifecycle — in Analytics mode the host app does.
         if launchModeProvider.launchMode == .subscriptionManagement {
@@ -335,6 +339,10 @@ final class PurchasesManager: PurchasesManagerInterface, @unchecked Sendable {
         }
 
         await switchToOwnerIfNeeded(resolvedOwnerUserId)
+
+        // The store sync reached the backend: the answer restore() returns
+        // must not come from the window opened before it.
+        entitlementsManager.invalidateFreshBackendCache()
 
         if let fetched: [String: Qonversion.Entitlement] = try? await entitlementsManager.entitlements() {
             return fetched
@@ -543,6 +551,9 @@ final class PurchasesManager: PurchasesManagerInterface, @unchecked Sendable {
         do {
             try await purchasesService.send(transaction, userId: reportUserId, options: reportOptions(for: transaction), trigger: trigger)
             purchaseAssociationsStorage.remove(for: transaction.productId)
+            // The deferred purchase this delivery emits must carry the
+            // entitlements the report produced, not the ones cached before it.
+            entitlementsManager.invalidateFreshBackendCache()
         } catch {
             if let id: String = transaction.id {
                 reportsGate.release(id)

--- a/Tests/QonversionUnitTests/EntitlementsManagerTests.swift
+++ b/Tests/QonversionUnitTests/EntitlementsManagerTests.swift
@@ -386,6 +386,70 @@ final class EntitlementsManagerTests: XCTestCase {
         XCTAssertEqual(service.entitlementsCalls.count, 2, "the backend is asked again after a local fallback")
     }
 
+    // MARK: - the fresh window is invalidated by a reported purchase
+
+    func testInvalidatingTheFreshWindowSendsTheNextResolutionToTheBackend() async throws {
+        // A purchase reported seconds after a gating check must not be
+        // answered from the pre-purchase cache.
+        service.entitlementsResult = [serverEntitlement(id: "premium")]
+        _ = try await manager.entitlements()
+        XCTAssertEqual(service.entitlementsCalls.count, 1)
+
+        manager.invalidateFreshBackendCache()
+        service.entitlementsResult = [serverEntitlement(id: "premium"), serverEntitlement(id: "extra")]
+
+        let refreshed: [String: Qonversion.Entitlement] = try await manager.entitlements()
+
+        XCTAssertEqual(service.entitlementsCalls.count, 2, "the invalidated window must cost a request")
+        XCTAssertEqual(refreshed.keys.sorted(), ["extra", "premium"])
+    }
+
+    func testInvalidationKeepsTheCachedEntitlementsForTheDegradationPath() async throws {
+        service.entitlementsResult = [serverEntitlement(id: "premium")]
+        _ = try await manager.entitlements()
+
+        manager.invalidateFreshBackendCache()
+        // The follow-up fetch fails and StoreKit grants nothing: only the
+        // kept cache can still answer.
+        service.error = QonversionError(type: .internal)
+        facade.currentEntitlementsResult = []
+
+        let served: [String: Qonversion.Entitlement] = await servedEntitlements()
+
+        XCTAssertEqual(served["premium"]?.active, true, "invalidating the window must not drop the cached entitlements")
+    }
+
+    func testInvalidationDoesNotRestartTheCacheLifetimeClock() async throws {
+        // The lifetime is measured from the last BACKEND answer. Dropping the
+        // marker instead of expiring it would hand the clock to the local
+        // fallback, which refreshes it on every failure — a permanently
+        // failing backend would then keep a lapsed user premium forever.
+        let backendTimestampKey = "qonversion.keys.entitlementsBackendTimestamp"
+        service.entitlementsResult = [serverEntitlement(id: "premium")]
+        _ = try await manager.entitlements()
+        let afterBackend: TimeInterval = storage.double(forKey: backendTimestampKey)
+
+        manager.invalidateFreshBackendCache()
+
+        let marker: TimeInterval = storage.double(forKey: backendTimestampKey)
+        XCTAssertGreaterThan(marker, 0, "the lifetime must stay anchored to a backend answer")
+        XCTAssertGreaterThan(marker, afterBackend - EntitlementsManager.freshCacheLifetime - 60,
+                             "the cache may only be aged by the width of the fresh window")
+    }
+
+    func testInvalidationLeavesAnAlreadyStaleMarkerAlone() async throws {
+        let backendTimestampKey = "qonversion.keys.entitlementsBackendTimestamp"
+        let sixDaysAgo: TimeInterval = Date().timeIntervalSince1970 - 6 * 24 * 60 * 60
+        try storage.set(["premium": serverEntitlement(id: "premium")], forKey: "qonversion.keys.entitlements")
+        storage.set(double: sixDaysAgo, forKey: "qonversion.keys.entitlementsTimestamp")
+        storage.set(double: sixDaysAgo, forKey: backendTimestampKey)
+
+        manager.invalidateFreshBackendCache()
+
+        XCTAssertEqual(storage.double(forKey: backendTimestampKey), sixDaysAgo,
+                       "an expired window must not be moved forward")
+    }
+
     // MARK: - in-flight coalescing
 
     func testConcurrentCallsShareOneRequest() async throws {

--- a/Tests/QonversionUnitTests/Mocks.swift
+++ b/Tests/QonversionUnitTests/Mocks.swift
@@ -885,6 +885,14 @@ final class MockProductsManager: ProductsManagerInterface, ProductsDataSource {
 
 final class MockEntitlementsManager: EntitlementsManagerInterface {
 
+    /// Recorded in order, so a test can assert that the fresh window was
+    /// invalidated BEFORE the entitlements of the result were resolved.
+    enum Call: Equatable {
+        case resolvedEntitlements
+        case localFallback
+        case invalidateFreshBackendCache
+    }
+
     var entitlementsResult: [String: Qonversion.Entitlement] = [:]
     var entitlementsError: Error?
     var localFallbackResult: [String: Qonversion.Entitlement] = [:]
@@ -892,6 +900,9 @@ final class MockEntitlementsManager: EntitlementsManagerInterface {
     var entitlementsSource: Qonversion.DeferredPurchase.EntitlementsSource = .backend
     private(set) var entitlementsCallsCount = 0
     private(set) var localFallbackTransactions: [[Qonversion.Transaction]] = []
+    private(set) var calls: [Call] = []
+
+    var invalidationCallsCount: Int { calls.filter { $0 == .invalidateFreshBackendCache }.count }
 
     func entitlements() async throws -> [String: Qonversion.Entitlement] {
         return try await resolvedEntitlements().entitlements
@@ -899,13 +910,19 @@ final class MockEntitlementsManager: EntitlementsManagerInterface {
 
     func resolvedEntitlements() async throws -> ResolvedEntitlements {
         entitlementsCallsCount += 1
+        calls.append(.resolvedEntitlements)
         if let entitlementsError { throw entitlementsError }
         return ResolvedEntitlements(entitlements: entitlementsResult, source: entitlementsSource)
     }
 
     func localFallbackEntitlements(for transactions: [Qonversion.Transaction]) async -> [String: Qonversion.Entitlement] {
         localFallbackTransactions.append(transactions)
+        calls.append(.localFallback)
         return localFallbackResult
+    }
+
+    func invalidateFreshBackendCache() {
+        calls.append(.invalidateFreshBackendCache)
     }
 }
 

--- a/Tests/QonversionUnitTests/PurchasesManagerTests.swift
+++ b/Tests/QonversionUnitTests/PurchasesManagerTests.swift
@@ -299,6 +299,96 @@ final class PurchasesManagerTests: XCTestCase {
         XCTAssertEqual(facade.finishedTransactions.count, 1)
     }
 
+    // MARK: - a reported purchase invalidates the fresh entitlements window
+
+    func testReportedPurchaseInvalidatesTheFreshWindowBeforeResolvingEntitlements() async throws {
+        // The entitlements manager serves a cached backend answer for five
+        // minutes; without this the result of a purchase made right after a
+        // gating check carries the PRE-purchase entitlements.
+        manager = makeManager(launchMode: .subscriptionManagement)
+        facade.purchaseResult = makeTransaction(id: "t1")
+        entitlementsManager.entitlementsResult = ["premium": entitlement(id: "premium")]
+
+        _ = try await manager.purchase(makeProduct())
+
+        XCTAssertEqual(entitlementsManager.invalidationCallsCount, 1)
+        XCTAssertEqual(entitlementsManager.calls.first, .invalidateFreshBackendCache,
+                       "the window must be closed before the result is resolved")
+        XCTAssertTrue(entitlementsManager.calls.contains(.resolvedEntitlements))
+    }
+
+    func testFailedPurchaseReportDoesNotInvalidateTheFreshWindow() async throws {
+        // Nothing reached the backend, so nothing there changed — the local
+        // fallback path must stay exactly as it was.
+        facade.purchaseResult = makeTransaction(id: "t1")
+        service.error = QonversionError(type: .internal)
+        entitlementsManager.localFallbackResult = ["premium": entitlement(id: "premium")]
+
+        _ = try await manager.purchase(makeProduct())
+
+        XCTAssertEqual(entitlementsManager.invalidationCallsCount, 0)
+    }
+
+    func testPurchaseThatDoesNotOwnTheReportDoesNotInvalidateTheFreshWindow() async throws {
+        // Another flow owns the report of this transaction and invalidates
+        // the window itself.
+        let reportsGate = TransactionReportsGate()
+        XCTAssertTrue(reportsGate.tryTake("t1"))
+        manager = makeManager(launchMode: .subscriptionManagement, reportsGate: reportsGate)
+        facade.purchaseResult = makeTransaction(id: "t1")
+        entitlementsManager.entitlementsResult = ["premium": entitlement(id: "premium")]
+
+        _ = try await manager.purchase(makeProduct())
+
+        XCTAssertTrue(service.sentTransactions.isEmpty, "the report belongs to the other flow")
+        XCTAssertEqual(entitlementsManager.invalidationCallsCount, 0)
+    }
+
+    func testRestoreInvalidatesTheFreshWindowAfterTheReport() async throws {
+        facade.restoreResult = [makeTransaction(id: "t1")]
+        entitlementsManager.entitlementsResult = ["premium": entitlement(id: "premium")]
+
+        _ = try await manager.restore()
+
+        XCTAssertEqual(entitlementsManager.invalidationCallsCount, 1)
+        XCTAssertEqual(entitlementsManager.calls.first, .invalidateFreshBackendCache)
+    }
+
+    func testFailedRestoreReportDoesNotInvalidateTheFreshWindow() async throws {
+        facade.restoreResult = [makeTransaction(id: "t1")]
+        service.error = QonversionError(type: .internal)
+        entitlementsManager.localFallbackResult = ["premium": entitlement(id: "premium")]
+
+        _ = try await manager.restore()
+
+        XCTAssertEqual(entitlementsManager.invalidationCallsCount, 0)
+    }
+
+    func testDeferredPurchaseDeliveryInvalidatesTheFreshWindowAfterTheReport() async {
+        manager = makeManager(launchMode: .subscriptionManagement)
+        entitlementsManager.entitlementsResult = ["premium": entitlement(id: "premium")]
+        let collector = StreamCollector(manager.deferredPurchases())
+
+        manager.transactionUpdated(makeTransaction(id: "u1"))
+
+        await waitUntil { await !collector.received.isEmpty }
+        XCTAssertEqual(entitlementsManager.invalidationCallsCount, 1)
+        XCTAssertEqual(entitlementsManager.calls.first, .invalidateFreshBackendCache,
+                       "an Ask to Buy approval must be answered with post-report entitlements")
+    }
+
+    func testFailedDeferredPurchaseReportDoesNotInvalidateTheFreshWindow() async {
+        manager = makeManager(launchMode: .subscriptionManagement)
+        service.error = QonversionError(type: .internal)
+        entitlementsManager.localFallbackResult = ["premium": entitlement(id: "premium")]
+        let collector = StreamCollector(manager.deferredPurchases())
+
+        manager.transactionUpdated(makeTransaction(id: "u1"))
+
+        await waitUntil { await !collector.received.isEmpty }
+        XCTAssertEqual(entitlementsManager.invalidationCallsCount, 0)
+    }
+
     // MARK: - purchase failures
 
     func testPurchaseFailsWhenUserGateFails() async {


### PR DESCRIPTION
The entitlements manager serves the last backend answer for five minutes without asking again, and nothing in the purchase flow closed that window. A purchase made shortly after a gating check was therefore answered with the PRE-purchase entitlements: PurchaseResult, restore() and the deferred Ask to Buy delivery all reported no access for a product just bought.

The flow that owns a successful report now expires the fresh window before resolving the entitlements it returns. The cached entitlements themselves are kept, so every degradation path is unchanged, and the window is expired rather than dropped: the cache lifetime is measured from the same marker.