### PR TITLE
fix: deliver deferred purchases exactly once and never lose them

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ The same file also answers `remoteConfig()` calls when the API is unreachable �
 
 ### Listening for updates
 
-Both streams follow the style of StoreKit's `Transaction.updates`: every access returns an independent stream, so subscribe from as many places as you need. Start the listeners once, right after initialization:
+The streams follow the style of StoreKit's `Transaction.updates`: every access returns an independent stream. Start the listeners once, right after initialization:
 
 ```swift
 Task {
@@ -322,7 +322,9 @@ Task {
 }
 ```
 
-Promo purchase intents arriving before your subscription are buffered — subscribing late (after onboarding) is safe.
+`deferredPurchases` and `promoPurchaseIntents` carry events you act on, so each one is delivered exactly once. An event produced while your loop is running reaches every stream being iterated at that moment; an event produced with nobody listening waits — with no deadline — and goes to the next stream alone, so subscribing late (after onboarding) is safe and a screen that re-appears never grants the same purchase twice. Keep one long-lived loop per event stream, and build the stream where you consume it: a stream you create and drop without iterating counts as having taken what was waiting. A deferred purchase nobody received before the app was terminated comes back on a later launch while its transaction is still unfinished.
+
+`entitlementsUpdates` is the exception: it carries access-state snapshots, so the latest one stays readable by every stream you create afterwards.
 
 ### Restore and historical data
 

--- a/Sources/Managers/PurchasesManager/PurchasesManager.swift
+++ b/Sources/Managers/PurchasesManager/PurchasesManager.swift
@@ -66,75 +66,75 @@ final class PurchasesManager: PurchasesManagerInterface, @unchecked Sendable {
 
     private let reportsGate: TransactionReportsGate
 
-    // Guards the persisted set of transactions already handed to the host.
+    // Guards the surfaced bookkeeping below.
     private let surfacedLock = NSLock()
 
-    /// True when this transaction had not been surfaced yet — and marks it
-    /// surfaced. Persisted: StoreKit re-delivers unfinished transactions on
-    /// every launch, and Analytics mode never finishes any.
-    private func markSurfacedIfNew(_ transactionId: String) -> Bool {
+    // Emitted for the host in this launch but not heard by it yet: the claim
+    // keeps a second path from emitting the same transaction, the persisted
+    // record is what survives a relaunch.
+    private var claimedTransactions: Set<String> = []
+
+    /// True when the host has not heard about this transaction yet — and
+    /// claims it for this launch.
+    private func claimForHost(_ transactionId: String) -> Bool {
         surfacedLock.lock()
         defer { surfacedLock.unlock() }
 
+        let surfaced: [String] = storedSurfacedTransactions()
+        guard !claimedTransactions.contains(transactionId), !surfaced.contains(transactionId) else { return false }
+
+        claimedTransactions.insert(transactionId)
+
+        return true
+    }
+
+    /// Records that the host actually received this transaction. Persisted:
+    /// StoreKit re-delivers unfinished transactions on every launch, and
+    /// Analytics mode never finishes any. Recording it only after the delivery
+    /// is what brings an event nobody received back on the next launch.
+    private func markHeardByHost(_ transactionId: String) {
+        surfacedLock.lock()
+        defer { surfacedLock.unlock() }
+
+        claimedTransactions.insert(transactionId)
         var surfaced: [String] = storedSurfacedTransactions()
-        guard !surfaced.contains(transactionId) else { return false }
+        guard !surfaced.contains(transactionId) else { return }
 
         surfaced.append(transactionId)
         if surfaced.count > IntConstants.maxSurfacedTransactions.rawValue {
             surfaced.removeFirst(surfaced.count - IntConstants.maxSurfacedTransactions.rawValue)
         }
         try? localStorage.set(surfaced, forKey: Constants.surfacedTransactionsKey.rawValue)
-
-        return true
     }
 
     private func storedSurfacedTransactions() -> [String] {
         return (try? localStorage.object(forKey: Constants.surfacedTransactionsKey.rawValue, dataType: [String].self)) ?? []
     }
 
-    // Buffered: an approval processed during launch, before the host
-    // subscribes, must not be dropped.
-    private let deferredPurchasesMulticast = AsyncMulticast<Qonversion.DeferredPurchase>(replaysBacklog: true)
+    // An approval processed before the host subscribes waits with no deadline
+    // and is handed to the first subscription only. Internal for the test that
+    // asserts the deadline it must NOT have.
+    let deferredPurchasesMulticast = AsyncMulticast<Qonversion.DeferredPurchase>(backlog: .deliveredOnce, backlogLifetime: .infinity)
 
     // Buffered until the first subscriber — an intent arriving at app start
-    // must not be lost.
-    private let promoIntentsMulticast = AsyncMulticast<Qonversion.PromoPurchaseIntent>(replaysBacklog: true)
+    // must not be lost, and acting on the same one twice would purchase twice.
+    private let promoIntentsMulticast = AsyncMulticast<Qonversion.PromoPurchaseIntent>(backlog: .deliveredOnce)
 
-    // The entitlements recalculated after a revocation. A refund is not a
-    // purchase, so no DeferredPurchase describes it — it reaches the host
-    // through entitlementsUpdates() only.
-    private let revocationsMulticast = AsyncMulticast<[String: Qonversion.Entitlement]>(replaysBacklog: true)
+    // Snapshots, not events: a host that re-subscribes may read the latest
+    // access state again. The single access-state channel — a revocation
+    // carries no DeferredPurchase and reaches the host through this one.
+    private let entitlementsMulticast = AsyncMulticast<[String: Qonversion.Entitlement]>(backlog: .replayed)
 
     func deferredPurchases() -> AsyncStream<Qonversion.DeferredPurchase> {
         return deferredPurchasesMulticast.stream()
     }
 
     /// The entitlements-only projection of the deferred purchases, plus the
-    /// revocations no deferred purchase can carry: one subscription of its own
-    /// per source, so every stream stays independent.
+    /// revocations no deferred purchase can carry. Fed alongside them rather
+    /// than derived from a subscription, so reading it never takes a purchase
+    /// away from ``deferredPurchases()``.
     func entitlementsUpdates() -> AsyncStream<[String: Qonversion.Entitlement]> {
-        // The same bound as the subscription it wraps: a host that stops
-        // reading must not turn the projection into an unbounded queue.
-        return AsyncStream(bufferingPolicy: .bufferingNewest(AsyncMulticast<Qonversion.DeferredPurchase>.subscriberBufferSize)) { continuation in
-            // Subscribing here does not consume what deferredPurchases() is
-            // owed: AsyncMulticast replays its backlog to every subscriber.
-            let purchases: AsyncStream<Qonversion.DeferredPurchase> = self.deferredPurchasesMulticast.stream()
-            let revocations: AsyncStream<[String: Qonversion.Entitlement]> = self.revocationsMulticast.stream()
-            let purchasesTask = Task {
-                for await purchase in purchases {
-                    continuation.yield(purchase.entitlements)
-                }
-            }
-            let revocationsTask = Task {
-                for await entitlements in revocations {
-                    continuation.yield(entitlements)
-                }
-            }
-            continuation.onTermination = { _ in
-                purchasesTask.cancel()
-                revocationsTask.cancel()
-            }
-        }
+        return entitlementsMulticast.stream()
     }
 
     func promoPurchaseIntents() -> AsyncStream<Qonversion.PromoPurchaseIntent> {
@@ -211,7 +211,7 @@ final class PurchasesManager: PurchasesManagerInterface, @unchecked Sendable {
         // Already surfaced by this call's result: a later re-delivery through
         // the updates listener must not repeat it as a deferred purchase.
         if let id: String = transaction.id {
-            _ = markSurfacedIfNew(id)
+            markHeardByHost(id)
         }
 
         // The id is claimed BEFORE the report goes out: a concurrent restore
@@ -599,16 +599,24 @@ final class PurchasesManager: PurchasesManagerInterface, @unchecked Sendable {
 
         // Gates what the host sees, not the report: a relaunch re-delivers
         // every unfinished transaction, and the host must hear it once.
-        if let id: String = transaction.id, !markSurfacedIfNew(id) { return }
+        let transactionId: String? = transaction.id
+        if let transactionId, !claimForHost(transactionId) { return }
 
         let deferredPurchase: Qonversion.DeferredPurchase = await self.deferredPurchase(for: transaction, reportFailed: reportFailed)
-        deferredPurchasesMulticast.yield(deferredPurchase)
+        // Marked heard only once it reaches a subscriber: an approval nobody
+        // received must come back after the next launch.
+        deferredPurchasesMulticast.yield(deferredPurchase) { [weak self] in
+            guard let transactionId else { return }
+
+            self?.markHeardByHost(transactionId)
+        }
+        entitlementsMulticast.yield(deferredPurchase.entitlements)
     }
 
     /// A refund or a family-sharing revocation. It is not a purchase: nothing
     /// is reported — the App Store server tells the backend about the refund —
-    /// and no deferred purchase is emitted. The host learns about it through
-    /// the entitlements the revocation leaves behind.
+    /// and no deferred purchase is emitted. The host learns about it from the
+    /// recalculated entitlements published to ``entitlementsUpdates()``.
     private func processRevocation(of transaction: Qonversion.Transaction) async {
         // Finished before the dedup gate below: an unfinished revocation is
         // re-delivered on every launch. In Analytics mode the host app owns
@@ -619,7 +627,12 @@ final class PurchasesManager: PurchasesManagerInterface, @unchecked Sendable {
 
         if let id: String = transaction.id {
             let revocationKey: String = Constants.revokedTransactionPrefix.rawValue + id
-            guard markSurfacedIfNew(revocationKey) else { return }
+            guard claimForHost(revocationKey) else { return }
+
+            // Recorded right away rather than on delivery: the snapshot below
+            // is state a later resolve reproduces, so a revocation nobody
+            // heard has nothing to come back for.
+            markHeardByHost(revocationKey)
         }
 
         // Whatever the fresh window holds was answered before the revocation.
@@ -632,7 +645,7 @@ final class PurchasesManager: PurchasesManagerInterface, @unchecked Sendable {
             entitlements = await entitlementsManager.localFallbackEntitlements(for: [transaction])
         }
 
-        revocationsMulticast.yield(entitlements)
+        entitlementsMulticast.yield(entitlements)
     }
 }
 

--- a/Sources/Managers/PurchasesManager/PurchasesManagerInterface.swift
+++ b/Sources/Managers/PurchasesManager/PurchasesManagerInterface.swift
@@ -10,15 +10,21 @@ protocol PurchasesManagerInterface: AnyObject {
 
     /// A stream of purchases the SDK processed out of band (Ask to Buy / SCA
     /// approvals, renewals, refunds, purchases on other devices), in both
-    /// launch modes. Every call returns an independent stream.
+    /// launch modes. Every call returns an independent stream, and every
+    /// purchase is delivered exactly once: broadcast to whoever is listening
+    /// when it happens, otherwise kept — with no deadline — for the next
+    /// stream alone.
     func deferredPurchases() -> AsyncStream<Qonversion.DeferredPurchase>
 
-    /// The entitlements-only projection of ``deferredPurchases()``. Every call
-    /// returns an independent stream.
+    /// The entitlements-only projection of ``deferredPurchases()``, plus the
+    /// revocations no deferred purchase can carry. Every call returns an
+    /// independent stream; the snapshot stays readable by streams created
+    /// later, and reading it never consumes a deferred purchase.
     func entitlementsUpdates() -> AsyncStream<[String: Qonversion.Entitlement]>
 
     /// A stream of App Store promoted-purchase intents; call purchase() on an
-    /// intent to proceed. Every call returns an independent stream.
+    /// intent to proceed. Every call returns an independent stream, and an
+    /// intent waiting for a subscriber is handed to exactly one of them.
     func promoPurchaseIntents() -> AsyncStream<Qonversion.PromoPurchaseIntent>
 
     /// Buys the product through the store, reports the purchase to the backend

--- a/Sources/Qonversion.swift
+++ b/Sources/Qonversion.swift
@@ -190,8 +190,9 @@ public final class Qonversion: @unchecked Sendable {
 
     /// A stream of purchases promoted in the App Store. Call purchase() on a
     /// received intent to proceed — right away or whenever the app is ready;
-    /// dropping the intent defers the purchase. Intents arriving before the
-    /// first subscription are buffered:
+    /// dropping the intent defers the purchase. An intent arriving before the
+    /// first subscription is buffered and handed to it exactly once, never
+    /// repeated to a stream created later:
     ///
     ///     for await intent in Qonversion.shared.promoPurchaseIntents {
     ///         try await intent.purchase()
@@ -208,8 +209,22 @@ public final class Qonversion: @unchecked Sendable {
     /// unreachable the entitlements are calculated locally and
     /// ``Qonversion/Qonversion/DeferredPurchase/entitlementsSource`` says so.
     /// Like StoreKit's `Transaction.updates`, every access returns an
-    /// independent stream, and purchases processed before the first
-    /// subscription are buffered:
+    /// independent stream. Each purchase is delivered exactly once, so it is
+    /// safe to grant content straight from the loop:
+    ///
+    /// * a purchase produced while one or more streams are being iterated
+    ///   reaches all of them at that moment;
+    /// * a purchase produced while nobody is listening waits — with no
+    ///   deadline — for the next stream and is handed to that one alone;
+    /// * a purchase that has already reached a stream is never repeated to a
+    ///   stream created later, so a screen that re-appears and subscribes
+    ///   again does not grant the content twice;
+    /// * a purchase nobody received before the app was terminated comes back
+    ///   on a later launch, as long as its transaction is still unfinished.
+    ///
+    /// A stream you create and drop without iterating counts as having
+    /// received what was waiting, so build the stream where you consume it —
+    /// and prefer one long-lived subscription for granting content:
     ///
     ///     for await purchase in Qonversion.shared.deferredPurchases {
     ///         grantAccess(with: purchase.entitlements, for: purchase.transaction)
@@ -221,7 +236,11 @@ public final class Qonversion: @unchecked Sendable {
     }
 
     /// The entitlements-only projection of ``deferredPurchases``, for hosts
-    /// that only refresh their access state:
+    /// that only refresh their access state. It also carries the changes no
+    /// purchase describes — a refund or a family-sharing revocation — so it is
+    /// the one stream to follow to keep access in sync. Each value is the
+    /// complete access state, not a delta, and stays readable by a stream
+    /// created later:
     ///
     ///     for await entitlements in Qonversion.shared.entitlementsUpdates { ... }
     public var entitlementsUpdates: AsyncStream<[String: Qonversion.Entitlement]> {

--- a/Sources/Utils/AsyncMulticast.swift
+++ b/Sources/Utils/AsyncMulticast.swift
@@ -5,44 +5,49 @@
 
 import Foundation
 
+/// What a multicast does with a value produced while nobody is listening.
+enum MulticastBacklog: Sendable, Equatable {
+
+    /// The value is dropped.
+    case dropped
+
+    /// The value is kept and replayed to EVERY subscriber arriving inside the
+    /// backlog lifetime. For idempotent snapshots, where reading the latest
+    /// state again costs the host nothing.
+    case replayed
+
+    /// The value waits and is handed to the FIRST subscriber that arrives,
+    /// which consumes it: nobody after that receives it. For events the host
+    /// acts on, where a second delivery would repeat the action.
+    case deliveredOnce
+}
+
 /// Fans one sequence of values out to any number of independent AsyncStreams
 /// (StoreKit's Transaction.updates style: every stream() call is a separate
 /// subscription).
 ///
-/// Backlog policy (`replaysBacklog: true`)
-/// --------------------------------------
-/// Every yielded value is kept in a bounded backlog and replayed to EVERY
-/// subscriber that arrives afterwards, independently of whether somebody was
-/// already listening when the value was produced. A subscriber reads the
-/// backlog exactly once — at subscription time, when by definition nothing has
-/// been delivered to it yet — and receives live values from then on, so no
-/// value is ever delivered to the same subscriber twice.
+/// A value produced while subscribers are listening is broadcast to all of
+/// them, whatever the backlog policy is — the policy only decides the fate of
+/// a value produced with nobody listening, see ``MulticastBacklog``.
 ///
-/// This matters because subscriptions are not simultaneous: the projection
-/// built by `entitlementsUpdates()` attaches while the AsyncStream is being
-/// constructed, so a host that subscribes to it first (exactly what the Sample
-/// and the README show) would otherwise consume the launch backlog and starve
-/// the `deferredPurchases()` subscription it creates a moment later.
-///
-/// The backlog is bounded two ways, so it stays a launch-window replay and
-/// never becomes an unbounded event log:
+/// The backlog is bounded two ways, so it never becomes an unbounded event
+/// log:
 ///   * by count — at most `maxPending` values, oldest dropped first;
-///   * by age — a value older than `backlogLifetime` is never replayed.
-///
-/// With `replaysBacklog: false` (the default) values yielded to nobody are
-/// simply dropped.
+///   * by age — a value older than `backlogLifetime` is never delivered. An
+///     infinite lifetime makes a value wait for its subscriber indefinitely,
+///     which is what a value that must not be lost needs.
 // @unchecked: the continuations and the backlog are lock-guarded.
 final class AsyncMulticast<Element: Sendable>: @unchecked Sendable {
 
-    /// Bounds the replay backlog; the oldest values are dropped first.
+    /// Bounds the backlog; the oldest values are dropped first.
     static var maxPending: Int { 10 }
 
     /// Bounds each subscriber's own buffer. INVARIANT: strictly greater than
-    /// ``maxPending`` — the whole backlog is replayed before a subscriber
+    /// ``maxPending`` — a whole backlog can be handed over before a subscriber
     /// drains, so the headroom absorbs live values instead of evicting it.
     static var subscriberBufferSize: Int { maxPending * 4 }
 
-    /// How long a value stays replayable to subscribers arriving after it.
+    /// How long a value stays deliverable to subscribers arriving after it.
     /// Sized for "the host finished wiring its streams up", not for the whole
     /// session.
     static var defaultBacklogLifetime: TimeInterval { 300 }
@@ -50,21 +55,24 @@ final class AsyncMulticast<Element: Sendable>: @unchecked Sendable {
     private struct BacklogEntry {
         let element: Element
         let addedAt: Date
+        // Cleared once it has run: a replayed value must not report a second
+        // delivery.
+        var onDelivery: (@Sendable () -> Void)?
     }
 
-    private let replaysBacklog: Bool
-    private let backlogLifetime: TimeInterval
+    let backlog: MulticastBacklog
+    let backlogLifetime: TimeInterval
     private let now: @Sendable () -> Date
     private let lock = NSLock()
     private var continuations: [UUID: AsyncStream<Element>.Continuation] = [:]
-    private var backlog: [BacklogEntry] = []
+    private var backlogEntries: [BacklogEntry] = []
 
     init(
-        replaysBacklog: Bool = false,
+        backlog: MulticastBacklog = .dropped,
         backlogLifetime: TimeInterval = AsyncMulticast.defaultBacklogLifetime,
         now: @escaping @Sendable () -> Date = { Date() }
     ) {
-        self.replaysBacklog = replaysBacklog
+        self.backlog = backlog
         self.backlogLifetime = backlogLifetime
         self.now = now
     }
@@ -94,39 +102,78 @@ final class AsyncMulticast<Element: Sendable>: @unchecked Sendable {
         }
     }
 
-    func yield(_ element: Element) {
+    /// Broadcasts to every subscriber listening right now; with none, the
+    /// backlog policy decides what happens to the value. `onDelivery` runs
+    /// once, when the value first reaches a subscriber — never for a value
+    /// that expires or is evicted before that.
+    func yield(_ element: Element, onDelivery: (@Sendable () -> Void)? = nil) {
         lock.lock()
-        if replaysBacklog {
-            pruneBacklogLocked()
-            let entry = BacklogEntry(element: element, addedAt: now())
-            backlog.append(entry)
-            if backlog.count > Self.maxPending {
-                backlog.removeFirst(backlog.count - Self.maxPending)
+        pruneBacklogLocked()
+        let active: [AsyncStream<Element>.Continuation] = Array(continuations.values)
+        let isDelivered: Bool = !active.isEmpty
+        let addedAt: Date = now()
+
+        switch backlog {
+        case .dropped:
+            break
+        case .replayed:
+            let hook: (@Sendable () -> Void)? = isDelivered ? nil : onDelivery
+            let entry = BacklogEntry(element: element, addedAt: addedAt, onDelivery: hook)
+            appendBacklogLocked(entry)
+        case .deliveredOnce:
+            if !isDelivered {
+                let entry = BacklogEntry(element: element, addedAt: addedAt, onDelivery: onDelivery)
+                appendBacklogLocked(entry)
             }
         }
-        let active: [AsyncStream<Element>.Continuation] = Array(continuations.values)
         lock.unlock()
 
         active.forEach { $0.yield(element) }
+        if isDelivered {
+            onDelivery?()
+        }
     }
 
     // MARK: - Private
 
-    /// Registers the subscriber and replays everything it has missed, all
-    /// under one lock. The replay yields INSIDE the critical section on
-    /// purpose: `Continuation.yield` never blocks under `.bufferingNewest`,
-    /// and doing it outside would let a value yielded concurrently reach this
-    /// subscriber BEFORE the backlog it is supposed to follow — the host would
-    /// see the launch purchase after the live one.
+    /// Registers the subscriber and hands it the backlog, all under one lock.
+    /// The yields happen INSIDE the critical section on purpose:
+    /// `Continuation.yield` never blocks under `.bufferingNewest`, and doing
+    /// it outside would let a value yielded concurrently reach this subscriber
+    /// BEFORE the backlog it is supposed to follow — the host would see the
+    /// launch purchase after the live one.
     private func register(id: UUID, continuation: AsyncStream<Element>.Continuation) {
         lock.lock()
-        defer { lock.unlock() }
-
         continuations[id] = continuation
-        guard replaysBacklog else { return }
-
         pruneBacklogLocked()
-        backlog.forEach { continuation.yield($0.element) }
+
+        var hooks: [@Sendable () -> Void] = []
+        switch backlog {
+        case .dropped:
+            break
+        case .replayed:
+            for index in backlogEntries.indices {
+                continuation.yield(backlogEntries[index].element)
+                if let hook = backlogEntries[index].onDelivery {
+                    hooks.append(hook)
+                    backlogEntries[index].onDelivery = nil
+                }
+            }
+        case .deliveredOnce:
+            let handedOver: [BacklogEntry] = backlogEntries
+            backlogEntries.removeAll()
+            handedOver.forEach { entry in
+                continuation.yield(entry.element)
+                if let hook = entry.onDelivery {
+                    hooks.append(hook)
+                }
+            }
+        }
+        lock.unlock()
+
+        // Outside the lock: a delivery hook is caller code and may take locks
+        // or touch storage of its own.
+        hooks.forEach { $0() }
     }
 
     private func unregister(id: UUID) {
@@ -135,10 +182,17 @@ final class AsyncMulticast<Element: Sendable>: @unchecked Sendable {
         lock.unlock()
     }
 
+    private func appendBacklogLocked(_ entry: BacklogEntry) {
+        backlogEntries.append(entry)
+        if backlogEntries.count > Self.maxPending {
+            backlogEntries.removeFirst(backlogEntries.count - Self.maxPending)
+        }
+    }
+
     private func pruneBacklogLocked() {
         guard backlogLifetime.isFinite else { return }
 
         let deadline: Date = now().addingTimeInterval(-backlogLifetime)
-        backlog.removeAll { $0.addedAt < deadline }
+        backlogEntries.removeAll { $0.addedAt < deadline }
     }
 }

--- a/Tests/QonversionUnitTests/AsyncMulticastTests.swift
+++ b/Tests/QonversionUnitTests/AsyncMulticastTests.swift
@@ -5,14 +5,17 @@
 //  Direct contract tests for the fan-out primitive behind deferredPurchases(),
 //  entitlementsUpdates() and promoPurchaseIntents().
 //
-//  Backlog policy under test:
+//  Contract under test:
 //    * every subscriber gets its own independent stream;
-//    * with replaysBacklog, a value is replayed to EVERY subscriber arriving
-//      inside the replay window, whether or not somebody was already listening
-//      when it was produced;
-//    * a subscriber reads the backlog once, at subscription, so a live
-//      subscriber never sees a value twice;
-//    * the backlog is bounded by count and by age.
+//    * a value produced while subscribers are listening is broadcast to all of
+//      them, whatever the backlog policy is;
+//    * .replayed keeps a value for every subscriber arriving inside the
+//      lifetime — idempotent snapshots;
+//    * .deliveredOnce hands a waiting value to the first subscriber that
+//      arrives, and to nobody after it — events the host acts on;
+//    * the delivery hook runs once, when a value first reaches a subscriber;
+//    * the backlog is bounded by count and by age, and an infinite lifetime
+//      makes a waiting value outwait anything.
 //
 
 import XCTest
@@ -76,13 +79,13 @@ final class AsyncMulticastTests: XCTestCase {
             return count == 1
         }
         let received: [Int] = await subscriber.received
-        XCTAssertEqual(received, [2], "no replay was asked for")
+        XCTAssertEqual(received, [2], "no backlog was asked for")
     }
 
-    // MARK: - backlog replay
+    // MARK: - .replayed
 
     func testTheBacklogIsReplayedToASubscriberThatArrivesLater() async {
-        let multicast = AsyncMulticast<Int>(replaysBacklog: true)
+        let multicast = AsyncMulticast<Int>(backlog: .replayed)
 
         multicast.yield(1)
         multicast.yield(2)
@@ -96,10 +99,29 @@ final class AsyncMulticastTests: XCTestCase {
         XCTAssertEqual(received, [1, 2])
     }
 
-    func testALiveSubscriberDoesNotConsumeTheBacklogOfALaterOne() async {
-        // The regression: the old implementation cleared the backlog as soon as
-        // any subscriber was live, so the second subscriber got nothing.
-        let multicast = AsyncMulticast<Int>(replaysBacklog: true)
+    func testAReplayedValueReachesEverySubscriberArrivingLater() async {
+        // The point of .replayed: the value is a snapshot, so reading it again
+        // costs nothing and every late subscriber is entitled to it.
+        let multicast = AsyncMulticast<Int>(backlog: .replayed)
+        multicast.yield(1)
+
+        let first = collect(multicast.stream())
+        await waitUntil {
+            let count: Int = await first.received.count
+            return count == 1
+        }
+        let second = collect(multicast.stream())
+
+        await waitUntil {
+            let count: Int = await second.received.count
+            return count == 1
+        }
+        let secondReceived: [Int] = await second.received
+        XCTAssertEqual(secondReceived, [1])
+    }
+
+    func testALiveSubscriberDoesNotConsumeTheReplayOfALaterOne() async {
+        let multicast = AsyncMulticast<Int>(backlog: .replayed)
         let early = collect(multicast.stream())
         await waitUntil {
             let attached: Bool = await early.attached
@@ -120,12 +142,12 @@ final class AsyncMulticastTests: XCTestCase {
         }
         let lateReceived: [Int] = await late.received
         let earlyReceived: [Int] = await early.received
-        XCTAssertEqual(lateReceived, [1], "the late subscriber is owed the backlog too")
+        XCTAssertEqual(lateReceived, [1], "the late subscriber is owed the replay too")
         XCTAssertEqual(earlyReceived, [1], "the live subscriber must not be replayed its own value")
     }
 
     func testALiveSubscriberIsNeverDeliveredTheSameValueTwice() async {
-        let multicast = AsyncMulticast<Int>(replaysBacklog: true)
+        let multicast = AsyncMulticast<Int>(backlog: .replayed)
         let subscriber = collect(multicast.stream())
         await waitUntil {
             let attached: Bool = await subscriber.attached
@@ -146,7 +168,7 @@ final class AsyncMulticastTests: XCTestCase {
     }
 
     func testATerminatedSubscriberStopsReceivingValues() async {
-        let multicast = AsyncMulticast<Int>(replaysBacklog: true)
+        let multicast = AsyncMulticast<Int>(backlog: .replayed)
         let survivor = collect(multicast.stream())
         // Kept alive on purpose: the point of the test is what the terminated
         // collector did NOT receive, which a released collector cannot report.
@@ -182,11 +204,11 @@ final class AsyncMulticastTests: XCTestCase {
     }
 
     func testTheBacklogIsDeliveredBeforeAConcurrentLiveValue() async {
-        // The replay happens under the same lock as the registration: yielding
-        // it afterwards would let a value produced concurrently overtake the
-        // backlog, so the host would see the launch purchase AFTER the live
-        // one.
-        let multicast = AsyncMulticast<Int>(replaysBacklog: true)
+        // The hand-over happens under the same lock as the registration:
+        // yielding it afterwards would let a value produced concurrently
+        // overtake the backlog, so the host would see the launch purchase
+        // AFTER the live one.
+        let multicast = AsyncMulticast<Int>(backlog: .replayed)
         multicast.yield(1)
         multicast.yield(2)
 
@@ -205,10 +227,216 @@ final class AsyncMulticastTests: XCTestCase {
         XCTAssertEqual(received, Array(1...8), "the backlog always precedes the live values")
     }
 
+    // MARK: - .deliveredOnce
+
+    func testAWaitingValueIsHandedToTheFirstSubscriberAndToNobodyElse() async {
+        let multicast = AsyncMulticast<Int>(backlog: .deliveredOnce)
+        multicast.yield(1)
+
+        let first = collect(multicast.stream())
+        await waitUntil {
+            let count: Int = await first.received.count
+            return count == 1
+        }
+        let second = collect(multicast.stream())
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        let firstReceived: [Int] = await first.received
+        let secondReceived: [Int] = await second.received
+        XCTAssertEqual(firstReceived, [1])
+        XCTAssertEqual(secondReceived, [], "the value was already handed over")
+    }
+
+    func testALiveValueIsBroadcastToEverySubscriberAndNotKeptForLaterOnes() async {
+        // Broadcast is not hand-off: N subscribers listening at the moment of
+        // the value all get it, and it is spent afterwards.
+        let multicast = AsyncMulticast<Int>(backlog: .deliveredOnce)
+        let first = collect(multicast.stream())
+        let second = collect(multicast.stream())
+        await waitUntil {
+            let firstAttached: Bool = await first.attached
+            let secondAttached: Bool = await second.attached
+            return firstAttached && secondAttached
+        }
+
+        multicast.yield(1)
+
+        await waitUntil {
+            let firstCount: Int = await first.received.count
+            let secondCount: Int = await second.received.count
+            return firstCount == 1 && secondCount == 1
+        }
+        let late = collect(multicast.stream())
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        let firstReceived: [Int] = await first.received
+        let secondReceived: [Int] = await second.received
+        let lateReceived: [Int] = await late.received
+        XCTAssertEqual(firstReceived, [1])
+        XCTAssertEqual(secondReceived, [1])
+        XCTAssertEqual(lateReceived, [], "a value that already reached its subscribers is never repeated")
+    }
+
+    func testEachWaitingValueIsHandedOverInOrderExactlyOnce() async {
+        let multicast = AsyncMulticast<Int>(backlog: .deliveredOnce)
+        multicast.yield(1)
+        multicast.yield(2)
+        multicast.yield(3)
+
+        let subscriber = collect(multicast.stream())
+
+        await waitUntil {
+            let count: Int = await subscriber.received.count
+            return count == 3
+        }
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        let received: [Int] = await subscriber.received
+        XCTAssertEqual(received, [1, 2, 3])
+    }
+
+    func testAValueWaitingWithoutADeadlineOutlivesAnyDelay() async {
+        // The deferred-purchases wiring: an approval processed while nobody
+        // listens must still be there when the host finally subscribes.
+        let clock = MulticastTestClock(start: Date(timeIntervalSince1970: 1_000_000))
+        let multicast = AsyncMulticast<Int>(
+            backlog: .deliveredOnce,
+            backlogLifetime: .infinity,
+            now: { clock.now }
+        )
+
+        multicast.yield(1)
+        clock.advance(by: 86_400)
+        let subscriber = collect(multicast.stream())
+
+        await waitUntil {
+            let count: Int = await subscriber.received.count
+            return count == 1
+        }
+        let received: [Int] = await subscriber.received
+        XCTAssertEqual(received, [1], "a value with no deadline waits for its subscriber")
+    }
+
+    func testAWaitingValueStillExpiresWhenTheLifetimeIsFinite() async {
+        let clock = MulticastTestClock(start: Date(timeIntervalSince1970: 1_000_000))
+        let multicast = AsyncMulticast<Int>(
+            backlog: .deliveredOnce,
+            backlogLifetime: 60,
+            now: { clock.now }
+        )
+
+        multicast.yield(1)
+        clock.advance(by: 61)
+        multicast.yield(2)
+        let subscriber = collect(multicast.stream())
+
+        await waitUntil {
+            let count: Int = await subscriber.received.count
+            return count == 1
+        }
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        let received: [Int] = await subscriber.received
+        XCTAssertEqual(received, [2], "the expired value must not be handed over")
+    }
+
+    // MARK: - the delivery hook
+
+    func testTheDeliveryHookRunsWhenTheValueIsBroadcastLive() async {
+        let deliveries = MulticastDeliveryCounter()
+        let multicast = AsyncMulticast<Int>(backlog: .deliveredOnce)
+        let subscriber = collect(multicast.stream())
+        await waitUntil {
+            let attached: Bool = await subscriber.attached
+            return attached
+        }
+
+        multicast.yield(1) { deliveries.record() }
+
+        XCTAssertEqual(deliveries.count, 1)
+    }
+
+    func testTheDeliveryHookRunsWhenAWaitingValueIsHandedOver() async {
+        let deliveries = MulticastDeliveryCounter()
+        let multicast = AsyncMulticast<Int>(backlog: .deliveredOnce)
+
+        multicast.yield(1) { deliveries.record() }
+        XCTAssertEqual(deliveries.count, 0, "nobody has received it yet")
+
+        let first = collect(multicast.stream())
+        await waitUntil {
+            let count: Int = await first.received.count
+            return count == 1
+        }
+        _ = collect(multicast.stream())
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        XCTAssertEqual(deliveries.count, 1, "the hand-over is reported exactly once")
+    }
+
+    func testTheDeliveryHookNeverRunsForAValueThatExpired() async {
+        let clock = MulticastTestClock(start: Date(timeIntervalSince1970: 1_000_000))
+        let deliveries = MulticastDeliveryCounter()
+        let multicast = AsyncMulticast<Int>(
+            backlog: .deliveredOnce,
+            backlogLifetime: 60,
+            now: { clock.now }
+        )
+
+        multicast.yield(1) { deliveries.record() }
+        clock.advance(by: 61)
+        let subscriber = collect(multicast.stream())
+        await waitUntil {
+            let attached: Bool = await subscriber.attached
+            return attached
+        }
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        XCTAssertEqual(deliveries.count, 0, "an expired value was never delivered")
+    }
+
+    func testTheDeliveryHookOfAReplayedValueRunsOnlyOnTheFirstDelivery() async {
+        let deliveries = MulticastDeliveryCounter()
+        let multicast = AsyncMulticast<Int>(backlog: .replayed)
+
+        multicast.yield(1) { deliveries.record() }
+
+        let first = collect(multicast.stream())
+        await waitUntil {
+            let count: Int = await first.received.count
+            return count == 1
+        }
+        let second = collect(multicast.stream())
+        await waitUntil {
+            let count: Int = await second.received.count
+            return count == 1
+        }
+
+        XCTAssertEqual(deliveries.count, 1, "the replay is not a new delivery")
+    }
+
     // MARK: - backlog bounds
 
     func testTheBacklogIsBoundedByCountAndKeepsTheNewestValues() async {
-        let multicast = AsyncMulticast<Int>(replaysBacklog: true)
+        let multicast = AsyncMulticast<Int>(backlog: .replayed)
+        let overflow: Int = AsyncMulticast<Int>.maxPending + 3
+
+        for value in 1...overflow {
+            multicast.yield(value)
+        }
+        let subscriber = collect(multicast.stream())
+
+        await waitUntil {
+            let count: Int = await subscriber.received.count
+            return count == AsyncMulticast<Int>.maxPending
+        }
+        let received: [Int] = await subscriber.received
+        let expected: [Int] = Array(4...overflow)
+        XCTAssertEqual(received, expected, "the oldest values are dropped first")
+    }
+
+    func testTheWaitingValuesAreBoundedByCountToo() async {
+        // No subscriber ever showing up must not turn the buffer into an
+        // unbounded event log.
+        let multicast = AsyncMulticast<Int>(backlog: .deliveredOnce)
         let overflow: Int = AsyncMulticast<Int>.maxPending + 3
 
         for value in 1...overflow {
@@ -228,7 +456,7 @@ final class AsyncMulticastTests: XCTestCase {
     func testABacklogEntryOlderThanTheLifetimeIsNotReplayed() async {
         let clock = MulticastTestClock(start: Date(timeIntervalSince1970: 1_000_000))
         let multicast = AsyncMulticast<Int>(
-            replaysBacklog: true,
+            backlog: .replayed,
             backlogLifetime: 60,
             now: { clock.now }
         )
@@ -257,16 +485,16 @@ final class AsyncMulticastTests: XCTestCase {
         // With the per-subscriber buffer sized exactly like the backlog, a
         // full backlog leaves zero headroom: one live value arriving before
         // the new subscriber starts draining silently evicts the oldest
-        // replayed entry — in production a lost DeferredPurchase.
-        let multicast = AsyncMulticast<Int>(replaysBacklog: true)
+        // handed-over entry — in production a lost DeferredPurchase.
+        let multicast = AsyncMulticast<Int>(backlog: .replayed)
         let backlogSize: Int = AsyncMulticast<Int>.maxPending
         for value in 1...backlogSize {
             multicast.yield(value)
         }
 
-        // The stream registers (and is replayed) as it is built, but nothing
+        // The stream registers (and is served) as it is built, but nothing
         // consumes it yet — the live value below lands in its buffer on top of
-        // the whole replay.
+        // the whole backlog.
         let stream: AsyncStream<Int> = multicast.stream()
         multicast.yield(backlogSize + 1)
 
@@ -328,5 +556,25 @@ private final class MulticastTestClock: @unchecked Sendable {
 
     func advance(by interval: TimeInterval) {
         current = current.addingTimeInterval(interval)
+    }
+}
+
+/// Counts delivery-hook calls; the hook can run on any thread.
+// @unchecked: the counter is lock-guarded.
+private final class MulticastDeliveryCounter: @unchecked Sendable {
+
+    private let lock = NSLock()
+    private var calls: Int = 0
+
+    var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return calls
+    }
+
+    func record() {
+        lock.lock()
+        calls += 1
+        lock.unlock()
     }
 }

--- a/Tests/QonversionUnitTests/PurchasesManagerTests.swift
+++ b/Tests/QonversionUnitTests/PurchasesManagerTests.swift
@@ -1028,6 +1028,49 @@ final class PurchasesManagerTests: XCTestCase {
         XCTAssertTrue(facade.finishedTransactions.isEmpty, "the host app owns the lifecycle in Analytics mode")
     }
 
+    func testARevocationStaysReadableByAStreamCreatedAfterIt() async {
+        // A revocation travels the same snapshot channel as a deferred
+        // purchase's entitlements, and a snapshot is replayed state: a screen
+        // that subscribes later must still read the access that is now gone.
+        manager = makeManager(launchMode: .subscriptionManagement)
+        entitlementsManager.entitlementsResult = [:]
+        let first = StreamCollector(manager.entitlementsUpdates())
+
+        manager.transactionUpdated(makeRevokedTransaction(id: "late-1"))
+        await waitUntil { await !first.received.isEmpty }
+
+        let second = StreamCollector(manager.entitlementsUpdates())
+
+        await waitUntil { await !second.received.isEmpty }
+        let received: [[String: Qonversion.Entitlement]] = await second.received
+        XCTAssertEqual(received.count, 1)
+        XCTAssertTrue(received.first?.isEmpty ?? false, "the first subscription must not consume the revocation snapshot")
+    }
+
+    func testARevocationAlreadyAccountedForIsNotProcessedAgainOnTheNextLaunch() async {
+        // Analytics mode never finishes the transaction, so the store hands
+        // the very same revocation over again on every launch.
+        manager = makeManager(launchMode: .analytics)
+        entitlementsManager.entitlementsResult = [:]
+        let first = StreamCollector(manager.entitlementsUpdates())
+
+        manager.transactionUpdated(makeRevokedTransaction(id: "twice-1"))
+        await waitUntil { await !first.received.isEmpty }
+
+        let surfaced: [String]? = try? localStorage.object(forKey: "qonversion.keys.surfacedTransactions", dataType: [String].self)
+        XCTAssertEqual(surfaced, ["revoked:twice-1"], "the revocation is recorded under a namespace of its own")
+
+        // "Next launch": a fresh manager over the same storage.
+        let relaunched: PurchasesManager = makeManager(launchMode: .analytics)
+        let second = StreamCollector(relaunched.entitlementsUpdates())
+        relaunched.transactionUpdated(makeRevokedTransaction(id: "twice-1"))
+
+        try? await Task.sleep(nanoseconds: 200_000_000)
+        let received: [[String: Qonversion.Entitlement]] = await second.received
+        XCTAssertTrue(received.isEmpty, "a revocation the SDK already accounted for must not be republished")
+        XCTAssertEqual(entitlementsManager.invalidationCallsCount, 1, "the fresh window is invalidated once, by the launch that saw the refund")
+    }
+
     func testTheBufferedLaunchEmissionReachesBothStreams() async {
         // The backlog exists for hosts that subscribe after launch; the
         // entitlements projection must not steal it from deferredPurchases.
@@ -1128,6 +1171,131 @@ final class PurchasesManagerTests: XCTestCase {
 
         let received: [[String: Qonversion.Entitlement]] = await collector.received
         XCTAssertEqual(received.count, bufferSize, "the projection must drop the oldest values, not queue them all")
+    }
+
+    // MARK: - deferred purchases are delivered exactly once
+
+    func testAPurchaseTheHostReceivedIsNotHandedToALaterSubscription() async {
+        // The documented SwiftUI shape: a screen that re-appears builds a
+        // second subscription. Handing it the same approval again would grant
+        // the content twice.
+        manager = makeManager(launchMode: .subscriptionManagement)
+        entitlementsManager.entitlementsResult = ["premium": entitlement(id: "premium")]
+        let first = StreamCollector(manager.deferredPurchases())
+
+        manager.transactionUpdated(makeTransaction(id: "once-1"))
+        await waitUntil { await !first.received.isEmpty }
+
+        let second = StreamCollector(manager.deferredPurchases())
+        try? await Task.sleep(nanoseconds: 200_000_000)
+
+        let firstReceived: [Qonversion.DeferredPurchase] = await first.received
+        let secondReceived: [Qonversion.DeferredPurchase] = await second.received
+        XCTAssertEqual(firstReceived.map(\.transaction.id), ["once-1"])
+        XCTAssertTrue(secondReceived.isEmpty, "a purchase the host already received must not be repeated")
+    }
+
+    func testABufferedPurchaseGoesToTheFirstSubscriptionOnly() async {
+        // The approval is processed before the host wires anything up: it
+        // waits, and the subscription that takes it consumes it.
+        manager = makeManager(launchMode: .subscriptionManagement)
+        entitlementsManager.entitlementsResult = ["premium": entitlement(id: "premium")]
+
+        manager.transactionUpdated(makeTransaction(id: "once-2"))
+        await waitUntil { !self.facade.finishedTransactions.isEmpty }
+
+        let first = StreamCollector(manager.deferredPurchases())
+        await waitUntil { await !first.received.isEmpty }
+        let second = StreamCollector(manager.deferredPurchases())
+        try? await Task.sleep(nanoseconds: 200_000_000)
+
+        let firstReceived: [Qonversion.DeferredPurchase] = await first.received
+        let secondReceived: [Qonversion.DeferredPurchase] = await second.received
+        XCTAssertEqual(firstReceived.map(\.transaction.id), ["once-2"])
+        XCTAssertTrue(secondReceived.isEmpty, "the buffered purchase was already taken")
+    }
+
+    func testConcurrentSubscriptionsBothReceiveTheSamePurchase() async {
+        // Broadcast, not hand-off: everybody listening at the moment of the
+        // approval hears it.
+        manager = makeManager(launchMode: .subscriptionManagement)
+        entitlementsManager.entitlementsResult = ["premium": entitlement(id: "premium")]
+        let first = StreamCollector(manager.deferredPurchases())
+        let second = StreamCollector(manager.deferredPurchases())
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        manager.transactionUpdated(makeTransaction(id: "both-1"))
+
+        await waitUntil {
+            let firstEmpty: Bool = await first.received.isEmpty
+            let secondEmpty: Bool = await second.received.isEmpty
+            return !firstEmpty && !secondEmpty
+        }
+        let firstReceived: [Qonversion.DeferredPurchase] = await first.received
+        let secondReceived: [Qonversion.DeferredPurchase] = await second.received
+        XCTAssertEqual(firstReceived.map(\.transaction.id), ["both-1"])
+        XCTAssertEqual(secondReceived.map(\.transaction.id), ["both-1"])
+    }
+
+    func testAPurchaseNobodyReceivedComesBackOnTheNextLaunch() async {
+        // Ask to Buy approved with the app in the background and no
+        // subscription alive. The event must not be written off as delivered.
+        manager = makeManager(launchMode: .analytics)
+        entitlementsManager.entitlementsResult = ["premium": entitlement(id: "premium")]
+
+        manager.transactionUpdated(makeTransaction(id: "unheard-1"))
+        await waitUntil { self.service.sentTransactions.count >= 1 }
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        // "Next launch": a fresh manager over the same storage, re-delivered
+        // by the store because Analytics mode never finishes anything.
+        let relaunched: PurchasesManager = makeManager(launchMode: .analytics)
+        let collector = StreamCollector(relaunched.deferredPurchases())
+        relaunched.transactionUpdated(makeTransaction(id: "unheard-1"))
+
+        await waitUntil { await !collector.received.isEmpty }
+        let received: [Qonversion.DeferredPurchase] = await collector.received
+        XCTAssertEqual(received.map(\.transaction.id), ["unheard-1"], "a purchase nobody heard must not be lost")
+    }
+
+    func testAPromoIntentHandedToASubscriptionIsNotRepeatedToTheNextOne() async {
+        // Acting on the same intent twice would run the purchase flow twice.
+        manager.emitPromoPurchaseIntent(storeProductId: "com.app.promo")
+
+        let first = StreamCollector(manager.promoPurchaseIntents())
+        await waitUntil { await !first.received.isEmpty }
+        let second = StreamCollector(manager.promoPurchaseIntents())
+        try? await Task.sleep(nanoseconds: 200_000_000)
+
+        let secondReceived: [Qonversion.PromoPurchaseIntent] = await second.received
+        XCTAssertTrue(secondReceived.isEmpty, "the intent was already handed over")
+    }
+
+    func testTheDeferredPurchasesBufferHasNoExpiryDeadline() {
+        // The replay window used to drop an approval the host had not
+        // subscribed for yet; a deadline cannot be caught by waiting it out,
+        // so the wiring itself is the assertion.
+        XCTAssertEqual(manager.deferredPurchasesMulticast.backlog, .deliveredOnce)
+        XCTAssertFalse(manager.deferredPurchasesMulticast.backlogLifetime.isFinite,
+                       "an approval nobody received waits for the host, not for a deadline")
+    }
+
+    func testEntitlementsUpdatesStillReachesEveryLaterSubscription() async {
+        // Unchanged on purpose: an entitlements snapshot is idempotent state,
+        // so a host that re-subscribes must still be able to read the latest.
+        manager = makeManager(launchMode: .subscriptionManagement)
+        entitlementsManager.entitlementsResult = ["premium": entitlement(id: "premium")]
+
+        manager.transactionUpdated(makeTransaction(id: "snapshot-1"))
+        await waitUntil { !self.facade.finishedTransactions.isEmpty }
+
+        let first = StreamCollector(manager.entitlementsUpdates())
+        await waitUntil { await !first.received.isEmpty }
+        let second = StreamCollector(manager.entitlementsUpdates())
+
+        await waitUntil { await !second.received.isEmpty }
+        let secondReceived: [[String: Qonversion.Entitlement]] = await second.received
+        XCTAssertEqual(secondReceived.first?.keys.sorted(), ["premium"], "the snapshot stays readable by later subscriptions")
     }
 
     // MARK: - promotional offer signature


### PR DESCRIPTION
AsyncMulticast replayed its whole non-expired backlog to EVERY new subscriber, so a host that re-subscribed inside the 300 s window (a SwiftUI screen that re-appears, a new .task) received the same DeferredPurchase again and granted the content twice. The same backlog expired after 300 s while the transaction had already been marked surfaced before the delivery, so an approval processed with nobody listening was gone for good.

The backlog policy is now explicit. `.replayed` keeps today's behavior for idempotent snapshots; `.deliveredOnce` hands a waiting value to the first subscriber that arrives and to nobody after it. Live broadcast is untouched: a value produced while N subscribers listen still reaches all N. Deferred purchases and promo intents use `.deliveredOnce`, and the deferred buffer has no expiry deadline, so an approval waits for the host instead of a clock.

A transaction is now persisted as surfaced only once the purchase actually reaches a subscriber, so an event nobody received comes back on the next launch; an in-launch claim keeps a second path from emitting it twice meanwhile. entitlementsUpdates() is fed alongside the deferred purchases instead of subscribing to them, so reading the projection can never take a purchase away from deferredPurchases().