### PR TITLE
fix: keep the offline replay from stranding purchases and losing errors

### DIFF
--- a/Sources/Managers/PurchasesManager/PurchasesManager.swift
+++ b/Sources/Managers/PurchasesManager/PurchasesManager.swift
@@ -572,9 +572,19 @@ final class PurchasesManager: PurchasesManagerInterface, @unchecked Sendable {
             }
         }
 
+        // The offline replay may have delivered this report already. It cannot
+        // finish or surface a transaction, so the rest of the outcome is still
+        // owed — only the POST must not happen twice.
+        var alreadyReported = false
+        if let id: String = transaction.id {
+            alreadyReported = reportsGate.wasReported(id)
+        }
+
         var reportFailed = false
         do {
-            try await purchasesService.send(transaction, userId: reportUserId, options: reportOptions(for: transaction), trigger: trigger)
+            if !alreadyReported {
+                try await purchasesService.send(transaction, userId: reportUserId, options: reportOptions(for: transaction), trigger: trigger)
+            }
             purchaseAssociationsStorage.remove(for: transaction.productId)
             // The deferred purchase this delivery emits must carry the
             // entitlements the report produced, not the ones cached before it.

--- a/Sources/Managers/PurchasesManager/TransactionReportsGate.swift
+++ b/Sources/Managers/PurchasesManager/TransactionReportsGate.swift
@@ -9,17 +9,30 @@ import Foundation
 /// purchase: the launch sweep of unfinished transactions, the
 /// Transaction.updates listener, and the offline replay of the requests queue
 /// (which at launch runs concurrently with the sweep and may hold a queued
-/// report for the very transaction the sweep is about to send). Whoever takes
-/// the id first reports it, the other paths skip. A failed report releases the
-/// id so the next attempt can retry.
+/// report for the very transaction the sweep is about to send).
+///
+/// The gate guards the POST, not the transaction's outcome. Reporting a
+/// purchase is only one third of it: the SDK must also finish the StoreKit
+/// transaction and surface one deferred purchase, and the replay does neither
+/// — it is an HTTP resend with no StoreKit context. So a taken id is released
+/// on every terminal outcome:
+///
+/// - the report failed — ``release(_:)``, the next attempt may retry it;
+/// - the report was delivered — ``markReported(_:)``, which also records the
+///   delivery so that a later path finishes and surfaces the transaction
+///   through ``wasReported(_:)`` instead of posting it a second time.
+///
+/// A holder that produces the whole outcome itself (the purchases funnel) never
+/// has to release: it keeps the id until ``reset()``.
 ///
 /// One instance SDK-wide — see MiscAssembly.transactionReportsGate().
-// @unchecked: the id set is lock-guarded; synchronous on purpose — the reset
+// @unchecked: the id sets are lock-guarded; synchronous on purpose — the reset
 // on a user change must be ordered before the next restore call.
 final class TransactionReportsGate: @unchecked Sendable {
 
     private let lock = NSLock()
     private var takenIds: Set<String> = []
+    private var reportedIds: Set<String> = []
 
     func tryTake(_ id: String) -> Bool {
         lock.lock()
@@ -35,11 +48,30 @@ final class TransactionReportsGate: @unchecked Sendable {
         takenIds.remove(id)
     }
 
+    /// The report reached the backend. Hands the id back so a path that can
+    /// finish and surface the transaction may take it, while
+    /// ``wasReported(_:)`` keeps that path from posting the purchase again.
+    func markReported(_ id: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        reportedIds.insert(id)
+        takenIds.remove(id)
+    }
+
+    /// True when this transaction's report already reached the backend in this
+    /// session — the caller still owes it a finish and a deferred purchase.
+    func wasReported(_ id: String) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return reportedIds.contains(id)
+    }
+
     /// The new user's restore must re-report everything: the gate belongs to
     /// the reporting session of one user.
     func reset() {
         lock.lock()
         defer { lock.unlock() }
         takenIds.removeAll()
+        reportedIds.removeAll()
     }
 }

--- a/Sources/NetworkLayer/Error/QonversionError.swift
+++ b/Sources/NetworkLayer/Error/QonversionError.swift
@@ -37,8 +37,9 @@ public struct QonversionError: Error, @unchecked Sendable {
 
     init(type: QonversionErrorType, message: String? = nil, error: Error? = nil, additionalInfo: [String : Any]? = nil, apiCode: String? = nil, apiType: String? = nil) {
         var errorMessage: String = message ?? type.message()
-        if let qonversionError = error as? QonversionError {
-            errorMessage += "\n" + qonversionError.message
+        let wrappedError: QonversionError? = error as? QonversionError
+        if let wrappedError {
+            errorMessage += "\n" + wrappedError.message
         } else if let error = error {
             errorMessage += "\n" + error.localizedDescription
         }
@@ -47,8 +48,10 @@ public struct QonversionError: Error, @unchecked Sendable {
         self.message = errorMessage
         self.error = error
         self.additionalInfo = additionalInfo
-        self.apiCode = apiCode
-        self.apiType = apiType
+        // A service names the operation that failed, but only the backend can
+        // classify WHY — that classification must survive the wrapping.
+        self.apiCode = apiCode ?? wrappedError?.apiCode
+        self.apiType = apiType ?? wrappedError?.apiType
     }
     
     static func initializationError() -> QonversionError {

--- a/Sources/NetworkLayer/RequestProcessor/RequestProcessor.swift
+++ b/Sources/NetworkLayer/RequestProcessor/RequestProcessor.swift
@@ -53,6 +53,12 @@ class RequestProcessor: RequestProcessorInterface, @unchecked Sendable {
     /// keeps it for the next session. A latched critical error (revoked
     /// project key) stops the replay without removing anything, so the entries
     /// wait for a launch where the key works again.
+    ///
+    /// A purchase report also passes through the shared reports gate, which the
+    /// replay always hands back: released when the report did not land, marked
+    /// reported when it did. The replay is an HTTP resend with no StoreKit
+    /// context — it cannot finish the transaction or surface a deferred
+    /// purchase, so the launch sweep must still be able to claim it.
     func processStoredRequests() {
         guard criticalError == nil else { return }
 
@@ -103,6 +109,18 @@ class RequestProcessor: RequestProcessorInterface, @unchecked Sendable {
 
                 do {
                     let (data, urlResponse) = try await self.networkProvider.send(request: urlRequest)
+                    let responseError: QonversionError? = self.errorHandler.extractError(from: urlResponse, body: data)
+
+                    // Checked before the entry is touched: a revoked project key
+                    // stops the replay with the queue intact, so the entries
+                    // wait for a launch where the key works again.
+                    if let responseError, responseError.type == .critical {
+                        if let transactionId {
+                            self.reportsGate.release(transactionId)
+                        }
+                        self.criticalErrorLatch.latch(responseError)
+                        return
+                    }
 
                     // 5xx/429 mean the backend did not process the request —
                     // keep it queued. Everything else counts as delivered
@@ -116,14 +134,14 @@ class RequestProcessor: RequestProcessorInterface, @unchecked Sendable {
                             self.reportsGate.release(transactionId)
                         }
                     } else {
-                        // Delivered: the id stays taken so the sweep running
-                        // alongside cannot post it a second time.
+                        // Delivered. The replay cannot finish the StoreKit
+                        // transaction nor surface it, so the id goes back to the
+                        // sweep marked as reported — it completes the outcome
+                        // without posting the purchase twice.
+                        if let transactionId {
+                            self.reportsGate.markReported(transactionId)
+                        }
                         self.requestsStorage.remove(stored)
-                    }
-
-                    if let error = self.errorHandler.extractError(from: urlResponse, body: data), error.type == .critical {
-                        self.criticalErrorLatch.latch(error)
-                        return
                     }
                 } catch {
                     // Kept in the queue for the next session.
@@ -228,14 +246,17 @@ class RequestProcessor: RequestProcessorInterface, @unchecked Sendable {
             responseBody = data
             responseCode = (urlResponse as? HTTPURLResponse)?.statusCode ?? 0
         } catch {
-            // The request never reached the backend — persist retriable ones
-            // for the offline replay.
-            if retriableRequestKinds.contains(request.kind) {
+            // Only a transport failure proves the request never reached the
+            // backend. A cancelled send may well have been processed, so
+            // queueing it would report the same purchase twice (ObjC parity:
+            // QNAPIClient.m queued strictly on [QNUtils isConnectionError:]).
+            let isTransportFailure: Bool = Self.isTransportFailure(error)
+            if isTransportFailure, retriableRequestKinds.contains(request.kind) {
                 queueForReplay(request, as: urlRequest, trigger: trigger, attempt: attemptsMade.total, ifGenerationIs: generation)
             }
             // Named for what it is, so the host can branch on "offline"
             // instead of on a broken response.
-            let type: QonversionErrorType = Self.isTransportFailure(error) ? .networkConnectionFailed : .invalidResponse
+            let type: QonversionErrorType = isTransportFailure ? .networkConnectionFailed : .invalidResponse
             throw QonversionError(type: type, error: error)
         }
 
@@ -331,15 +352,19 @@ class RequestProcessor: RequestProcessorInterface, @unchecked Sendable {
     }
 
     /// A failure with no response at all: the request never reached the
-    /// backend, so resending it cannot duplicate anything. The first five are
-    /// the connection-class URLErrors; the last two are the extra codes the
-    /// ObjC client also treated as "no transport" (QNUtils.m:106-116).
+    /// backend, so resending it cannot duplicate anything. The connection-class
+    /// URLErrors, plus the extra codes the ObjC client also treated as "no
+    /// transport" (QNUtils.m:106-116).
     static func isTransportFailure(_ error: Error) -> Bool {
         guard let urlError = error as? URLError else { return false }
 
         switch urlError.code {
         case .notConnectedToInternet, .timedOut, .networkConnectionLost, .cannotConnectToHost, .dnsLookupFailed,
-             .callIsActive, .dataNotAllowed:
+             .callIsActive, .dataNotAllowed,
+             // CFNetwork reports an offline name lookup as -1003 far more often
+             // than as -1006, and a TLS handshake that never completed carries
+             // no response either.
+             .cannotFindHost, .secureConnectionFailed:
             return true
         default:
             return false
@@ -364,15 +389,16 @@ class RequestProcessor: RequestProcessorInterface, @unchecked Sendable {
 
             do {
                 return try await networkProvider.send(request: attemptedRequest)
-            } catch {
-                guard attempt <= Self.maxTransportRetries, Self.isTransportFailure(error) else { throw error }
+            } catch let transportError {
+                guard attempt <= Self.maxTransportRetries, Self.isTransportFailure(transportError) else { throw transportError }
 
                 do {
                     try await waitBeforeRetry(number: attempt)
                 } catch {
                     // Cancelled while backing off: surface the transport
-                    // failure rather than starting another attempt.
-                    throw error
+                    // failure rather than the CancellationError, or the host
+                    // loses its "offline" branch and the local fallback.
+                    throw transportError
                 }
                 attempt += 1
             }

--- a/Sources/NetworkLayer/RequestsStorage/RequestsStorage.swift
+++ b/Sources/NetworkLayer/RequestsStorage/RequestsStorage.swift
@@ -43,7 +43,18 @@ class RequestsStorage: RequestsStorageInterface, @unchecked Sendable {
         guard _cleanGeneration == generation else { return }
 
         var requests: [StoredRequest] = fetchStoredRequests()
-        if let dedupKey = request.dedupKey, requests.contains(where: { $0.dedupKey == dedupKey }) {
+        if let dedupKey = request.dedupKey, let index = requests.firstIndex(where: { $0.dedupKey == dedupKey }) {
+            // Device and attribution keys identify the RESOURCE, not the
+            // payload, so a second append under the same key is usually a
+            // fresher state (an IDFA collected after the first failure) that
+            // must supersede the queued one — in place, to keep the send order.
+            // An identical payload is a true duplicate: keep the queued entry,
+            // whose attempt count is the real one.
+            if requests[index].body != request.body {
+                requests[index] = request
+                persist(requests)
+            }
+
             return
         }
 

--- a/Tests/QonversionUnitTests/PurchasesManagerTests.swift
+++ b/Tests/QonversionUnitTests/PurchasesManagerTests.swift
@@ -1756,6 +1756,26 @@ final class PurchasesManagerTests: XCTestCase {
         XCTAssertEqual(facade.finishedTransactions.map(\.id), ["swept-1"])
     }
 
+    func testTheSweepFinishesAndSurfacesATransactionTheReplayAlreadyReported() async {
+        // The offline replay POSTs a queued report but cannot finish a StoreKit
+        // transaction or emit a deferred purchase — the sweep completes the
+        // outcome without posting the purchase a second time.
+        let reportsGate = TransactionReportsGate()
+        reportsGate.markReported("replayed-1")
+        manager = makeManager(launchMode: .subscriptionManagement, reportsGate: reportsGate)
+        entitlementsManager.entitlementsResult = ["premium": entitlement(id: "premium")]
+        facade.unfinishedTransactionsResult = [makeTransaction(id: "replayed-1")]
+        let collector = StreamCollector(manager.deferredPurchases())
+
+        await manager.processUnfinishedTransactions()
+
+        await waitUntil { await !collector.received.isEmpty }
+        XCTAssertTrue(service.sentTransactions.isEmpty, "the replay already delivered this report")
+        XCTAssertEqual(facade.finishedTransactions.map(\.id), ["replayed-1"])
+        let received: [Qonversion.DeferredPurchase] = await collector.received
+        XCTAssertEqual(received.map(\.transaction.id), ["replayed-1"])
+    }
+
     func testATransactionSurfacedByTheSweepIsNotEmittedAgainOnTheNextLaunch() async {
         // Analytics mode never finishes anything, so the store re-delivers the
         // same transaction on every cold start.

--- a/Tests/QonversionUnitTests/QonversionErrorTests.swift
+++ b/Tests/QonversionUnitTests/QonversionErrorTests.swift
@@ -69,4 +69,44 @@ final class QonversionErrorTests: XCTestCase {
         XCTAssertEqual(error.error as? URLError, underlying)
         XCTAssertTrue(error.message.hasPrefix(QonversionErrorType.productsLoadingFailed.message()))
     }
+
+    // MARK: - the backend classification survives the service wrapping
+
+    func testWrappingABackendErrorKeepsItsApiCodeAndApiType() {
+        // A service names the operation that failed, but the backend's own
+        // classification is what the host branches on.
+        let backendError = QonversionError(type: .fraudPurchase, message: "fraud", apiCode: "purchase_fraud", apiType: "logical")
+
+        let wrapped = QonversionError(type: .purchaseReportingFailed, message: nil, error: backendError)
+
+        XCTAssertEqual(wrapped.type, .purchaseReportingFailed)
+        XCTAssertEqual(wrapped.apiCode, "purchase_fraud")
+        XCTAssertEqual(wrapped.apiType, "logical")
+    }
+
+    func testAnExplicitApiCodeWinsOverTheUnderlyingOne() {
+        let backendError = QonversionError(type: .fraudPurchase, apiCode: "purchase_fraud", apiType: "logical")
+
+        let wrapped = QonversionError(type: .purchaseReportingFailed, error: backendError, apiCode: "explicit", apiType: "request")
+
+        XCTAssertEqual(wrapped.apiCode, "explicit")
+        XCTAssertEqual(wrapped.apiType, "request")
+    }
+
+    func testWrappingANonApiErrorLeavesTheClassificationEmpty() {
+        let wrapped = QonversionError(type: .purchaseReportingFailed, error: URLError(.notConnectedToInternet))
+
+        XCTAssertNil(wrapped.apiCode)
+        XCTAssertNil(wrapped.apiType)
+    }
+
+    func testTheClassificationSurvivesTwoLevelsOfWrapping() {
+        let backendError = QonversionError(type: .fraudPurchase, apiCode: "purchase_fraud", apiType: "logical")
+        let firstWrap = QonversionError(type: .purchaseReportingFailed, error: backendError)
+
+        let secondWrap = QonversionError(type: .productsLoadingFailed, error: firstWrap)
+
+        XCTAssertEqual(secondWrap.apiCode, "purchase_fraud")
+        XCTAssertEqual(secondWrap.apiType, "logical")
+    }
 }

--- a/Tests/QonversionUnitTests/RequestProcessorTests.swift
+++ b/Tests/QonversionUnitTests/RequestProcessorTests.swift
@@ -43,7 +43,7 @@ final class RequestProcessorTests: XCTestCase {
         super.tearDown()
     }
 
-    private func makeProcessor(retriableRequestKinds: [Request.Kind] = [], reportsGate: TransactionReportsGate = TransactionReportsGate(), criticalErrorLatch: CriticalErrorLatch = CriticalErrorLatch(), networkProvider: NetworkProviderInterface? = nil, rateLimiter: RateLimiterInterface? = nil) -> RequestProcessor {
+    private func makeProcessor(retriableRequestKinds: [Request.Kind] = [], reportsGate: TransactionReportsGate = TransactionReportsGate(), criticalErrorLatch: CriticalErrorLatch = CriticalErrorLatch(), networkProvider: NetworkProviderInterface? = nil, rateLimiter: RateLimiterInterface? = nil, transportRetryDelayCeiling: TimeInterval = 0) -> RequestProcessor {
         let provider: NetworkProviderInterface = networkProvider ?? self.networkProvider
         let limiter: RateLimiterInterface = rateLimiter ?? self.rateLimiter
 
@@ -59,7 +59,7 @@ final class RequestProcessorTests: XCTestCase {
             delayCalculator: IncrementalDelayCalculator(),
             // The backoff itself is proven by IncrementalDelayCalculatorTests;
             // waiting it out here would only make the suite slow.
-            transportRetryDelayCeiling: 0,
+            transportRetryDelayCeiling: transportRetryDelayCeiling,
             reportsGate: reportsGate,
             criticalErrorLatch: criticalErrorLatch
         )
@@ -252,7 +252,10 @@ final class RequestProcessorTests: XCTestCase {
         XCTAssertEqual(requestsStorage.storedRequests.count, 1, "the entry stays queued for the sweep to evict on delivery")
     }
 
-    func testADeliveredReplayKeepsTheTransactionTakenSoTheSweepSkipsIt() async {
+    func testADeliveredReplayHandsTheTransactionBackToTheSweepAsAlreadyReported() async {
+        // The replay only POSTs — it never finishes the StoreKit transaction
+        // and never surfaces a deferred purchase. Holding the id would strand
+        // the transaction for the whole session.
         let reportsGate = TransactionReportsGate()
         requestsStorage.append(StoredRequest(
             url: baseURL + "v4/users/u/purchases",
@@ -268,7 +271,51 @@ final class RequestProcessorTests: XCTestCase {
         await waitUntil { self.requestsStorage.storedRequests.isEmpty }
 
         XCTAssertEqual(networkProvider.sentRequests.count, 1)
-        XCTAssertFalse(reportsGate.tryTake("tx1"), "the sweep must not post the same purchase again")
+        XCTAssertTrue(reportsGate.wasReported("tx1"), "the delivery must be recorded so nobody posts it twice")
+        XCTAssertTrue(reportsGate.tryTake("tx1"), "the sweep must still be able to finish and surface it")
+    }
+
+    func testAReplayThatTripsTheLatchKeepsItsEntryQueued() async {
+        // The doc contract of processStoredRequests: a latched critical error
+        // stops the replay WITHOUT removing anything.
+        let latch = CriticalErrorLatch()
+        requestsStorage.append(StoredRequest(
+            url: baseURL + "v4/users/u/purchases",
+            method: "POST",
+            body: nil,
+            dedupKey: "createPurchase-u-tx1",
+            transactionId: "tx1"
+        ))
+        networkProvider.response = makeHTTPResponse(statusCode: 401)
+        errorHandler.errorToReturn = QonversionError(type: .critical)
+        let processor = makeProcessor(criticalErrorLatch: latch)
+
+        processor.processStoredRequests()
+        await waitUntil { latch.error != nil }
+
+        XCTAssertNotNil(latch.error, "a revoked key must latch")
+        XCTAssertEqual(requestsStorage.storedRequests.count, 1, "the entry must wait for a launch where the key works")
+    }
+
+    func testAReplayThatTripsTheLatchReleasesTheTransactionForTheNextLaunch() async {
+        let reportsGate = TransactionReportsGate()
+        let latch = CriticalErrorLatch()
+        requestsStorage.append(StoredRequest(
+            url: baseURL + "v4/users/u/purchases",
+            method: "POST",
+            body: nil,
+            dedupKey: "createPurchase-u-tx1",
+            transactionId: "tx1"
+        ))
+        networkProvider.response = makeHTTPResponse(statusCode: 401)
+        errorHandler.errorToReturn = QonversionError(type: .critical)
+        let processor = makeProcessor(reportsGate: reportsGate, criticalErrorLatch: latch)
+
+        processor.processStoredRequests()
+        await waitUntil { latch.error != nil }
+
+        XCTAssertFalse(reportsGate.wasReported("tx1"), "a rejected report is not a delivery")
+        XCTAssertTrue(reportsGate.tryTake("tx1"), "an undelivered report must not block the sweep")
     }
 
     func testAFailedReplayReleasesTheTransactionForTheSweep() async {
@@ -773,7 +820,7 @@ final class RequestProcessorTests: XCTestCase {
     func testAConnectionFailureSurfacesAsNetworkConnectionFailed() async {
         // No response ever arrived, so ".invalidResponse" describes a response
         // that does not exist — and the host has no way to branch on "offline".
-        let connectionErrors: [URLError.Code] = [.notConnectedToInternet, .timedOut, .networkConnectionLost, .cannotConnectToHost, .dnsLookupFailed, .callIsActive, .dataNotAllowed]
+        let connectionErrors: [URLError.Code] = [.notConnectedToInternet, .timedOut, .networkConnectionLost, .cannotConnectToHost, .dnsLookupFailed, .callIsActive, .dataNotAllowed, .cannotFindHost, .secureConnectionFailed]
 
         for code in connectionErrors {
             networkProvider = MockNetworkProvider()
@@ -788,6 +835,54 @@ final class RequestProcessorTests: XCTestCase {
                 XCTAssertEqual(qonversionError?.type, .networkConnectionFailed, "\(code) is a connection failure")
                 XCTAssertEqual((qonversionError?.error as? URLError)?.code, code, "the underlying error stays attached")
             }
+        }
+    }
+
+    func testAnUnresolvableHostIsRetriedLikeAnyConnectionFailure() async {
+        // CFNetwork reports an offline DNS failure as -1003, not -1006.
+        networkProvider.error = URLError(.cannotFindHost)
+        let processor = makeProcessor()
+
+        _ = try? await processor.process(request: .getUser(id: "u"), responseType: ProcessorTestPayload.self)
+
+        XCTAssertEqual(networkProvider.sentRequests.count, RequestProcessor.maxTransportRetries + 1)
+    }
+
+    // MARK: - cancellation is not an offline failure
+
+    func testACancelledSendIsNotQueuedForReplay() async {
+        // The request may well have reached the backend — replaying it would
+        // report the same purchase twice.
+        networkProvider.error = URLError(.cancelled)
+        let processor = makeProcessor(retriableRequestKinds: [.createPurchase])
+
+        _ = try? await processor.process(
+            request: .createPurchase(userId: "u", body: ["store_data": ["transaction_id": "t1"] as RequestBodyDict]),
+            responseType: EmptyApiResponse.self
+        )
+
+        XCTAssertTrue(requestsStorage.storedRequests.isEmpty, "a cancelled send must never be queued")
+    }
+
+    func testCancellationDuringTheBackoffStillSurfacesTheTransportFailure() async {
+        // The host branches on .networkConnectionFailed to fall back to local
+        // entitlements; a CancellationError would hide the outage.
+        networkProvider.error = URLError(.notConnectedToInternet)
+        let processor = makeProcessor(transportRetryDelayCeiling: 5)
+
+        let task = Task { () -> ProcessorTestPayload in
+            return try await processor.process(request: .getUser(id: "u"), responseType: ProcessorTestPayload.self)
+        }
+        await waitUntil { self.networkProvider.sentRequests.count >= 1 }
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("Expected the transport failure to surface")
+        } catch {
+            let qonversionError = error as? QonversionError
+            XCTAssertEqual(qonversionError?.type, .networkConnectionFailed)
+            XCTAssertEqual((qonversionError?.error as? URLError)?.code, .notConnectedToInternet, "the original outage must stay attached")
         }
     }
 

--- a/Tests/QonversionUnitTests/RequestsStorageTests.swift
+++ b/Tests/QonversionUnitTests/RequestsStorageTests.swift
@@ -141,6 +141,45 @@ final class RequestsStorageTests: XCTestCase {
         XCTAssertEqual(storage.fetchRequests().compactMap(\.dedupKey), ["createPurchase-u-t1", "createPurchase-u-t2"])
     }
 
+    func testAFresherPayloadSupersedesTheQueuedOneUnderTheSameKey() {
+        // Device and attribution keys identify the RESOURCE, not the payload:
+        // an IDFA collected after the first failure must not be thrown away.
+        let storage = makeStorage(TestDefaults.makeIsolated())
+        let stale: Data = Data("{\"idfa\": null}".utf8)
+        let fresh: Data = Data("{\"idfa\": \"AAA\"}".utf8)
+
+        storage.append(makeRequest(body: stale, dedupKey: "createDevice-u"))
+        storage.append(makeRequest(body: fresh, dedupKey: "createDevice-u"))
+
+        let queued: [StoredRequest] = storage.fetchRequests()
+        XCTAssertEqual(queued.count, 1, "the resource is still queued once")
+        XCTAssertEqual(queued.first?.body, fresh, "the newest payload is the one worth replaying")
+    }
+
+    func testAnIdenticalPayloadKeepsTheQueuedAttemptCount() {
+        // Re-queueing the same payload is a duplicate, not an update: the
+        // attempt history of the queued entry must survive.
+        let storage = makeStorage(TestDefaults.makeIsolated())
+        let body: Data = Data("{\"idfa\": \"AAA\"}".utf8)
+        let queued = StoredRequest(url: "https://api.qonversion.io/v3/devices", method: "POST", body: body, dedupKey: "createDevice-u", attempt: 4)
+        storage.append(queued)
+
+        storage.append(StoredRequest(url: "https://api.qonversion.io/v3/devices", method: "POST", body: body, dedupKey: "createDevice-u", attempt: 1))
+
+        XCTAssertEqual(storage.fetchRequests().count, 1)
+        XCTAssertEqual(storage.fetchRequests().first?.attempt, 4)
+    }
+
+    func testAFresherPayloadKeepsItsPlaceInTheQueue() {
+        let storage = makeStorage(TestDefaults.makeIsolated())
+        storage.append(makeRequest(dedupKey: "createDevice-u"))
+        storage.append(makeRequest(dedupKey: "createPurchase-u-t1"))
+
+        storage.append(makeRequest(body: Data("{\"fresh\": true}".utf8), dedupKey: "createDevice-u"))
+
+        XCTAssertEqual(storage.fetchRequests().compactMap(\.dedupKey), ["createDevice-u", "createPurchase-u-t1"])
+    }
+
     func testAppendWithoutDedupKeyIsNeverDeduplicated() {
         let storage = makeStorage(TestDefaults.makeIsolated())
 


### PR DESCRIPTION
Seven audited defects in the network layer and the offline queue.

Replay and the reports gate (designed as one contract):
- a 401/402/403 removed its entry from the queue BEFORE the critical-error latch was checked, contradicting the method's own doc: the report of a purchase the store already charged for was lost on a key rotation. The latch is now checked first and stops the replay with the queue intact.
- a delivered replay held the transaction id forever, so the launch sweep skipped the transaction entirely: it was never finished in subscription management mode and never surfaced as a deferred purchase. The gate now distinguishes "taken" from "reported": the replay hands the id back marked as reported, and the purchases funnel completes the outcome (finish plus one deferred purchase) without posting the purchase a second time.

Error classification and transport:
- wrapping a backend error in a service destroyed its classification — apiCode and apiType were dropped, so a host could not tell a fraud rejection from any other reporting failure. The initializer now carries them through from the underlying error unless given explicitly.
- the offline queue deduplicated by resource kind, so a fresher device or attribution payload was dropped and the stale one replayed. The newest payload now supersedes the queued one in place; an identical payload is still a duplicate and keeps the queued attempt count.
- any send failure, cancellation included, queued a retriable request for replay, risking a duplicate purchase report. Only a transport failure does now, matching the ObjC client.
- a cancellation during the retry backoff shadowed the original transport error, so the host got a CancellationError instead of the URLError and lost its offline entitlements fallback.
- isTransportFailure missed cannotFindHost (-1003) and secureConnectionFailed, so an offline DNS failure was classified as invalidResponse and never retried.