### PR TITLE
fix: guard remote-config loads against user change and harden RC deco…

### DIFF
--- a/Sources/Entities/Experiment.swift
+++ b/Sources/Entities/Experiment.swift
@@ -43,12 +43,28 @@ extension Qonversion {
                 self.type = type
             }
 
+            init() {
+                self.name = ""
+                self.identifier = ""
+                self.type = .unknown
+            }
+
             public init(from decoder: Decoder) throws {
                 let container = try decoder.container(keyedBy: CodingKeys.self)
-                name = try container.decode(String.self, forKey: .name)
-                identifier = try container.decode(String.self, forKey: .identifier)
+                // None of the known keys means a schema break, not an
+                // incomplete group.
+                guard !container.allKeys.isEmpty else {
+                    let context = DecodingError.Context(codingPath: container.codingPath, debugDescription: "Experiment group carries none of the expected keys")
+                    throw DecodingError.dataCorrupted(context)
+                }
+
+                // A missing key used to fail the group, and a failed group took
+                // the whole remote config — payload included — with it.
+                name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
+                identifier = try container.decodeIfPresent(String.self, forKey: .identifier) ?? ""
                 // Unknown backend values must not fail the whole config decode.
-                type = GroupType(rawValue: try container.decode(String.self, forKey: .type)) ?? .unknown
+                let typeStr: String? = try container.decodeIfPresent(String.self, forKey: .type)
+                type = typeStr.flatMap { GroupType(rawValue: $0) } ?? .unknown
             }
 
             private enum CodingKeys: String, CodingKey {
@@ -72,6 +88,23 @@ extension Qonversion {
             self.identifier = identifier
             self.name = name
             self.group = group
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            // None of the known keys means a schema break, not an incomplete
+            // experiment.
+            guard !container.allKeys.isEmpty else {
+                let context = DecodingError.Context(codingPath: container.codingPath, debugDescription: "Experiment carries none of the expected keys")
+                throw DecodingError.dataCorrupted(context)
+            }
+
+            // Same tolerance as Group: incomplete experiment metadata must not
+            // cost the host the remote config that carries it.
+            identifier = try container.decodeIfPresent(String.self, forKey: .identifier) ?? ""
+            name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
+            let decodedGroup: Group? = try? container.decodeIfPresent(Group.self, forKey: .group)
+            group = decodedGroup ?? Group()
         }
 
         private enum CodingKeys: String, CodingKey {

--- a/Sources/Entities/RemoteConfig.swift
+++ b/Sources/Entities/RemoteConfig.swift
@@ -57,7 +57,11 @@ extension Qonversion {
             /// Remote config assignment type that indicates how the current payload was assigned to the user.
             public let assignmentType: AssignmentType
 
-            /// Remote configuration context key. Empty string if not specified.
+            /// Remote configuration context key, or `nil` when the
+            /// configuration is not bound to one. A context key the backend
+            /// sends as an empty string means the same thing and is normalized
+            /// to `nil`, so a check for `""` never matches — compare against
+            /// `nil`, or use ``Qonversion/RemoteConfigList/remoteConfigForEmptyContextKey()``.
             public let contextKey: String?
 
             init(identifier: String, name: String, type: SourceType, assignmentType: AssignmentType, contextKey: String?) {
@@ -70,11 +74,25 @@ extension Qonversion {
 
             public init(from decoder: Decoder) throws {
                 let container: KeyedDecodingContainer = try decoder.container(keyedBy: CodingKeys.self)
-                identifier = try container.decode(String.self, forKey: .identifier)
-                name = try container.decode(String.self, forKey: .name)
+                // An object carrying none of the known keys is a schema break,
+                // not an incomplete source. Failing here is what still lets the
+                // lossy list drop the row instead of surfacing an empty source.
+                guard !container.allKeys.isEmpty else {
+                    let context = DecodingError.Context(codingPath: container.codingPath, debugDescription: "Remote config source carries none of the expected keys")
+                    throw DecodingError.dataCorrupted(context)
+                }
+
+                // Metadata keys decode leniently: a source missing one of them
+                // used to fail, and a failed source took the whole config —
+                // payload included — with it. The context key still decides
+                // where the config is served from, so the config stays usable.
+                identifier = try container.decodeIfPresent(String.self, forKey: .identifier) ?? ""
+                name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
                 // Unknown backend values must not fail the whole config decode.
-                type = SourceType(rawValue: try container.decode(String.self, forKey: .type)) ?? .unknown
-                assignmentType = AssignmentType(rawValue: try container.decode(String.self, forKey: .assignmentType)) ?? .unknown
+                let typeStr: String? = try container.decodeIfPresent(String.self, forKey: .type)
+                type = typeStr.flatMap { SourceType(rawValue: $0) } ?? .unknown
+                let assignmentTypeStr: String? = try container.decodeIfPresent(String.self, forKey: .assignmentType)
+                assignmentType = assignmentTypeStr.flatMap { AssignmentType(rawValue: $0) } ?? .unknown
                 let contextKeyStr: String? = try container.decodeIfPresent(String.self, forKey: .contextKey)
                 contextKey = contextKeyStr?.isEmpty == false ? contextKeyStr : nil
             }

--- a/Sources/Entities/RemoteConfigList.swift
+++ b/Sources/Entities/RemoteConfigList.swift
@@ -39,16 +39,22 @@ extension Qonversion {
             case remoteConfigs
         }
 
-        /// Searches for remote configuration with the specific context key.
+        /// Searches for the remote configuration with a specific context key.
         /// - Parameters:
-        ///   - contextKey: context key to search remote configuration for.
-        /// - Returns: remote configuration with the specified context key or nil if no matching configuration found.
+        ///   - contextKey: context key to search the remote configuration for.
+        ///   An empty string is treated as "no context key" and is equivalent
+        ///   to calling ``remoteConfigForEmptyContextKey()``.
+        /// - Returns: the remote configuration with the specified context key,
+        /// or nil if no matching configuration was found.
         public func remoteConfig(for contextKey: String) -> RemoteConfig? {
             return findRemoteConfig(for: contextKey)
         }
 
-        /// Searches for remote configuration with empty context key.
-        /// - Returns: remote configuration with empty context key or nil if no matching configuration found.
+        /// Searches for the remote configuration that is not bound to any
+        /// context key. A configuration the backend reports no source for is
+        /// not a match: it is assigned to nothing at all.
+        /// - Returns: the remote configuration without a context key, or nil if
+        /// no matching configuration was found.
         public func remoteConfigForEmptyContextKey() -> RemoteConfig? {
             return findRemoteConfig(for: nil)
         }
@@ -60,8 +66,17 @@ extension Qonversion {
 extension Qonversion.RemoteConfigList {
     
     private func findRemoteConfig(for contextKey: String?) -> Qonversion.RemoteConfig? {
+        // The decoder normalizes an empty context key to nil, so the lookup key
+        // is normalized the same way — otherwise remoteConfig(for: "") could
+        // never match anything.
+        let normalizedKey: String? = contextKey?.isEmpty == false ? contextKey : nil
+
         return remoteConfigs.first { config in
-            return (contextKey == nil && config.source?.contextKey == nil) || config.source?.contextKey == contextKey
+            // A config the backend reports no source for is assigned to no
+            // context key, not to the empty one.
+            guard let source: Qonversion.RemoteConfig.Source = config.source else { return false }
+
+            return source.contextKey == normalizedKey
         }
     }
 }

--- a/Sources/Managers/RemoteConfig/RemoteConfigManager.swift
+++ b/Sources/Managers/RemoteConfig/RemoteConfigManager.swift
@@ -151,6 +151,7 @@ final class RemoteConfigManager: RemoteConfigManagerInterface, @unchecked Sendab
 
             let generation: Int = currentGeneration()
             let remoteConfigList: Qonversion.RemoteConfigList = try await remoteConfigService.loadRemoteConfigList()
+            try checkGenerationUnchanged(generation)
             handleLoadedRemoteConfigList(remoteConfigList, generation: generation)
             return remoteConfigList
         } catch {
@@ -185,6 +186,7 @@ final class RemoteConfigManager: RemoteConfigManagerInterface, @unchecked Sendab
 
             let generation: Int = currentGeneration()
             let remoteConfigList: Qonversion.RemoteConfigList = try await remoteConfigService.loadRemoteConfigList(contextKeys: contextKeys, includeEmptyContextKey: includeEmptyContextKey)
+            try checkGenerationUnchanged(generation)
             handleLoadedRemoteConfigList(remoteConfigList, generation: generation)
             return remoteConfigList
         } catch {
@@ -202,25 +204,32 @@ final class RemoteConfigManager: RemoteConfigManagerInterface, @unchecked Sendab
         }
     }
 
+    /// The stability gate matters as much here as on the loading paths: an
+    /// attach issued while an identify is switching the uid would bind the
+    /// pre-identify user.
     func attachUserToRemoteConfig(id: String) async throws {
+        try await awaitUserStability()
         _ = try await userManager.obtainUser()
         try await remoteConfigService.attachUserToRemoteConfig(id: id)
         invalidateCache()
     }
 
     func detachUserFromRemoteConfig(id: String) async throws {
+        try await awaitUserStability()
         _ = try await userManager.obtainUser()
         try await remoteConfigService.detachUserFromRemoteConfig(id: id)
         invalidateCache()
     }
 
     func attachUserToExperiment(id: String, groupId: String) async throws {
+        try await awaitUserStability()
         _ = try await userManager.obtainUser()
         try await remoteConfigService.attachUserToExperiment(id: id, groupId: groupId)
         invalidateCache()
     }
 
     func detachUserFromExperiment(id: String) async throws {
+        try await awaitUserStability()
         _ = try await userManager.obtainUser()
         try await remoteConfigService.detachUserFromExperiment(id: id)
         invalidateCache()
@@ -230,11 +239,16 @@ final class RemoteConfigManager: RemoteConfigManagerInterface, @unchecked Sendab
     /// ones afterwards would defeat the call.
     private func invalidateCache() {
         lock.lock()
-        defer { lock.unlock() }
         // The generation bump keeps an in-flight pre-attach response from
         // repopulating the cache it just cleared.
         cacheGeneration += 1
         loadedConfigs = [:]
+        // Deregistering the in-flight loads stops a post-attach caller from
+        // joining a request that was computed before the attach. Unlike
+        // userDidChange they are not cancelled: the response still belongs to
+        // the SAME user, so the caller that started it keeps its answer.
+        loadTasks = [:]
+        lock.unlock()
     }
     
     // MARK: - Private
@@ -252,6 +266,16 @@ final class RemoteConfigManager: RemoteConfigManagerInterface, @unchecked Sendab
         return cacheGeneration
     }
 
+    /// A list that came back after a user switch was computed for the previous
+    /// user: it is neither cached nor returned. Throwing cancellation puts it
+    /// on the same path as an abandoned single-config load — the caller gets a
+    /// classified QonversionError and never the bundled fallback.
+    private func checkGenerationUnchanged(_ generation: Int) throws {
+        lock.lock()
+        defer { lock.unlock() }
+        guard generation == cacheGeneration else { throw CancellationError() }
+    }
+
     private func cachedConfigs(for contextKeys: [String]) -> [Qonversion.RemoteConfig] {
         lock.lock()
         defer { lock.unlock() }
@@ -265,7 +289,12 @@ final class RemoteConfigManager: RemoteConfigManagerInterface, @unchecked Sendab
         guard generation == cacheGeneration else { return }
 
         remoteConfigList.remoteConfigs.forEach { remoteConfig in
-            let contextKey: String = remoteConfig.source?.contextKey ?? Constants.emptyContextKey.rawValue
+            // A config the backend reports no source for is assigned to no
+            // context key at all: caching it under "" would let it shadow the
+            // empty-context-key config that loadRemoteConfig(nil) asks for.
+            guard let source: Qonversion.RemoteConfig.Source = remoteConfig.source else { return }
+
+            let contextKey: String = source.contextKey ?? Constants.emptyContextKey.rawValue
             loadedConfigs[contextKey] = remoteConfig
         }
     }

--- a/Sources/Services/RemoteConfigService/RemoteConfigService.swift
+++ b/Sources/Services/RemoteConfigService/RemoteConfigService.swift
@@ -112,6 +112,27 @@ final class RemoteConfigService: RemoteConfigServiceInterface {
     /// the integrator must be able to tell apart.
     private static var notAvailableApiCodes: Set<String> { ["not_found", "relation_not_found"] }
 
+    /// 404 is not in the SDK's `ResponseCode` list, so the network layer types
+    /// it `.unknown` and only the body slug can refine it. A 404 whose body
+    /// carries no slug — an empty body, a proxy page, a partial error envelope
+    /// — therefore reached the host as a generic loading failure. On the
+    /// loading endpoints it means the same thing the slugged 404 does.
+    private static var notFoundStatusCode: Int { 404 }
+
+    private static func isConfigurationMissing(_ apiError: QonversionError) -> Bool {
+        if apiError.type == .resourceNotFound, let apiCode: String = apiError.apiCode {
+            return notAvailableApiCodes.contains(apiCode)
+        }
+
+        // Only when the body named no code at all: a 404 that DID name one the
+        // SDK understands (e.g. `user_not_found`) keeps its own meaning.
+        guard apiError.apiCode == nil else { return false }
+
+        let statusCode: Int? = apiError.additionalInfo?[ErrorConstants.statusCodeKey.rawValue] as? Int
+
+        return statusCode == notFoundStatusCode
+    }
+
     private func remoteConfigError(from error: Error, unclassifiedType: QonversionErrorType, asWarning: Bool = false, remapsNotFound: Bool = true) -> QonversionError {
         let result: QonversionError = classify(error, unclassifiedType: unclassifiedType, remapsNotFound: remapsNotFound)
         if asWarning {
@@ -128,16 +149,13 @@ final class RemoteConfigService: RemoteConfigServiceInterface {
             return QonversionError(type: unclassifiedType, message: nil, error: error)
         }
 
-        if remapsNotFound,
-           apiError.type == .resourceNotFound,
-           let apiCode: String = apiError.apiCode,
-           Self.notAvailableApiCodes.contains(apiCode) {
+        if remapsNotFound, Self.isConfigurationMissing(apiError) {
             return QonversionError(
                 type: .remoteConfigurationNotAvailable,
                 message: nil,
                 error: apiError.error,
                 additionalInfo: apiError.additionalInfo,
-                apiCode: apiCode,
+                apiCode: apiError.apiCode,
                 apiType: apiError.apiType
             )
         }

--- a/Sources/Utils/Utils.swift
+++ b/Sources/Utils/Utils.swift
@@ -42,14 +42,34 @@ private final class CurrencySymbolCache: @unchecked Sendable {
             return cached
         }
 
-        let locale: Locale? = sortedLocaleIdentifiers.lazy.map { Locale(identifier: $0) }.first { $0.currencyCode == currencyCode }
-        let symbol: String? = locale?.currencySymbol
+        let symbol: String? = Self.resolveSymbol(for: currencyCode)
 
         lock.lock()
         symbols[currencyCode] = symbol
         lock.unlock()
 
         return symbol
+    }
+
+    /// Many locales share a currency, and most of them render it with a
+    /// disambiguating prefix — ba_RU gives "RUB", ain_JP "JP¥", csw_CA "CA$".
+    /// The currency's own locale is the one that needs no prefix, so the
+    /// shortest symbol wins; ties keep the sorted-identifier order, which
+    /// makes the answer stable across calls and launches.
+    private static func resolveSymbol(for currencyCode: String) -> String? {
+        var bestSymbol: String? = nil
+
+        for identifier in sortedLocaleIdentifiers {
+            let locale = Locale(identifier: identifier)
+            guard locale.currencyCode == currencyCode else { continue }
+            guard let symbol: String = locale.currencySymbol, !symbol.isEmpty else { continue }
+
+            if bestSymbol == nil || symbol.count < bestSymbol!.count {
+                bestSymbol = symbol
+            }
+        }
+
+        return bestSymbol
     }
 }
 
@@ -108,6 +128,13 @@ func decode(fromObject container: KeyedDecodingContainer<JSONCodingKeys>) -> [St
   return result
 }
 
+/// Decodes any JSON value, carrying nothing over. Decoding it succeeds for
+/// every element, which is what advances an unkeyed container past a value
+/// none of the typed branches can represent.
+private struct SkippedJSONValue: Decodable {
+  init(from decoder: Decoder) throws {}
+}
+
 func decode(fromArray container: inout UnkeyedDecodingContainer) -> [Any] {
   var result: [Any] = []
 
@@ -126,6 +153,15 @@ func decode(fromArray container: inout UnkeyedDecodingContainer) -> [Any] {
       result.append(decode(fromArray: &nestedArray))
     } else if (try? container.decodeNil()) == true {
       result.append(Any?(nil) as Any)
+    } else if (try? container.decode(SkippedJSONValue.self)) != nil {
+      // Representable in no branch above — e.g. a number larger than Double,
+      // which decodeNil() also declines without moving the cursor. Skipping
+      // the element is what keeps the loop advancing.
+      continue
+    } else {
+      // The container refused to advance at all: stop with what was decoded
+      // rather than spin forever.
+      break
     }
   }
 

--- a/Tests/QonversionUnitTests/EntitiesDecodingTests.swift
+++ b/Tests/QonversionUnitTests/EntitiesDecodingTests.swift
@@ -239,13 +239,19 @@ final class EntitiesDecodingTests: XCTestCase {
         XCTAssertEqual(experiment.group.type, .treatment)
     }
 
-    func testExperimentDecodingRejectsTheSwiftPropertyNameAsKey() {
+    func testExperimentDecodingRejectsTheSwiftPropertyNameAsKey() throws {
         // Regression: "identifier" is a Swift property name, never a wire key —
-        // decoding it would mean the SDK is reading a payload the backend
-        // does not send.
+        // reading it would mean the SDK is decoding a payload the backend does
+        // not send. Missing metadata no longer throws (an incomplete experiment
+        // must not cost the host the config that carries it), so the guard is
+        // that the value is not picked up rather than that the decode fails.
         let json = #"{"identifier": "exp_4", "name": "Exp", "group": {"name": "G", "identifier": "g", "type": "control"}}"#
 
-        XCTAssertThrowsError(try decode(Qonversion.Experiment.self, json))
+        let experiment = try decode(Qonversion.Experiment.self, json)
+
+        XCTAssertEqual(experiment.identifier, "", "only \"uid\" carries the experiment identifier")
+        XCTAssertEqual(experiment.group.identifier, "", "only \"uid\" carries the group identifier")
+        XCTAssertEqual(experiment.name, "Exp")
     }
 
     // MARK: - RemoteConfigList

--- a/Tests/QonversionUnitTests/Mocks.swift
+++ b/Tests/QonversionUnitTests/Mocks.swift
@@ -602,6 +602,7 @@ final class MockRemoteConfigService: RemoteConfigServiceInterface {
     private(set) var detachedExperimentIds: [String] = []
 
     var onLoadRemoteConfig: (() async -> Void)?
+    var onLoadRemoteConfigList: (() async -> Void)?
 
     func loadRemoteConfig(contextKey: String?) async throws -> Qonversion.RemoteConfig {
         serviceStateLock.lock()
@@ -615,6 +616,7 @@ final class MockRemoteConfigService: RemoteConfigServiceInterface {
 
     func loadRemoteConfigList() async throws -> Qonversion.RemoteConfigList {
         loadListCallsCount += 1
+        await onLoadRemoteConfigList?()
         if let error { throw error }
         guard let remoteConfigListResult else { throw MockError.noStub }
         return remoteConfigListResult
@@ -622,6 +624,7 @@ final class MockRemoteConfigService: RemoteConfigServiceInterface {
 
     func loadRemoteConfigList(contextKeys: [String], includeEmptyContextKey: Bool) async throws -> Qonversion.RemoteConfigList {
         loadListContextKeysArgs.append((contextKeys, includeEmptyContextKey))
+        await onLoadRemoteConfigList?()
         if let error { throw error }
         guard let remoteConfigListResult else { throw MockError.noStub }
         return remoteConfigListResult

--- a/Tests/QonversionUnitTests/RemoteConfigDecodingTests.swift
+++ b/Tests/QonversionUnitTests/RemoteConfigDecodingTests.swift
@@ -1,0 +1,168 @@
+//
+//  RemoteConfigDecodingTests.swift
+//  QonversionUnitTests
+//
+//  Decoding contract for Qonversion.RemoteConfig, its Source, the Experiment
+//  it carries, and the context-key lookups on Qonversion.RemoteConfigList.
+//
+
+import XCTest
+@testable import Qonversion
+
+final class RemoteConfigDecodingTests: XCTestCase {
+
+    private func decodeConfig(_ json: String) throws -> Qonversion.RemoteConfig {
+        let decoder = JSONDecoder()
+        return try decoder.decode(Qonversion.RemoteConfig.self, from: Data(json.utf8))
+    }
+
+    private func decodeList(_ json: String) throws -> Qonversion.RemoteConfigList {
+        let decoder = JSONDecoder()
+        return try decoder.decode(Qonversion.RemoteConfigList.self, from: Data(json.utf8))
+    }
+
+    // MARK: - context key normalization
+
+    func testAnEmptyContextKeyDecodesToNil() throws {
+        let json = #"{"payload": {"k": "v"}, "source": {"uid": "u1", "name": "n", "type": "remote_configuration", "assignment_type": "auto", "context_key": ""}}"#
+
+        let config: Qonversion.RemoteConfig = try decodeConfig(json)
+
+        XCTAssertNil(config.source?.contextKey, "an empty context key means the config is bound to none")
+    }
+
+    func testAnAbsentContextKeyDecodesToNil() throws {
+        let json = #"{"payload": {"k": "v"}, "source": {"uid": "u1", "name": "n", "type": "remote_configuration", "assignment_type": "auto"}}"#
+
+        let config: Qonversion.RemoteConfig = try decodeConfig(json)
+
+        XCTAssertNil(config.source?.contextKey)
+    }
+
+    func testLookupByAnEmptyStringFindsTheEmptyContextKeyConfig() throws {
+        // The documented shape used to be an empty string, so hosts written
+        // against it — and hosts migrating from the ObjC SDK — pass "".
+        let json = """
+        [
+          {"payload": {"k": "empty"}, "source": {"uid": "u1", "name": "n", "type": "remote_configuration", "assignment_type": "auto", "context_key": ""}},
+          {"payload": {"k": "main"}, "source": {"uid": "u2", "name": "n", "type": "remote_configuration", "assignment_type": "auto", "context_key": "main"}}
+        ]
+        """
+
+        let list: Qonversion.RemoteConfigList = try decodeList(json)
+
+        XCTAssertEqual(list.remoteConfig(for: "")?.source?.identifier, "u1")
+        XCTAssertEqual(list.remoteConfigForEmptyContextKey()?.source?.identifier, "u1")
+        XCTAssertEqual(list.remoteConfig(for: "main")?.source?.identifier, "u2")
+    }
+
+    func testAConfigWithoutASourceIsNotTheEmptyContextKeyConfig() throws {
+        let json = """
+        [
+          {"payload": {"k": "unassigned"}, "source": null},
+          {"payload": {"k": "empty"}, "source": {"uid": "u1", "name": "n", "type": "remote_configuration", "assignment_type": "auto", "context_key": ""}}
+        ]
+        """
+
+        let list: Qonversion.RemoteConfigList = try decodeList(json)
+
+        XCTAssertEqual(list.remoteConfigForEmptyContextKey()?.source?.identifier, "u1",
+                       "an unassigned config must not answer the empty-context-key lookup")
+        XCTAssertEqual(list.remoteConfig(for: "")?.source?.identifier, "u1")
+    }
+
+    func testAListOfOnlyUnassignedConfigsHasNoEmptyContextKeyConfig() throws {
+        let json = #"[{"payload": {"k": "unassigned"}, "source": null}]"#
+
+        let list: Qonversion.RemoteConfigList = try decodeList(json)
+
+        XCTAssertEqual(list.remoteConfigs.count, 1)
+        XCTAssertNil(list.remoteConfigForEmptyContextKey())
+    }
+
+    // MARK: - tolerant Source decoding
+
+    func testASourceWithoutAnAssignmentTypeKeepsTheConfig() throws {
+        let json = #"{"payload": {"k": "v"}, "source": {"uid": "u1", "name": "n", "type": "remote_configuration", "context_key": "main"}}"#
+
+        let config: Qonversion.RemoteConfig = try decodeConfig(json)
+
+        XCTAssertEqual(config.payload?["k"] as? String, "v", "one missing metadata key must not cost the payload")
+        XCTAssertEqual(config.source?.contextKey, "main", "the context key must survive so the config still routes")
+        XCTAssertEqual(config.source?.assignmentType, .unknown)
+    }
+
+    func testASourceWithoutATypeKeepsTheConfig() throws {
+        let json = #"{"payload": {"k": "v"}, "source": {"uid": "u1", "name": "n", "assignment_type": "auto", "context_key": "main"}}"#
+
+        let config: Qonversion.RemoteConfig = try decodeConfig(json)
+
+        XCTAssertEqual(config.source?.type, .unknown)
+        XCTAssertEqual(config.source?.contextKey, "main")
+    }
+
+    func testASourceWithoutAUidOrNameKeepsTheConfig() throws {
+        let json = #"{"payload": {"k": "v"}, "source": {"type": "remote_configuration", "assignment_type": "auto", "context_key": "main"}}"#
+
+        let config: Qonversion.RemoteConfig = try decodeConfig(json)
+
+        XCTAssertEqual(config.source?.identifier, "")
+        XCTAssertEqual(config.source?.name, "")
+        XCTAssertEqual(config.source?.contextKey, "main")
+    }
+
+    func testAFullSourceStillDecodesEveryField() throws {
+        let json = #"{"payload": {"k": "v"}, "source": {"uid": "u1", "name": "Main config", "type": "experiment_control_group", "assignment_type": "manual", "context_key": "main"}}"#
+
+        let config: Qonversion.RemoteConfig = try decodeConfig(json)
+
+        XCTAssertEqual(config.source?.identifier, "u1")
+        XCTAssertEqual(config.source?.name, "Main config")
+        XCTAssertEqual(config.source?.type, .experimentControlGroup)
+        XCTAssertEqual(config.source?.assignmentType, .manual)
+        XCTAssertEqual(config.source?.contextKey, "main")
+    }
+
+    // MARK: - tolerant Experiment decoding
+
+    func testAnExperimentWithoutAGroupTypeKeepsTheConfig() throws {
+        let json = #"{"payload": {"k": "v"}, "experiment": {"uid": "e1", "name": "Exp", "group": {"uid": "g1", "name": "Group"}}, "source": null}"#
+
+        let config: Qonversion.RemoteConfig = try decodeConfig(json)
+
+        XCTAssertEqual(config.experiment?.identifier, "e1")
+        XCTAssertEqual(config.experiment?.group.identifier, "g1")
+        XCTAssertEqual(config.experiment?.group.type, .unknown)
+    }
+
+    func testAnExperimentWithoutAGroupKeepsTheConfig() throws {
+        let json = #"{"payload": {"k": "v"}, "experiment": {"uid": "e1", "name": "Exp"}, "source": null}"#
+
+        let config: Qonversion.RemoteConfig = try decodeConfig(json)
+
+        XCTAssertEqual(config.payload?["k"] as? String, "v")
+        XCTAssertEqual(config.experiment?.identifier, "e1")
+        XCTAssertEqual(config.experiment?.group.type, .unknown)
+    }
+
+    func testAnExperimentWithoutAUidKeepsTheConfig() throws {
+        let json = #"{"payload": {"k": "v"}, "experiment": {"name": "Exp", "group": {"uid": "g1", "name": "Group", "type": "treatment"}}, "source": null}"#
+
+        let config: Qonversion.RemoteConfig = try decodeConfig(json)
+
+        XCTAssertEqual(config.experiment?.identifier, "")
+        XCTAssertEqual(config.experiment?.group.type, .treatment)
+    }
+
+    func testAFullExperimentStillDecodesEveryField() throws {
+        let json = #"{"payload": {"k": "v"}, "experiment": {"uid": "e1", "name": "Exp", "group": {"uid": "g1", "name": "Group", "type": "control"}}, "source": null}"#
+
+        let config: Qonversion.RemoteConfig = try decodeConfig(json)
+
+        XCTAssertEqual(config.experiment?.identifier, "e1")
+        XCTAssertEqual(config.experiment?.name, "Exp")
+        XCTAssertEqual(config.experiment?.group.identifier, "g1")
+        XCTAssertEqual(config.experiment?.group.name, "Group")
+        XCTAssertEqual(config.experiment?.group.type, .control)
+    }
+}

--- a/Tests/QonversionUnitTests/RemoteConfigManagerTests.swift
+++ b/Tests/QonversionUnitTests/RemoteConfigManagerTests.swift
@@ -620,6 +620,130 @@ final class RemoteConfigManagerTests: XCTestCase {
         }
     }
 
+    // MARK: - list loads abandoned by a user switch
+
+    func testAListLoadedForThePreviousUserIsNotServed() async throws {
+        // The single-config loader is guarded; the list loader used to hand the
+        // previous user's configs straight to the host.
+        remoteConfigService.remoteConfigListResult = Qonversion.RemoteConfigList(remoteConfigs: [
+            makeRemoteConfig(contextKey: "main", identifier: "previous-user-config"),
+        ])
+        let gate = ManagerAsyncGate()
+        remoteConfigService.onLoadRemoteConfigList = { await gate.wait() }
+
+        async let staleLoad: Qonversion.RemoteConfigList = manager.loadRemoteConfigList()
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        manager.userDidChange()
+        await gate.open()
+
+        do {
+            _ = try await staleLoad
+            XCTFail("Expected the abandoned list load to fail")
+        } catch let error as QonversionError {
+            XCTAssertEqual(error.type, .cancelled, "the previous user's configs must never reach the host")
+        } catch {
+            XCTFail("A raw \(type(of: error)) must never reach the host")
+        }
+    }
+
+    func testAContextKeyedListLoadedForThePreviousUserIsNotServed() async throws {
+        remoteConfigService.remoteConfigListResult = Qonversion.RemoteConfigList(remoteConfigs: [
+            makeRemoteConfig(contextKey: "main", identifier: "previous-user-config"),
+        ])
+        let gate = ManagerAsyncGate()
+        remoteConfigService.onLoadRemoteConfigList = { await gate.wait() }
+
+        async let staleLoad: Qonversion.RemoteConfigList = manager.loadRemoteConfigList(contextKeys: ["main"], includeEmptyContextKey: false)
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        manager.userDidChange()
+        await gate.open()
+
+        do {
+            _ = try await staleLoad
+            XCTFail("Expected the abandoned list load to fail")
+        } catch let error as QonversionError {
+            XCTAssertEqual(error.type, .cancelled, "the previous user's configs must never reach the host")
+        } catch {
+            XCTFail("A raw \(type(of: error)) must never reach the host")
+        }
+    }
+
+    func testAListLoadedWithoutAUserSwitchIsStillServed() async throws {
+        remoteConfigService.remoteConfigListResult = Qonversion.RemoteConfigList(remoteConfigs: [
+            makeRemoteConfig(contextKey: "main", identifier: "current-user-config"),
+        ])
+
+        let list: Qonversion.RemoteConfigList = try await manager.loadRemoteConfigList()
+
+        XCTAssertEqual(list.remoteConfigs.map { $0.source?.identifier }, ["current-user-config"])
+    }
+
+    // MARK: - attach / detach and the user-stability gate
+
+    func testAttachAndDetachWaitForUserStability() async throws {
+        try await manager.attachUserToRemoteConfig(id: "rc-1")
+        try await manager.detachUserFromRemoteConfig(id: "rc-1")
+        try await manager.attachUserToExperiment(id: "exp-1", groupId: "group-1")
+        try await manager.detachUserFromExperiment(id: "exp-1")
+
+        XCTAssertEqual(userManager.awaitUserStabilityCallsCount, 4,
+                       "an attach landing mid-identify would bind the pre-identify user")
+    }
+
+    func testACallerArrivingAfterAttachDoesNotJoinThePreAttachRequest() async throws {
+        remoteConfigService.remoteConfigResult = makeRemoteConfig(contextKey: "main", identifier: "pre-attach")
+        let gate = ManagerAsyncGate()
+        remoteConfigService.onLoadRemoteConfig = { await gate.wait() }
+
+        async let staleLoad: Qonversion.RemoteConfig = manager.loadRemoteConfig(contextKey: "main")
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        try await manager.attachUserToRemoteConfig(id: "rc-1")
+
+        // The host redraws right after the successful attach, while the
+        // pre-attach request is still in flight — the only moment it can be
+        // joined.
+        remoteConfigService.onLoadRemoteConfig = nil
+        remoteConfigService.remoteConfigResult = makeRemoteConfig(contextKey: "main", identifier: "post-attach")
+        async let freshLoad: Qonversion.RemoteConfig = manager.loadRemoteConfig(contextKey: "main")
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        await gate.open()
+
+        let fresh: Qonversion.RemoteConfig = try await freshLoad
+        _ = try? await staleLoad
+
+        XCTAssertEqual(fresh.source?.identifier, "post-attach",
+                       "the post-attach caller must not be answered by the pre-attach request")
+        XCTAssertEqual(remoteConfigService.loadRemoteConfigContextKeys.count, 2)
+    }
+
+    // MARK: - list cache keying
+
+    func testAConfigWithoutASourceDoesNotOccupyTheEmptyContextKeySlot() async throws {
+        let unassigned = Qonversion.RemoteConfig(payload: ["flag": "unassigned"], experiment: nil, source: nil)
+        remoteConfigService.remoteConfigListResult = Qonversion.RemoteConfigList(remoteConfigs: [unassigned])
+
+        _ = try await manager.loadRemoteConfigList(contextKeys: ["paywall"], includeEmptyContextKey: false)
+
+        remoteConfigService.remoteConfigResult = makeRemoteConfig(contextKey: nil, identifier: "empty-key-config")
+        let config: Qonversion.RemoteConfig = try await manager.loadRemoteConfig(contextKey: nil)
+
+        XCTAssertEqual(config.source?.identifier, "empty-key-config",
+                       "an unassigned config must not shadow the empty context key")
+        XCTAssertEqual(remoteConfigService.loadRemoteConfigContextKeys.count, 1)
+    }
+
+    func testAConfigWithAnEmptyContextKeyStillFillsTheEmptyContextKeySlot() async throws {
+        remoteConfigService.remoteConfigListResult = Qonversion.RemoteConfigList(remoteConfigs: [
+            makeRemoteConfig(contextKey: nil, identifier: "empty-key-config"),
+        ])
+
+        _ = try await manager.loadRemoteConfigList(contextKeys: [], includeEmptyContextKey: true)
+        let config: Qonversion.RemoteConfig = try await manager.loadRemoteConfig(contextKey: nil)
+
+        XCTAssertEqual(config.source?.identifier, "empty-key-config")
+        XCTAssertTrue(remoteConfigService.loadRemoteConfigContextKeys.isEmpty, "the list response must have filled the cache")
+    }
+
     func testUserDidChangeClearsCachedConfigs() async throws {
         remoteConfigService.remoteConfigResult = makeRemoteConfig(contextKey: "main")
         _ = try await manager.loadRemoteConfig(contextKey: "main")

--- a/Tests/QonversionUnitTests/RemoteConfigServiceTests.swift
+++ b/Tests/QonversionUnitTests/RemoteConfigServiceTests.swift
@@ -166,6 +166,61 @@ final class RemoteConfigServiceTests: XCTestCase {
         }
     }
 
+    func testANotFoundWithoutASlugStillBecomesRemoteConfigurationNotAvailable() async {
+        // 404 is not in the SDK's ResponseCode list, so the type is derived
+        // from the body slug alone. A 404 body without one used to degrade to
+        // the generic loading failure instead of "this user has no config".
+        let service = makeLiveService(json: #"{"error": {"message": "not found"}}"#, status: 404)
+
+        do {
+            _ = try await service.loadRemoteConfig(contextKey: "main")
+            XCTFail("Expected an error")
+        } catch let error as QonversionError {
+            XCTAssertEqual(error.type, .remoteConfigurationNotAvailable)
+        } catch {
+            XCTFail("Expected QonversionError, got \(error)")
+        }
+    }
+
+    func testANotFoundWithAnEmptyBodyStillBecomesRemoteConfigurationNotAvailable() async {
+        let service = makeLiveService(json: "", status: 404)
+
+        do {
+            _ = try await service.loadRemoteConfigList()
+            XCTFail("Expected an error")
+        } catch let error as QonversionError {
+            XCTAssertEqual(error.type, .remoteConfigurationNotAvailable)
+        } catch {
+            XCTFail("Expected QonversionError, got \(error)")
+        }
+    }
+
+    func testASlugLessNotFoundOnAttachIsStillNotAMissingConfiguration() async {
+        let service = makeLiveService(json: #"{"error": {"message": "not found"}}"#, status: 404)
+
+        do {
+            try await service.attachUserToRemoteConfig(id: "rc_missing")
+            XCTFail("Expected an error")
+        } catch let error as QonversionError {
+            XCTAssertNotEqual(error.type, .remoteConfigurationNotAvailable, "on attach a 404 means the caller's id is unknown")
+        } catch {
+            XCTFail("Expected QonversionError, got \(error)")
+        }
+    }
+
+    func testAServerErrorWithoutASlugIsNotAMissingConfiguration() async {
+        let service = makeLiveService(json: #"{"error": {"message": "boom"}}"#, status: 500)
+
+        do {
+            _ = try await service.loadRemoteConfig(contextKey: "main")
+            XCTFail("Expected an error")
+        } catch let error as QonversionError {
+            XCTAssertNotEqual(error.type, .remoteConfigurationNotAvailable, "only 404 means there is no configuration")
+        } catch {
+            XCTFail("Expected QonversionError, got \(error)")
+        }
+    }
+
     func testANotFoundOnAttachIsNotAMissingConfiguration() async {
         // On attach/detach a 404 means the id the CALLER passed is unknown.
         let service = makeLiveService(

--- a/Tests/QonversionUnitTests/UtilsTests.swift
+++ b/Tests/QonversionUnitTests/UtilsTests.swift
@@ -30,6 +30,24 @@ private struct UtilsTestsArrayContainer: Decodable {
     }
 }
 
+/// Carries a decode result off the background queue it ran on.
+private final class UtilsTestsResultBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: [Any]?
+
+    func store(_ value: [Any]?) {
+        lock.lock()
+        defer { lock.unlock() }
+        stored = value
+    }
+
+    var value: [Any]? {
+        lock.lock()
+        defer { lock.unlock() }
+        return stored
+    }
+}
+
 final class UtilsTests: XCTestCase {
 
     // MARK: - decode(fromObject:)
@@ -114,7 +132,90 @@ final class UtilsTests: XCTestCase {
         XCTAssertNil(result[6] as? Int)
     }
 
+    // MARK: - decode(fromArray:) termination
+
+    /// Decodes on a background queue: a container that refuses to advance
+    /// spins forever, and a hung XCTest run reports nothing useful.
+    private func decodeArrayWithinTimeout(_ json: String, file: StaticString = #filePath, line: UInt = #line) -> [Any]? {
+        let data = Data(json.utf8)
+        let finished = expectation(description: "decode(fromArray:) returned")
+        let resultBox = UtilsTestsResultBox()
+
+        DispatchQueue.global().async {
+            let decoded = try? JSONDecoder().decode(UtilsTestsArrayContainer.self, from: data).value
+            resultBox.store(decoded)
+            finished.fulfill()
+        }
+
+        let outcome = XCTWaiter.wait(for: [finished], timeout: 5)
+        guard outcome == .completed else {
+            XCTFail("decode(fromArray:) never returned — the loop cannot advance past this element", file: file, line: line)
+            return nil
+        }
+
+        return resultBox.value
+    }
+
+    func testDecodeArrayTerminatesOnANumberTooLargeForDoubleOrInt() {
+        // 1e999 is representable in neither Int nor Double, is not a string,
+        // bool, container or null — every branch of the loop declines it.
+        _ = decodeArrayWithinTimeout("[1e999]")
+    }
+
+    func testDecodeArrayTerminatesOnANegativeNumberTooLargeForDoubleOrInt() {
+        _ = decodeArrayWithinTimeout("[-1e999]")
+    }
+
+    func testDecodeArraySkipsTheUnrepresentableElementAndKeepsTheRest() throws {
+        let result = try XCTUnwrap(decodeArrayWithinTimeout(#"[1, 1e999, "a", true, null]"#))
+
+        XCTAssertEqual(result[0] as? Int, 1)
+        XCTAssertEqual(result[1] as? String, "a")
+        XCTAssertEqual(result[2] as? Bool, true)
+        XCTAssertEqual(result.count, 4, "only the unrepresentable element is dropped")
+    }
+
+    func testDecodeArrayStillDecodesOrdinaryArraysInFull() throws {
+        let result = try XCTUnwrap(decodeArrayWithinTimeout(#"[1, "a", true, 2.5, {"k": "v"}, [3], null]"#))
+
+        XCTAssertEqual(result.count, 7)
+        XCTAssertEqual(result[0] as? Int, 1)
+        XCTAssertEqual(result[3] as? Double, 2.5)
+    }
+
+    func testDecodeObjectTerminatesOnANumberTooLargeForDoubleOrInt() throws {
+        // The object decoder iterates the key list rather than advancing a
+        // cursor, so it terminates — the unrepresentable value is dropped.
+        let data = Data(#"{"huge": 1e999, "present": 1}"#.utf8)
+
+        let result = try JSONDecoder().decode(UtilsTestsObjectContainer.self, from: data).value
+
+        XCTAssertEqual(result["present"] as? Int, 1)
+        XCTAssertNil(result["huge"])
+    }
+
     // MARK: - String.toCurrencySymbol()
+
+    func testToCurrencySymbolPrefersTheCurrencysOwnSymbolOverAMinorityLocale() {
+        // Scanning sorted identifiers and taking the first match picked
+        // ba_RU ("RUB"), ain_JP ("JP¥") and csw_CA ("CA$") — deterministic,
+        // but the wrong symbol for a price label.
+        XCTAssertEqual("RUB".toCurrencySymbol(), "\u{20BD}")
+        XCTAssertEqual("JPY".toCurrencySymbol(), "\u{00A5}")
+        XCTAssertEqual("CAD".toCurrencySymbol(), "$")
+    }
+
+    func testToCurrencySymbolKeepsTheAlreadyCorrectMajorCurrencies() {
+        XCTAssertEqual("USD".toCurrencySymbol(), "$")
+        XCTAssertEqual("EUR".toCurrencySymbol(), "\u{20AC}")
+        XCTAssertEqual("GBP".toCurrencySymbol(), "\u{00A3}")
+        XCTAssertEqual("VND".toCurrencySymbol(), "\u{20AB}")
+    }
+
+    func testToCurrencySymbolKeepsTheCodeWhenItIsTheSymbol() {
+        // Every Swiss locale renders CHF as its code — that is the symbol.
+        XCTAssertEqual("CHF".toCurrencySymbol(), "CHF")
+    }
 
     func testToCurrencySymbolForKnownCurrencyReturnsSymbol() {
         let symbol = "USD".toCurrencySymbol()


### PR DESCRIPTION
…ding

Nine audit findings in the remote-config and shared-utils cluster.

loadRemoteConfigList (both variants) had no protection against a user switch: the generation guard stopped the response being cached but still handed the previous user's configs to the host. It now fails the same way an abandoned single-config load does, so the bundled fallback cannot answer it either.

decode(fromArray:) spun forever on a JSON number representable in neither Int nor Double: every branch declined it and decodeNil() does not advance the cursor. A terminal skip branch advances past the element, with a break as a last resort. decode(fromObject:) walks the key list, so it already terminated; the value is dropped there as before.

attach/detach now pass the user-stability gate, so a call issued while an identify is switching the uid no longer binds the pre-identify user. invalidateCache() also deregisters the in-flight loads so a post-attach caller starts its own request instead of joining a pre-attach one; unlike userDidChange they are not cancelled, since the response still belongs to the same user.

A config the backend reports no source for is no longer cached under the empty context key, where it shadowed loadRemoteConfig(nil), and no longer answers remoteConfigForEmptyContextKey(). remoteConfig(for: "") now normalizes its key the way the decoder does, so it matches instead of never matching, and the contextKey documentation describes the nil it actually returns.

RemoteConfig.Source and Experiment tolerate missing metadata keys rather than dropping the whole config, payload included. An object carrying none of the known keys still fails, which is what keeps the lossy list able to drop a genuinely broken row.

A 404 without an error slug in the body now maps to .remoteConfigurationNotAvailable on the loading endpoints: 404 is not in the SDK's ResponseCode list, so the type is derived from the slug alone and a slug-less body degraded to a generic loading failure. A 404 that does name a code the SDK understands keeps its own meaning.

Currency symbol resolution picks the shortest symbol among the locales using a currency rather than the alphabetically first locale, which chose ba_RU ("RUB"), ain_JP ("JP¥") and csw_CA ("CA$"). RUB/JPY/CAD now resolve to the symbols a price label needs, and memoization is unchanged.