### PR TITLE
fix: honor transaction revocations (refunds, family sharing)

### DIFF
--- a/Sources/Entities/Transaction.swift
+++ b/Sources/Entities/Transaction.swift
@@ -58,7 +58,8 @@ extension Qonversion {
         public var revocationReason: Qonversion.Transaction.RevocationReason? { Qonversion.Transaction.RevocationReason.from(revocataionReason: storeKitTransaction?.revocationReason) }
         
         /// The date that the App Store refunded the transaction or revoked it from Family Sharing.
-        public var revocationDate: Date? { storeKitTransaction?.revocationDate }
+        /// A non-nil value means the purchase no longer grants access.
+        public let revocationDate: Date?
         
         /// A UUID that associates the transaction with a user on your own service.
         public var appAccountToken: UUID? { storeKitTransaction?.appAccountToken }
@@ -348,10 +349,12 @@ extension Qonversion {
             price: Decimal? = nil,
             currency: Qonversion.Currency? = nil,
             storefront: Qonversion.Storefront? = nil,
-            jws: String? = nil
+            jws: String? = nil,
+            revocationDate: Date? = nil
         ) {
             self.jsonRepresentation = nil
             self.id = id
+            self.revocationDate = revocationDate
             self.originalId = originalId
             self.productId = productId
             self.subscriptionGroupId = subscriptionGroupId
@@ -370,6 +373,7 @@ extension Qonversion {
             self.jsonRepresentation = transaction.jsonRepresentation
             self.jws = jws
             self.id = String(transaction.id)
+            self.revocationDate = transaction.revocationDate
             self.originalId = String(transaction.originalID)
             self.productId = transaction.productID
             self.subscriptionGroupId = transaction.subscriptionGroupID

--- a/Sources/Managers/PurchasesManager/PurchasesManager.swift
+++ b/Sources/Managers/PurchasesManager/PurchasesManager.swift
@@ -11,6 +11,9 @@ fileprivate enum Constants: String {
     // The transactions the host has already been told about, persisted:
     // StoreKit re-delivers every unfinished transaction on each cold start.
     case surfacedTransactionsKey = "qonversion.keys.surfacedTransactions"
+    // A revocation carries the id of the purchase it undoes, which that set
+    // already holds; this prefix gives it a namespace of its own.
+    case revokedTransactionPrefix = "revoked:"
 }
 
 fileprivate enum IntConstants: Int {
@@ -97,12 +100,18 @@ final class PurchasesManager: PurchasesManagerInterface, @unchecked Sendable {
     // must not be lost.
     private let promoIntentsMulticast = AsyncMulticast<Qonversion.PromoPurchaseIntent>(replaysBacklog: true)
 
+    // The entitlements recalculated after a revocation. A refund is not a
+    // purchase, so no DeferredPurchase describes it — it reaches the host
+    // through entitlementsUpdates() only.
+    private let revocationsMulticast = AsyncMulticast<[String: Qonversion.Entitlement]>(replaysBacklog: true)
+
     func deferredPurchases() -> AsyncStream<Qonversion.DeferredPurchase> {
         return deferredPurchasesMulticast.stream()
     }
 
-    /// The entitlements-only projection of the deferred purchases: one
-    /// subscription of its own, so both streams stay independent.
+    /// The entitlements-only projection of the deferred purchases, plus the
+    /// revocations no deferred purchase can carry: one subscription of its own
+    /// per source, so every stream stays independent.
     func entitlementsUpdates() -> AsyncStream<[String: Qonversion.Entitlement]> {
         // The same bound as the subscription it wraps: a host that stops
         // reading must not turn the projection into an unbounded queue.
@@ -110,13 +119,21 @@ final class PurchasesManager: PurchasesManagerInterface, @unchecked Sendable {
             // Subscribing here does not consume what deferredPurchases() is
             // owed: AsyncMulticast replays its backlog to every subscriber.
             let purchases: AsyncStream<Qonversion.DeferredPurchase> = self.deferredPurchasesMulticast.stream()
-            let task = Task {
+            let revocations: AsyncStream<[String: Qonversion.Entitlement]> = self.revocationsMulticast.stream()
+            let purchasesTask = Task {
                 for await purchase in purchases {
                     continuation.yield(purchase.entitlements)
                 }
-                continuation.finish()
             }
-            continuation.onTermination = { _ in task.cancel() }
+            let revocationsTask = Task {
+                for await entitlements in revocations {
+                    continuation.yield(entitlements)
+                }
+            }
+            continuation.onTermination = { _ in
+                purchasesTask.cancel()
+                revocationsTask.cancel()
+            }
         }
     }
 
@@ -520,6 +537,14 @@ final class PurchasesManager: PurchasesManagerInterface, @unchecked Sendable {
     /// launch mode, one deferred purchase. A nil `userId` makes the funnel pass
     /// the user gate itself, and only once it owns the transaction.
     private func processObservedTransaction(_ transaction: Qonversion.Transaction, userId: String?, trigger: RequestTrigger) async {
+        // Checked before every dedup gate below: a revocation arrives as the
+        // very transaction the purchase already reported and surfaced, so both
+        // gates hold its id and both would swallow it.
+        if transaction.revocationDate != nil {
+            await processRevocation(of: transaction)
+            return
+        }
+
         // A purchase() call owns this product's lifecycle. Step aside BEFORE
         // reporting or finishing: a skipped transaction must stay unfinished so
         // the store re-delivers it.
@@ -578,6 +603,36 @@ final class PurchasesManager: PurchasesManagerInterface, @unchecked Sendable {
 
         let deferredPurchase: Qonversion.DeferredPurchase = await self.deferredPurchase(for: transaction, reportFailed: reportFailed)
         deferredPurchasesMulticast.yield(deferredPurchase)
+    }
+
+    /// A refund or a family-sharing revocation. It is not a purchase: nothing
+    /// is reported — the App Store server tells the backend about the refund —
+    /// and no deferred purchase is emitted. The host learns about it through
+    /// the entitlements the revocation leaves behind.
+    private func processRevocation(of transaction: Qonversion.Transaction) async {
+        // Finished before the dedup gate below: an unfinished revocation is
+        // re-delivered on every launch. In Analytics mode the host app owns
+        // the lifecycle, exactly as for a purchase.
+        if launchModeProvider.launchMode == .subscriptionManagement {
+            await storeKitFacade.finish(transaction)
+        }
+
+        if let id: String = transaction.id {
+            let revocationKey: String = Constants.revokedTransactionPrefix.rawValue + id
+            guard markSurfacedIfNew(revocationKey) else { return }
+        }
+
+        // Whatever the fresh window holds was answered before the revocation.
+        entitlementsManager.invalidateFreshBackendCache()
+
+        let entitlements: [String: Qonversion.Entitlement]
+        if let resolved: ResolvedEntitlements = try? await entitlementsManager.resolvedEntitlements() {
+            entitlements = resolved.entitlements
+        } else {
+            entitlements = await entitlementsManager.localFallbackEntitlements(for: [transaction])
+        }
+
+        revocationsMulticast.yield(entitlements)
     }
 }
 

--- a/Sources/Utils/EntitlementsCalculator.swift
+++ b/Sources/Utils/EntitlementsCalculator.swift
@@ -71,7 +71,8 @@ enum EntitlementsCalculator {
     ///
     /// Grant rule (production-exact): an entitlement is granted when the
     /// calculated expiration is nil (lifetime) or in the future; expired
-    /// transactions are skipped entirely.
+    /// transactions are skipped entirely. A revoked transaction (refund,
+    /// family-sharing revocation) grants nothing at all.
     static func calculate(
         transactions: [Qonversion.Transaction],
         products: [Qonversion.Product],
@@ -85,6 +86,10 @@ enum EntitlementsCalculator {
 
         var result: [String: Qonversion.Entitlement] = [:]
         for transaction in transactions {
+            // Checked before the expiration: a refunded lifetime purchase has
+            // no expiration to fail, and a mid-period refund has one in the future.
+            guard transaction.revocationDate == nil else { continue }
+
             let product: Qonversion.Product? = productsByStoreId[transaction.productId]
             let expiration: Date? = expirationDate(for: transaction, product: product)
             guard expiration == nil || expiration! > now else { continue }

--- a/Tests/QonversionUnitTests/EntitlementsCalculatorTests.swift
+++ b/Tests/QonversionUnitTests/EntitlementsCalculatorTests.swift
@@ -146,6 +146,75 @@ final class EntitlementsCalculatorTests: XCTestCase {
         XCTAssertTrue(entitlements.isEmpty)
     }
 
+    // MARK: - Revocations (refund, family sharing revocation)
+
+    private func makeRevokedTransaction(productId: String = "com.app.pro", purchasedSecondsAgo: TimeInterval, revokedSecondsAgo: TimeInterval = 0) -> Qonversion.Transaction {
+        let purchaseDate: Date = now.addingTimeInterval(-purchasedSecondsAgo)
+        let revocationDate: Date = now.addingTimeInterval(-revokedSecondsAgo)
+
+        return Qonversion.Transaction(id: UUID().uuidString, productId: productId, purchaseDate: purchaseDate, revocationDate: revocationDate)
+    }
+
+    func testRevokedTransactionGrantsNothingWhileItsPeriodIsStillRunning() {
+        // A refund lands mid-period: the purchase is 10 days into a month, so
+        // the expiration check alone would still call it active.
+        let day: TimeInterval = 24 * 60 * 60
+        let entitlements = EntitlementsCalculator.calculate(
+            transactions: [makeRevokedTransaction(purchasedSecondsAgo: 10 * day)],
+            products: [makeProduct()],
+            mapping: ["pro": ["premium", "extra"]],
+            now: now
+        )
+
+        XCTAssertTrue(entitlements.isEmpty, "a refunded purchase must not grant access for the rest of its period")
+    }
+
+    func testRevokedLifetimePurchaseGrantsNothing() {
+        // No period means no expiration at all: without reading the revocation
+        // a refunded lifetime purchase would grant access forever.
+        let entitlements = EntitlementsCalculator.calculate(
+            transactions: [makeRevokedTransaction(purchasedSecondsAgo: 0)],
+            products: [makeProduct(periodUnit: nil)],
+            mapping: ["pro": ["premium"]],
+            now: now
+        )
+
+        XCTAssertTrue(entitlements.isEmpty)
+    }
+
+    func testRevokedTransactionOfAnAlreadyExpiredPeriodGrantsNothing() {
+        let day: TimeInterval = 24 * 60 * 60
+        let entitlements = EntitlementsCalculator.calculate(
+            transactions: [makeRevokedTransaction(purchasedSecondsAgo: 31 * day)],
+            products: [makeProduct()],
+            mapping: ["pro": ["premium"]],
+            now: now
+        )
+
+        XCTAssertTrue(entitlements.isEmpty)
+    }
+
+    func testRevokedTransactionDoesNotTakeDownAGrantAnotherProductStillHolds() {
+        // Only the revoked purchase loses its grant: a second product mapped to
+        // the same permission keeps granting it.
+        let day: TimeInterval = 24 * 60 * 60
+        let monthly: Qonversion.Product = makeProduct(qonversionId: "monthly", storeId: "com.app.monthly", periodUnit: .month, periodValue: 1)
+        let annual: Qonversion.Product = makeProduct(qonversionId: "annual", storeId: "com.app.annual", periodUnit: .year, periodValue: 1)
+        let revoked: Qonversion.Transaction = makeRevokedTransaction(productId: "com.app.monthly", purchasedSecondsAgo: 0)
+        let active: Qonversion.Transaction = makeTransaction(productId: "com.app.annual", purchasedSecondsAgo: 0)
+
+        let entitlements = EntitlementsCalculator.calculate(
+            transactions: [revoked, active],
+            products: [monthly, annual],
+            mapping: ["monthly": ["premium"], "annual": ["premium"]],
+            now: now
+        )
+
+        XCTAssertEqual(entitlements["premium"]?.active, true)
+        XCTAssertEqual(entitlements["premium"]?.productId, "annual")
+        XCTAssertEqual(entitlements["premium"]?.expirationDate, now.addingTimeInterval(365 * day))
+    }
+
     func testProductWithoutPeriodGrantsLifetimeEntitlement() {
         let entitlements = EntitlementsCalculator.calculate(
             transactions: [makeTransaction(purchasedSecondsAgo: 365 * 24 * 60 * 60)],

--- a/Tests/QonversionUnitTests/PurchasesManagerTests.swift
+++ b/Tests/QonversionUnitTests/PurchasesManagerTests.swift
@@ -936,6 +936,98 @@ final class PurchasesManagerTests: XCTestCase {
         XCTAssertEqual(facade.finishedTransactions.map(\.id), ["p1"])
     }
 
+    // MARK: - revocations (refund, family sharing revocation)
+
+    private func makeRevokedTransaction(id: String, productId: String = "com.app.pro") -> Qonversion.Transaction {
+        let revocationDate = Date(timeIntervalSince1970: 1_700_000_000)
+
+        return Qonversion.Transaction(id: id, productId: productId, purchaseDate: nil, jws: "jws-proof", revocationDate: revocationDate)
+    }
+
+    func testRevokedTransactionEmitsUpdatedEntitlementsEvenWhenItsIdIsAlreadySurfaced() async {
+        // StoreKit delivers a refund as the SAME transaction id that was
+        // reported and surfaced when it was bought — both dedup gates already
+        // hold it, and both would swallow the revocation.
+        let gate = TransactionReportsGate()
+        _ = gate.tryTake("t1")
+        try? localStorage.set(["t1"], forKey: "qonversion.keys.surfacedTransactions")
+        manager = makeManager(launchMode: .subscriptionManagement, reportsGate: gate)
+        entitlementsManager.entitlementsResult = [:]
+        let collector = StreamCollector(manager.entitlementsUpdates())
+
+        manager.transactionUpdated(makeRevokedTransaction(id: "t1"))
+
+        await waitUntil { await !collector.received.isEmpty }
+        let received = await collector.received
+        XCTAssertEqual(received.count, 1)
+        XCTAssertTrue(received.first?.isEmpty ?? false, "the host must learn that the entitlement is gone")
+        XCTAssertTrue(entitlementsManager.calls.contains(.invalidateFreshBackendCache),
+                      "the cached answer predates the revocation")
+    }
+
+    func testRevokedTransactionIsNotReportedAsAPurchase() async {
+        manager = makeManager(launchMode: .subscriptionManagement)
+        entitlementsManager.entitlementsResult = [:]
+        let collector = StreamCollector(manager.entitlementsUpdates())
+
+        manager.transactionUpdated(makeRevokedTransaction(id: "r1"))
+
+        await waitUntil { await !collector.received.isEmpty }
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        XCTAssertTrue(service.sentTransactions.isEmpty, "the App Store server already told the backend about the refund")
+    }
+
+    func testRevokedTransactionEmitsNoDeferredPurchase() async {
+        manager = makeManager(launchMode: .subscriptionManagement)
+        entitlementsManager.entitlementsResult = [:]
+        let purchases = StreamCollector(manager.deferredPurchases())
+        let updates = StreamCollector(manager.entitlementsUpdates())
+
+        manager.transactionUpdated(makeRevokedTransaction(id: "r1"))
+
+        await waitUntil { await !updates.received.isEmpty }
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        let received = await purchases.received
+        XCTAssertTrue(received.isEmpty, "a refund is not a purchase")
+    }
+
+    func testRevokedTransactionSeenByTheLaunchSweepEmitsUpdatedEntitlements() async {
+        manager = makeManager(launchMode: .subscriptionManagement)
+        entitlementsManager.entitlementsResult = [:]
+        facade.unfinishedTransactionsResult = [makeRevokedTransaction(id: "r1")]
+        let collector = StreamCollector(manager.entitlementsUpdates())
+
+        await manager.processUnfinishedTransactions()
+
+        await waitUntil { await !collector.received.isEmpty }
+        let received = await collector.received
+        XCTAssertEqual(received.count, 1)
+        XCTAssertTrue(service.sentTransactions.isEmpty, "a revocation is never reported as a purchase")
+    }
+
+    func testRevokedTransactionIsFinishedInSubscriptionManagementMode() async {
+        // An unfinished revocation is re-delivered by the store on every launch.
+        manager = makeManager(launchMode: .subscriptionManagement)
+        entitlementsManager.entitlementsResult = [:]
+
+        manager.transactionUpdated(makeRevokedTransaction(id: "r1"))
+
+        await waitUntil { !self.facade.finishedTransactions.isEmpty }
+        XCTAssertEqual(facade.finishedTransactions.map(\.id), ["r1"])
+    }
+
+    func testRevokedTransactionIsNotFinishedInAnalyticsMode() async {
+        manager = makeManager(launchMode: .analytics)
+        entitlementsManager.entitlementsResult = [:]
+        let collector = StreamCollector(manager.entitlementsUpdates())
+
+        manager.transactionUpdated(makeRevokedTransaction(id: "r1"))
+
+        await waitUntil { await !collector.received.isEmpty }
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        XCTAssertTrue(facade.finishedTransactions.isEmpty, "the host app owns the lifecycle in Analytics mode")
+    }
+
     func testTheBufferedLaunchEmissionReachesBothStreams() async {
         // The backlog exists for hosts that subscribe after launch; the
         // entitlements projection must not steal it from deferredPurchases.


### PR DESCRIPTION
A refunded or revoked transaction still granted an active entitlement and never reached the host at all.

Local calculation: EntitlementsCalculator.calculate() checked only the expiration, and transaction.revocationDate was read nowhere in the SDK. A mid-period refund kept its grant until the period would have ended, and a refunded lifetime purchase kept it forever. Revoked transactions are now skipped before the expiration check, in every local-calculation path (offline fallback after a failed report, Analytics mode, deferred purchases).

Propagation: StoreKit delivers a revocation as the SAME transaction id that was already reported and surfaced when the purchase happened, so the reports gate dropped it before the report and the surfaced set dropped it before the emission — neither entitlementsUpdates nor any callback ever reflected it. processObservedTransaction now branches on revocationDate before both gates and routes revocations to their own path: never reported as a purchase (the App Store server already told the backend about the refund), never emitted as a DeferredPurchase, entitlements re-resolved with the fresh-window cache invalidated first and published through entitlementsUpdates(). The revocation is finished when the SDK owns the lifecycle, and deduplicated under a key namespace of its own so a re-delivery does not republish it.

Transaction.revocationDate becomes a stored property, captured from the StoreKit transaction at mapping time — the value is unchanged, but it is now constructible, which is what makes the behavior testable.