### PR TITLE
feat: invalidateRemoteConfigsCache + remote config refetch after same-uid identify (DEV-1236)

### DIFF
--- a/Qonversion.xcodeproj/project.pbxproj
+++ b/Qonversion.xcodeproj/project.pbxproj
@@ -275,6 +275,7 @@
 		89673C2F26F49BAA008D209A /* QNIdentityManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 89673C2E26F49BA9008D209A /* QNIdentityManagerTests.m */; };
 		A1DEF1231000000000000001 /* QNUserPropertiesManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A1DEF1231000000000000002 /* QNUserPropertiesManagerTests.m */; };
 		A1DEF1231000000000000003 /* QONRemoteConfigManagerInvalidationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A1DEF1231000000000000004 /* QONRemoteConfigManagerInvalidationTests.m */; };
+		A1DEF1231000000000000005 /* QNProductCenterManagerIdentifyRemoteConfigTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A1DEF1231000000000000006 /* QNProductCenterManagerIdentifyRemoteConfigTests.m */; };
 		8981E78825C030DD002310BD /* QonversionFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 45239D6E2517CEB00085D0A8 /* QonversionFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		89A192A52604974800C3FCD9 /* QNUserInfoServiceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 89A192A42604974800C3FCD9 /* QNUserInfoServiceTests.m */; };
 		89A193262604B99C00C3FCD9 /* XCTestCase+Unmock.m in Sources */ = {isa = PBXBuildFile; fileRef = 89A193252604B99C00C3FCD9 /* XCTestCase+Unmock.m */; };
@@ -648,6 +649,7 @@
 		89673C2E26F49BA9008D209A /* QNIdentityManagerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QNIdentityManagerTests.m; sourceTree = "<group>"; };
 		A1DEF1231000000000000002 /* QNUserPropertiesManagerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QNUserPropertiesManagerTests.m; sourceTree = "<group>"; };
 		A1DEF1231000000000000004 /* QONRemoteConfigManagerInvalidationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QONRemoteConfigManagerInvalidationTests.m; sourceTree = "<group>"; };
+		A1DEF1231000000000000006 /* QNProductCenterManagerIdentifyRemoteConfigTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QNProductCenterManagerIdentifyRemoteConfigTests.m; sourceTree = "<group>"; };
 		89713B4625C1B95700A2448E /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk/System/iOSSupport/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		89713B4A25C1BA1F00A2448E /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk/System/iOSSupport/System/Library/Frameworks/WebKit.framework; sourceTree = DEVELOPER_DIR; };
 		89A192A42604974800C3FCD9 /* QNUserInfoServiceTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QNUserInfoServiceTests.m; sourceTree = "<group>"; };
@@ -1780,6 +1782,7 @@
 				89673C2E26F49BA9008D209A /* QNIdentityManagerTests.m */,
 				A1DEF1231000000000000002 /* QNUserPropertiesManagerTests.m */,
 				A1DEF1231000000000000004 /* QONRemoteConfigManagerInvalidationTests.m */,
+				A1DEF1231000000000000006 /* QNProductCenterManagerIdentifyRemoteConfigTests.m */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -2443,6 +2446,7 @@
 				89673C2F26F49BAA008D209A /* QNIdentityManagerTests.m in Sources */,
 				A1DEF1231000000000000001 /* QNUserPropertiesManagerTests.m in Sources */,
 				A1DEF1231000000000000003 /* QONRemoteConfigManagerInvalidationTests.m in Sources */,
+				A1DEF1231000000000000005 /* QNProductCenterManagerIdentifyRemoteConfigTests.m in Sources */,
 				4531CBCB24581BD80022C422 /* QNUserInfoTests.m in Sources */,
 				456ECD37249BB68B00D2BC40 /* QRequestBuilderTests.m in Sources */,
 				89A193262604B99C00C3FCD9 /* XCTestCase+Unmock.m in Sources */,

--- a/QonversionTests/Managers/QNProductCenterManagerIdentifyRemoteConfigTests.m
+++ b/QonversionTests/Managers/QNProductCenterManagerIdentifyRemoteConfigTests.m
@@ -1,0 +1,152 @@
+//
+//  QNProductCenterManagerIdentifyRemoteConfigTests.m
+//  QonversionTests
+//
+//  Copyright © 2026 Qonversion Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import <OCMock/OCMock.h>
+#import "QNProductCenterManager.h"
+#import "QNAPIClient.h"
+#import "QNUserInfoService.h"
+#import "QNIdentityManager.h"
+#import "QNLocalStorage.h"
+#import "QONFallbackService.h"
+#import "QONRemoteConfigManager.h"
+
+/*
+ * Contract tests for the same-uid identify -> remote config cache
+ * invalidation seam (DEV-1236 B4).
+ *
+ * The first identify for a user does not change the Qonversion uid (the
+ * backend attaches the external identity to the existing client row), so the
+ * destructive user-switch path never runs. Without an explicit invalidation
+ * the host keeps the pre-login targeting evaluation for the rest of the
+ * process lifetime. These tests pin:
+ *   1. processIdentity resolving to the SAME uid invalidates the remote
+ *      configs cache (and does NOT fire the destructive userHasBeenChanged);
+ *   2. the invalidation runs BEFORE the pending-request replay — swapping the
+ *      two lets the replay hit the still-warm cache, which serves the
+ *      pre-identify evaluation and orphans queued completions;
+ *   3. an identity error leaves the cache untouched.
+ */
+
+@interface QNProductCenterManager (IdentifyRemoteConfigTestPrivate)
+
+@property (nonatomic, assign) BOOL launchingFinished;
+
+- (void)processIdentity:(NSString *)identityId;
+
+@end
+
+@interface QNProductCenterManagerIdentifyRemoteConfigTests : XCTestCase
+
+@property (nonatomic, strong) id mockClient;
+@property (nonatomic, strong) id mockUserInfoService;
+@property (nonatomic, strong) id mockIdentityManager;
+@property (nonatomic, strong) id mockRemoteConfigManager;
+@property (nonatomic, strong) QNProductCenterManager *manager;
+
+@end
+
+@implementation QNProductCenterManagerIdentifyRemoteConfigTests
+
+- (void)setUp {
+  [super setUp];
+
+  _mockClient = OCMClassMock([QNAPIClient class]);
+  OCMStub([_mockClient shared]).andReturn(_mockClient);
+
+  _mockUserInfoService = OCMProtocolMock(@protocol(QNUserInfoServiceInterface));
+  _mockIdentityManager = OCMClassMock([QNIdentityManager class]);
+  id mockLocalStorage = OCMProtocolMock(@protocol(QNLocalStorage));
+  id mockFallbackService = OCMClassMock([QONFallbackService class]);
+
+  _manager = [[QNProductCenterManager alloc] initWithUserInfoService:_mockUserInfoService
+                                                     identityManager:_mockIdentityManager
+                                                        localStorage:mockLocalStorage
+                                                     fallbackService:mockFallbackService];
+
+  _mockRemoteConfigManager = OCMClassMock([QONRemoteConfigManager class]);
+  _manager.remoteConfigManager = _mockRemoteConfigManager;
+}
+
+- (void)tearDown {
+  [_mockClient stopMocking];
+  _manager = nil;
+
+  [super tearDown];
+}
+
+- (void)testProcessIdentity_SameUid_InvalidatesRemoteConfigsCache {
+  // Given - the backend resolves the identity to the CURRENT uid
+  NSString *identityId = @"login@example.com";
+  NSString *sameUid = @"uid_initial";
+  OCMStub([_mockUserInfoService obtainUserID]).andReturn(sameUid);
+  // Extra parens are required: without them the commas inside
+  // invokeBlockWithArgs are parsed as extra OCMStub macro arguments.
+  OCMStub(([_mockIdentityManager identify:identityId
+                               completion:[OCMArg invokeBlockWithArgs:sameUid, [NSNull null], nil]]));
+
+  // The destructive user-switch path must NOT fire on same-uid
+  OCMReject([_mockRemoteConfigManager userHasBeenChanged]);
+
+  // When - launchingFinished stays NO, so handlePendingRequests: returns
+  // early and fireIdentitySuccess no-ops on the empty pending blocks
+  [_manager processIdentity:identityId];
+
+  // Then - deleting the invalidation call in the same-uid branch fails here
+  OCMVerify([_mockRemoteConfigManager invalidateRemoteConfigsCache]);
+  OCMVerifyAll(_mockRemoteConfigManager);
+}
+
+- (void)testProcessIdentity_SameUid_InvalidatesBeforePendingRequestReplay {
+  // Given
+  NSString *identityId = @"login@example.com";
+  NSString *sameUid = @"uid_initial";
+  OCMStub([_mockUserInfoService obtainUserID]).andReturn(sameUid);
+  OCMStub(([_mockIdentityManager identify:identityId
+                               completion:[OCMArg invokeBlockWithArgs:sameUid, [NSNull null], nil]]));
+
+  // launchingFinished so PCM's handlePendingRequests: reaches the RC manager
+  // (executeEntitlementsBlocksWithError: no-ops on zero queued blocks)
+  _manager.launchingFinished = YES;
+
+  NSMutableArray<NSString *> *order = [NSMutableArray new];
+  OCMStub([_mockRemoteConfigManager invalidateRemoteConfigsCache]).andDo(^(NSInvocation *invocation) {
+    [order addObject:@"invalidate"];
+  });
+  OCMStub([_mockRemoteConfigManager handlePendingRequests]).andDo(^(NSInvocation *invocation) {
+    [order addObject:@"replay"];
+  });
+
+  // When
+  [_manager processIdentity:identityId];
+
+  // Then - the replay must observe an already-invalidated cache; the reversed
+  // order serves queued completions the pre-identify evaluation and orphans
+  // them on the cache-hit path
+  XCTAssertEqualObjects(order, (@[@"invalidate", @"replay"]));
+}
+
+- (void)testProcessIdentity_IdentityError_DoesNotInvalidateRemoteConfigsCache {
+  // Given - identify fails
+  NSString *identityId = @"login@example.com";
+  OCMStub([_mockUserInfoService obtainUserID]).andReturn(@"uid_initial");
+  NSError *identityError = [NSError errorWithDomain:@"test" code:1 userInfo:nil];
+  OCMStub(([_mockIdentityManager identify:identityId
+                               completion:[OCMArg invokeBlockWithArgs:[NSNull null], identityError, nil]]));
+
+  OCMReject([_mockRemoteConfigManager invalidateRemoteConfigsCache]);
+  OCMReject([_mockRemoteConfigManager userHasBeenChanged]);
+
+  // When
+  [_manager processIdentity:identityId];
+
+  // Then - the error is propagated to the RC manager without cache changes
+  OCMVerify([_mockRemoteConfigManager userChangingRequestFailedWithError:identityError]);
+  OCMVerifyAll(_mockRemoteConfigManager);
+}
+
+@end

--- a/QonversionTests/Managers/QNProductCenterManagerIdentifyRemoteConfigTests.m
+++ b/QonversionTests/Managers/QNProductCenterManagerIdentifyRemoteConfigTests.m
@@ -74,6 +74,11 @@
 
 - (void)tearDown {
   [_mockClient stopMocking];
+  // Class mocks swizzle the class for as long as they live — stop them
+  // explicitly so tests exercising the real classes in the same process
+  // cannot be poisoned by ordering.
+  [_mockIdentityManager stopMocking];
+  [_mockRemoteConfigManager stopMocking];
   _manager = nil;
 
   [super tearDown];

--- a/QonversionTests/Managers/QONRemoteConfigManagerInvalidationTests.m
+++ b/QonversionTests/Managers/QONRemoteConfigManagerInvalidationTests.m
@@ -17,6 +17,7 @@
 #import "QONRemoteConfigurationSource.h"
 #import "QONFallbackService.h"
 #import "QONFallbackObject.h"
+#import "QONErrors.h"
 
 /*
  * Contract tests for the cache invalidation seams (DEV-1231 + DEV-1236 B4).
@@ -217,6 +218,190 @@
   // then - the pre-attach evaluation is dropped and the load re-issued
   XCTAssertEqual(deliveryCount, 0);
   XCTAssertEqual(serviceCallCount, 2);
+  XCTAssertNil(self.manager.loadingStates[@"ctx"].loadedConfig);
+}
+
+- (void)testCacheHitDrainsQueuedCompletions {
+  // given - a warm state that still carries a queued completion (e.g. a list
+  // load cached into a state whose own load never fired it, or a completion
+  // queued while the user was unstable meets a warm cache on replay)
+  [self stubUserStableAndImmediatePropertiesFlush];
+  QONRemoteConfig *cachedConfig = OCMClassMock([QONRemoteConfig class]);
+  QONRemoteConfigLoadingState *state = [QONRemoteConfigLoadingState new];
+  state.loadedConfig = cachedConfig;
+  __block QONRemoteConfig *queuedDelivered = nil;
+  [state.completions addObject:^(QONRemoteConfig * _Nullable remoteConfig, NSError * _Nullable error) {
+    queuedDelivered = remoteConfig;
+  }];
+  self.manager.loadingStates[@"ctx"] = state;
+
+  // when - a direct caller hits the warm cache
+  __block QONRemoteConfig *directDelivered = nil;
+  [self.manager obtainRemoteConfigWithContextKey:@"ctx"
+                                      completion:^(QONRemoteConfig * _Nullable remoteConfig, NSError * _Nullable error) {
+    directDelivered = remoteConfig;
+  }];
+
+  // then - both the direct caller and the stranded waiter are served
+  XCTAssertEqual(directDelivered, cachedConfig);
+  XCTAssertEqual(queuedDelivered, cachedConfig);
+  XCTAssertEqual(state.completions.count, 0);
+}
+
+- (void)testReissueOntoWarmCacheServesQueuedWaiters {
+  // given - a single-key load is in flight with a second caller queued
+  [self stubUserStableAndImmediatePropertiesFlush];
+  __block NSUInteger singleCalls = 0;
+  __block QONRemoteConfigCompletionHandler serviceCompletion = nil;
+  OCMStub([self.mockService loadRemoteConfig:[OCMArg any] completion:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
+    singleCalls += 1;
+    __unsafe_unretained QONRemoteConfigCompletionHandler completion = nil;
+    [invocation getArgument:&completion atIndex:3];
+    serviceCompletion = [completion copy];
+  });
+  __block QONRemoteConfigListCompletionHandler listServiceCompletion = nil;
+  OCMStub([self.mockService loadRemoteConfigList:[OCMArg any] includeEmptyContextKey:NO completion:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
+    __unsafe_unretained QONRemoteConfigListCompletionHandler completion = nil;
+    [invocation getArgument:&completion atIndex:4];
+    listServiceCompletion = [completion copy];
+  });
+
+  __block QONRemoteConfig *deliveredA = nil;
+  __block QONRemoteConfig *deliveredB = nil;
+  [self.manager obtainRemoteConfigWithContextKey:@"ctx"
+                                      completion:^(QONRemoteConfig * _Nullable remoteConfig, NSError * _Nullable error) {
+    deliveredA = remoteConfig;
+  }];
+  [self.manager obtainRemoteConfigWithContextKey:@"ctx"
+                                      completion:^(QONRemoteConfig * _Nullable remoteConfig, NSError * _Nullable error) {
+    deliveredB = remoteConfig;
+  }];
+  XCTAssertEqual(singleCalls, 1);
+
+  // when - an invalidation lands, a list load started AFTER it caches the
+  // same key, and only then the superseded single-key response arrives, so
+  // its re-issue hits the warm cache
+  [self.manager invalidateRemoteConfigsCache];
+  [self.manager obtainRemoteConfigListWithContextKeys:@[@"ctx"]
+                               includeEmptyContextKey:NO
+                                           completion:^(QONRemoteConfigList * _Nullable remoteConfigList, NSError * _Nullable error) {}];
+  QONRemoteConfig *warmConfig = OCMClassMock([QONRemoteConfig class]);
+  QONRemoteConfigurationSource *warmSource = OCMClassMock([QONRemoteConfigurationSource class]);
+  OCMStub([warmConfig source]).andReturn(warmSource);
+  OCMStub([warmSource contextKey]).andReturn(@"ctx");
+  listServiceCompletion([[QONRemoteConfigList alloc] initWithRemoteConfigs:@[warmConfig]], nil);
+  serviceCompletion(OCMClassMock([QONRemoteConfig class]), nil);
+
+  // then - BOTH the direct caller and the queued waiter are served with the
+  // warm (current generation) config instead of hanging forever, and no
+  // second single-key request was needed
+  XCTAssertEqual(deliveredA, warmConfig);
+  XCTAssertEqual(deliveredB, warmConfig);
+  XCTAssertEqual(singleCalls, 1);
+  XCTAssertEqual(self.manager.loadingStates[@"ctx"].completions.count, 0);
+}
+
+- (void)testFailedReissueDeliversSupersededEvaluation {
+  // given - a load is in flight
+  [self stubUserStableAndImmediatePropertiesFlush];
+  __block NSUInteger singleCalls = 0;
+  __block QONRemoteConfigCompletionHandler serviceCompletion = nil;
+  OCMStub([self.mockService loadRemoteConfig:[OCMArg any] completion:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
+    singleCalls += 1;
+    __unsafe_unretained QONRemoteConfigCompletionHandler completion = nil;
+    [invocation getArgument:&completion atIndex:3];
+    serviceCompletion = [completion copy];
+  });
+
+  __block QONRemoteConfig *deliveredConfig = nil;
+  __block NSError *deliveredError = nil;
+  __block NSUInteger deliveryCount = 0;
+  [self.manager obtainRemoteConfigWithContextKey:@"ctx"
+                                      completion:^(QONRemoteConfig * _Nullable remoteConfig, NSError * _Nullable error) {
+    deliveryCount += 1;
+    deliveredConfig = remoteConfig;
+    deliveredError = error;
+  }];
+
+  // when - invalidation mid-flight, the superseded (valid) response triggers
+  // a re-issue, and the retry fails without a fallback (no bundled data)
+  [self.manager invalidateRemoteConfigsCache];
+  QONRemoteConfig *supersededConfig = OCMClassMock([QONRemoteConfig class]);
+  QONRemoteConfigCompletionHandler firstServiceCompletion = serviceCompletion;
+  firstServiceCompletion(supersededConfig, nil);
+  XCTAssertEqual(singleCalls, 2);
+  serviceCompletion(nil, [NSError errorWithDomain:@"test" code:400 userInfo:nil]);
+
+  // then - never worse than before: the superseded evaluation is delivered
+  // as a success instead of surfacing the retry error, and nothing is cached
+  XCTAssertEqual(deliveryCount, 1);
+  XCTAssertEqual(deliveredConfig, supersededConfig);
+  XCTAssertNil(deliveredError);
+  XCTAssertNil(self.manager.loadingStates[@"ctx"].loadedConfig);
+}
+
+- (void)testUserSwitchMidFlightDoesNotReissue {
+  // given - a load is in flight
+  [self stubUserStableAndImmediatePropertiesFlush];
+  __block NSUInteger singleCalls = 0;
+  __block QONRemoteConfigCompletionHandler serviceCompletion = nil;
+  OCMStub([self.mockService loadRemoteConfig:[OCMArg any] completion:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
+    singleCalls += 1;
+    __unsafe_unretained QONRemoteConfigCompletionHandler completion = nil;
+    [invocation getArgument:&completion atIndex:3];
+    serviceCompletion = [completion copy];
+  });
+  [self.manager obtainRemoteConfigWithContextKey:@"ctx"
+                                      completion:^(QONRemoteConfig * _Nullable remoteConfig, NSError * _Nullable error) {}];
+  XCTAssertEqual(singleCalls, 1);
+
+  // when - the user switches (states map replaced), then the response lands
+  // on the now-orphaned state
+  [self.manager userHasBeenChanged];
+  serviceCompletion(OCMClassMock([QONRemoteConfig class]), nil);
+
+  // then - the orphaned state must not fire a request nobody awaits
+  XCTAssertEqual(singleCalls, 1);
+}
+
+- (void)testRateLimitedLoadDeliversBundledFallback {
+  // given - a bundled fallback exists and a load is in flight
+  [self stubUserStableAndImmediatePropertiesFlush];
+  QONRemoteConfig *fallbackConfig = OCMClassMock([QONRemoteConfig class]);
+  QONRemoteConfigurationSource *fallbackSource = OCMClassMock([QONRemoteConfigurationSource class]);
+  OCMStub([fallbackConfig source]).andReturn(fallbackSource);
+  OCMStub([fallbackSource contextKey]).andReturn(@"ctx");
+  QONFallbackObject *fallbackObject = [QONFallbackObject new];
+  fallbackObject.remoteConfigList = [[QONRemoteConfigList alloc] initWithRemoteConfigs:@[fallbackConfig]];
+  OCMStub([self.mockFallbackService obtainFallbackData]).andReturn(fallbackObject);
+
+  __block QONRemoteConfigCompletionHandler serviceCompletion = nil;
+  OCMStub([self.mockService loadRemoteConfig:[OCMArg any] completion:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
+    __unsafe_unretained QONRemoteConfigCompletionHandler completion = nil;
+    [invocation getArgument:&completion atIndex:3];
+    serviceCompletion = [completion copy];
+  });
+
+  __block QONRemoteConfig *deliveredConfig = nil;
+  __block NSError *deliveredError = nil;
+  [self.manager obtainRemoteConfigWithContextKey:@"ctx"
+                                      completion:^(QONRemoteConfig * _Nullable remoteConfig, NSError * _Nullable error) {
+    deliveredConfig = remoteConfig;
+    deliveredError = error;
+  }];
+  XCTAssertNotNil(serviceCompletion, @"the load must reach the service");
+
+  // when - the request is short-circuited by the local rate limiter (since
+  // fallbacks are no longer cached, offline repeat calls hit the limiter
+  // instead of the old cached-fallback fast path)
+  // shouldFireFallback matches on the code alone, so the domain is irrelevant
+  serviceCompletion(nil, [NSError errorWithDomain:@"test"
+                                             code:QONErrorCodeApiRateLimitExceeded
+                                         userInfo:nil]);
+
+  // then - the bundled payload is served instead of a hard error, uncached
+  XCTAssertEqual(deliveredConfig, fallbackConfig);
+  XCTAssertNil(deliveredError);
   XCTAssertNil(self.manager.loadingStates[@"ctx"].loadedConfig);
 }
 

--- a/QonversionTests/Managers/QONRemoteConfigManagerInvalidationTests.m
+++ b/QonversionTests/Managers/QONRemoteConfigManagerInvalidationTests.m
@@ -155,6 +155,48 @@
   XCTAssertFalse(self.manager.loadingStates[@"ctx"].isInProgress);
 }
 
+- (void)testRefreshRemoteConfigsDropsCachesNonDestructively {
+  // given - cached configs with a pending completion (DEV-1236 B4: the public
+  // refresh and the same-uid identify path both route here)
+  [self seedCachedConfigs];
+
+  // when
+  [self.manager refreshRemoteConfigs];
+
+  // then - caches dropped, states and completions survive
+  [self assertInvalidatedForEntryPoint:@"refreshRemoteConfigs"];
+}
+
+- (void)testRefreshRemoteConfigsGuardsInFlightLoads {
+  // given - a load is in flight when the refresh lands
+  OCMStub([self.mockProductCenterManager isUserStable]).andReturn(YES);
+  OCMStub([self.mockUserPropertiesManager forceSendProperties:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
+    __unsafe_unretained QONUserPropertiesEmptyCompletionHandler flushCompletion = nil;
+    [invocation getArgument:&flushCompletion atIndex:2];
+    if (flushCompletion) {
+      flushCompletion();
+    }
+  });
+
+  __block QONRemoteConfigCompletionHandler serviceCompletion = nil;
+  OCMStub([self.mockService loadRemoteConfig:[OCMArg any] completion:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
+    __unsafe_unretained QONRemoteConfigCompletionHandler completion = nil;
+    [invocation getArgument:&completion atIndex:3];
+    serviceCompletion = [completion copy];
+  });
+
+  [self.manager obtainRemoteConfigWithContextKey:@"ctx"
+                                      completion:^(QONRemoteConfig * _Nullable remoteConfig, NSError * _Nullable error) {}];
+  XCTAssertNotNil(serviceCompletion);
+
+  // when - refresh mid-flight, then the pre-refresh response lands
+  [self.manager refreshRemoteConfigs];
+  serviceCompletion(OCMClassMock([QONRemoteConfig class]), nil);
+
+  // then - the stale evaluation must not be re-cached
+  XCTAssertNil(self.manager.loadingStates[@"ctx"].loadedConfig);
+}
+
 - (void)testAttachInvalidationPreventsInFlightListLoadFromReCachingStaleConfigs {
   // given - the user is stable and a list load is in flight (attach does NOT
   // replace the states map, so the generation guard is the only barrier here)

--- a/QonversionTests/Managers/QONRemoteConfigManagerInvalidationTests.m
+++ b/QonversionTests/Managers/QONRemoteConfigManagerInvalidationTests.m
@@ -15,15 +15,20 @@
 #import "QONRemoteConfig.h"
 #import "QONRemoteConfigList+Protected.h"
 #import "QONRemoteConfigurationSource.h"
+#import "QONFallbackService.h"
+#import "QONFallbackObject.h"
 
 /*
- * Contract tests for the attach/detach cache invalidation (DEV-1231).
+ * Contract tests for the cache invalidation seams (DEV-1231 + DEV-1236 B4).
  *
  * An attach/detach is addressed by experiment/configuration id, and the SDK
  * cannot know which context key that entity serves — so EVERY cached config
- * must be dropped (named keys included), loading states must survive with
- * their pending completions, and an in-flight load must not re-cache a
- * pre-attach evaluation (generation guard).
+ * must be dropped (named keys included) and loading states must survive with
+ * their pending completions. The public invalidateRemoteConfigsCache shares
+ * the same semantics. A superseded in-flight load (generation moved while the
+ * request was flying) is re-issued once per generation instead of delivering
+ * the stale evaluation, and bundled fallback configs are delivered without
+ * being cached.
  */
 
 @interface QONRemoteConfigManager (InvalidationContractPrivate)
@@ -38,6 +43,7 @@
 @property (nonatomic, strong) id mockService;
 @property (nonatomic, strong) id mockProductCenterManager;
 @property (nonatomic, strong) id mockUserPropertiesManager;
+@property (nonatomic, strong) id mockFallbackService;
 @property (nonatomic, strong) QONRemoteConfigManager *manager;
 
 @end
@@ -52,19 +58,33 @@
   self.mockService = OCMClassMock([QONRemoteConfigService class]);
   self.mockProductCenterManager = OCMClassMock([QNProductCenterManager class]);
   self.mockUserPropertiesManager = OCMClassMock([QNUserPropertiesManager class]);
+  self.mockFallbackService = OCMClassMock([QONFallbackService class]);
 
   self.manager.remoteConfigService = self.mockService;
   self.manager.productCenterManager = self.mockProductCenterManager;
   self.manager.userPropertiesManager = self.mockUserPropertiesManager;
+  self.manager.fallbackService = self.mockFallbackService;
 }
 
 - (void)tearDown {
   [self.mockService stopMocking];
   [self.mockProductCenterManager stopMocking];
   [self.mockUserPropertiesManager stopMocking];
+  [self.mockFallbackService stopMocking];
   self.manager = nil;
 
   [super tearDown];
+}
+
+- (void)stubUserStableAndImmediatePropertiesFlush {
+  OCMStub([self.mockProductCenterManager isUserStable]).andReturn(YES);
+  OCMStub([self.mockUserPropertiesManager forceSendProperties:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
+    __unsafe_unretained QONUserPropertiesEmptyCompletionHandler flushCompletion = nil;
+    [invocation getArgument:&flushCompletion atIndex:2];
+    if (flushCompletion) {
+      flushCompletion();
+    }
+  });
 }
 
 - (void)seedCachedConfigs {
@@ -90,7 +110,7 @@
                  @"%@ must preserve pending completions", entryPoint);
 }
 
-- (void)testEveryAttachAndDetachEntryPointInvalidatesNamedKeyCachedConfigs {
+- (void)testEveryInvalidationEntryPointInvalidatesNamedKeyCachedConfigs {
   // attach to remote configuration
   [self seedCachedConfigs];
   [self.manager attachUserToRemoteConfiguration:@"config_id"
@@ -115,18 +135,102 @@
   [self.manager detachUserFromExperiment:@"experiment_id"
                               completion:^(BOOL success, NSError * _Nullable error) {}];
   [self assertInvalidatedForEntryPoint:@"detachUserFromExperiment"];
+
+  // public cache invalidation (DEV-1236 B4: the same-uid identify path and
+  // the public API both route here)
+  [self seedCachedConfigs];
+  [self.manager invalidateRemoteConfigsCache];
+  [self assertInvalidatedForEntryPoint:@"invalidateRemoteConfigsCache"];
 }
 
-- (void)testAttachInvalidationPreventsInFlightLoadFromReCachingStaleConfig {
+- (void)testInvalidateMidFlightReissuesLoadAndDeliversFreshEvaluation {
   // given - the user is stable and a single-key load is in flight
-  OCMStub([self.mockProductCenterManager isUserStable]).andReturn(YES);
-  OCMStub([self.mockUserPropertiesManager forceSendProperties:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
-    __unsafe_unretained QONUserPropertiesEmptyCompletionHandler flushCompletion = nil;
-    [invocation getArgument:&flushCompletion atIndex:2];
-    if (flushCompletion) {
-      flushCompletion();
-    }
+  [self stubUserStableAndImmediatePropertiesFlush];
+
+  __block NSUInteger serviceCallCount = 0;
+  __block QONRemoteConfigCompletionHandler serviceCompletion = nil;
+  OCMStub([self.mockService loadRemoteConfig:[OCMArg any] completion:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
+    serviceCallCount += 1;
+    __unsafe_unretained QONRemoteConfigCompletionHandler completion = nil;
+    [invocation getArgument:&completion atIndex:3];
+    serviceCompletion = [completion copy];
   });
+
+  __block NSUInteger deliveryCount = 0;
+  __block QONRemoteConfig *deliveredConfig = nil;
+  [self.manager obtainRemoteConfigWithContextKey:@"ctx"
+                                      completion:^(QONRemoteConfig * _Nullable remoteConfig, NSError * _Nullable error) {
+    deliveryCount += 1;
+    deliveredConfig = remoteConfig;
+  }];
+  XCTAssertEqual(serviceCallCount, 1, @"the load must reach the service");
+
+  // when - the cache is invalidated mid-flight, then the superseded response
+  // lands
+  [self.manager invalidateRemoteConfigsCache];
+  QONRemoteConfig *staleConfig = OCMClassMock([QONRemoteConfig class]);
+  QONRemoteConfigCompletionHandler firstServiceCompletion = serviceCompletion;
+  firstServiceCompletion(staleConfig, nil);
+
+  // then - the stale evaluation is neither delivered nor cached; the load is
+  // re-issued exactly once for the awaiting completion
+  XCTAssertEqual(deliveryCount, 0);
+  XCTAssertEqual(serviceCallCount, 2);
+  XCTAssertNil(self.manager.loadingStates[@"ctx"].loadedConfig);
+
+  // and the fresh response is delivered, cached, and the state settled
+  QONRemoteConfig *freshConfig = OCMClassMock([QONRemoteConfig class]);
+  serviceCompletion(freshConfig, nil);
+  XCTAssertEqual(deliveryCount, 1);
+  XCTAssertEqual(deliveredConfig, freshConfig);
+  XCTAssertEqual(self.manager.loadingStates[@"ctx"].loadedConfig, freshConfig);
+  XCTAssertFalse(self.manager.loadingStates[@"ctx"].isInProgress);
+  XCTAssertEqual(serviceCallCount, 2, @"no runaway retries after the fresh delivery");
+}
+
+- (void)testAttachInvalidationMidFlightAlsoReissuesLoad {
+  // given - attach shares the invalidation seam with the public API
+  [self stubUserStableAndImmediatePropertiesFlush];
+
+  __block NSUInteger serviceCallCount = 0;
+  __block QONRemoteConfigCompletionHandler serviceCompletion = nil;
+  OCMStub([self.mockService loadRemoteConfig:[OCMArg any] completion:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
+    serviceCallCount += 1;
+    __unsafe_unretained QONRemoteConfigCompletionHandler completion = nil;
+    [invocation getArgument:&completion atIndex:3];
+    serviceCompletion = [completion copy];
+  });
+
+  __block NSUInteger deliveryCount = 0;
+  [self.manager obtainRemoteConfigWithContextKey:@"ctx"
+                                      completion:^(QONRemoteConfig * _Nullable remoteConfig, NSError * _Nullable error) {
+    deliveryCount += 1;
+  }];
+  XCTAssertEqual(serviceCallCount, 1);
+
+  // when - the attach invalidates mid-flight, then the pre-attach response
+  // lands
+  [self.manager attachUserToRemoteConfiguration:@"config_id"
+                                     completion:^(BOOL success, NSError * _Nullable error) {}];
+  serviceCompletion(OCMClassMock([QONRemoteConfig class]), nil);
+
+  // then - the pre-attach evaluation is dropped and the load re-issued
+  XCTAssertEqual(deliveryCount, 0);
+  XCTAssertEqual(serviceCallCount, 2);
+  XCTAssertNil(self.manager.loadingStates[@"ctx"].loadedConfig);
+}
+
+- (void)testFallbackConfigIsDeliveredWithoutBeingCached {
+  // given - a bundled fallback exists and a single-key load is in flight
+  [self stubUserStableAndImmediatePropertiesFlush];
+
+  QONRemoteConfig *fallbackConfig = OCMClassMock([QONRemoteConfig class]);
+  QONRemoteConfigurationSource *fallbackSource = OCMClassMock([QONRemoteConfigurationSource class]);
+  OCMStub([fallbackConfig source]).andReturn(fallbackSource);
+  OCMStub([fallbackSource contextKey]).andReturn(@"ctx");
+  QONFallbackObject *fallbackObject = [QONFallbackObject new];
+  fallbackObject.remoteConfigList = [[QONRemoteConfigList alloc] initWithRemoteConfigs:@[fallbackConfig]];
+  OCMStub([self.mockFallbackService obtainFallbackData]).andReturn(fallbackObject);
 
   __block QONRemoteConfigCompletionHandler serviceCompletion = nil;
   OCMStub([self.mockService loadRemoteConfig:[OCMArg any] completion:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
@@ -142,59 +246,55 @@
   }];
   XCTAssertNotNil(serviceCompletion, @"the load must reach the service");
 
-  // when - the attach invalidates mid-flight, then the pre-attach response lands
-  [self.manager attachUserToRemoteConfiguration:@"config_id"
-                                     completion:^(BOOL success, NSError * _Nullable error) {}];
-  QONRemoteConfig *staleConfig = OCMClassMock([QONRemoteConfig class]);
-  serviceCompletion(staleConfig, nil);
+  // when - the network fails in a fallback-eligible way
+  NSError *networkError = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorNotConnectedToInternet userInfo:nil];
+  serviceCompletion(nil, networkError);
 
-  // then - the stale evaluation is delivered to the waiting caller but must
-  // NOT be re-cached; the state stays refetchable
-  XCTAssertEqual(deliveredConfig, staleConfig);
+  // then - the fallback is delivered but NOT pinned into the cache, so the
+  // next call retries the network instead of serving the fallback until the
+  // next invalidation
+  XCTAssertEqual(deliveredConfig, fallbackConfig);
   XCTAssertNil(self.manager.loadingStates[@"ctx"].loadedConfig);
   XCTAssertFalse(self.manager.loadingStates[@"ctx"].isInProgress);
 }
 
-- (void)testRefreshRemoteConfigsDropsCachesNonDestructively {
-  // given - cached configs with a pending completion (DEV-1236 B4: the public
-  // refresh and the same-uid identify path both route here)
-  [self seedCachedConfigs];
+- (void)testFallbackListIsBuiltFromBundledDataAndNotCached {
+  // given - a bundled fallback exists and a keyed list load is in flight
+  [self stubUserStableAndImmediatePropertiesFlush];
 
-  // when
-  [self.manager refreshRemoteConfigs];
+  QONRemoteConfig *fallbackConfig = OCMClassMock([QONRemoteConfig class]);
+  QONRemoteConfigurationSource *fallbackSource = OCMClassMock([QONRemoteConfigurationSource class]);
+  OCMStub([fallbackConfig source]).andReturn(fallbackSource);
+  OCMStub([fallbackSource contextKey]).andReturn(@"ctx");
+  QONFallbackObject *fallbackObject = [QONFallbackObject new];
+  fallbackObject.remoteConfigList = [[QONRemoteConfigList alloc] initWithRemoteConfigs:@[fallbackConfig]];
+  OCMStub([self.mockFallbackService obtainFallbackData]).andReturn(fallbackObject);
 
-  // then - caches dropped, states and completions survive
-  [self assertInvalidatedForEntryPoint:@"refreshRemoteConfigs"];
-}
-
-- (void)testRefreshRemoteConfigsGuardsInFlightLoads {
-  // given - a load is in flight when the refresh lands
-  OCMStub([self.mockProductCenterManager isUserStable]).andReturn(YES);
-  OCMStub([self.mockUserPropertiesManager forceSendProperties:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
-    __unsafe_unretained QONUserPropertiesEmptyCompletionHandler flushCompletion = nil;
-    [invocation getArgument:&flushCompletion atIndex:2];
-    if (flushCompletion) {
-      flushCompletion();
-    }
-  });
-
-  __block QONRemoteConfigCompletionHandler serviceCompletion = nil;
-  OCMStub([self.mockService loadRemoteConfig:[OCMArg any] completion:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
-    __unsafe_unretained QONRemoteConfigCompletionHandler completion = nil;
-    [invocation getArgument:&completion atIndex:3];
+  __block QONRemoteConfigListCompletionHandler serviceCompletion = nil;
+  OCMStub([self.mockService loadRemoteConfigList:[OCMArg any] includeEmptyContextKey:NO completion:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
+    __unsafe_unretained QONRemoteConfigListCompletionHandler completion = nil;
+    [invocation getArgument:&completion atIndex:4];
     serviceCompletion = [completion copy];
   });
 
-  [self.manager obtainRemoteConfigWithContextKey:@"ctx"
-                                      completion:^(QONRemoteConfig * _Nullable remoteConfig, NSError * _Nullable error) {}];
-  XCTAssertNotNil(serviceCompletion);
+  __block QONRemoteConfigList *deliveredList = nil;
+  [self.manager obtainRemoteConfigListWithContextKeys:@[@"ctx"]
+                               includeEmptyContextKey:NO
+                                           completion:^(QONRemoteConfigList * _Nullable remoteConfigList, NSError * _Nullable error) {
+    deliveredList = remoteConfigList;
+  }];
+  XCTAssertNotNil(serviceCompletion, @"the list load must reach the service");
 
-  // when - refresh mid-flight, then the pre-refresh response lands
-  [self.manager refreshRemoteConfigs];
-  serviceCompletion(OCMClassMock([QONRemoteConfig class]), nil);
+  // when - the network fails in a fallback-eligible way
+  NSError *networkError = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorNotConnectedToInternet userInfo:nil];
+  serviceCompletion(nil, networkError);
 
-  // then - the stale evaluation must not be re-cached
-  XCTAssertNil(self.manager.loadingStates[@"ctx"].loadedConfig);
+  // then - the keyed fallback is filtered from the BUNDLED list (previously
+  // it was filtered from the nil network list and always came back empty),
+  // delivered, and nothing is cached
+  XCTAssertEqual(deliveredList.remoteConfigs.count, 1);
+  XCTAssertEqual(deliveredList.remoteConfigs.firstObject, fallbackConfig);
+  XCTAssertNil(self.manager.loadingStates[@"ctx"]);
 }
 
 - (void)testAttachInvalidationPreventsInFlightListLoadFromReCachingStaleConfigs {

--- a/QonversionTests/Managers/QONRemoteConfigManagerInvalidationTests.m
+++ b/QonversionTests/Managers/QONRemoteConfigManagerInvalidationTests.m
@@ -429,6 +429,59 @@
   XCTAssertNil(errorB);
 }
 
+- (void)testStashLeftByUserChangeFailureCannotResurfaceLater {
+  // given - the superseded response arrives while the user is unstable, so
+  // the re-issue can only queue, and the identity change then fails - the
+  // one drain path that bypasses fireRemoteConfig
+  __block BOOL userStable = YES;
+  OCMStub([self.mockProductCenterManager isUserStable]).andDo(^(NSInvocation *invocation) {
+    [invocation setReturnValue:&userStable];
+  });
+  OCMStub([self.mockUserPropertiesManager forceSendProperties:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
+    __unsafe_unretained QONUserPropertiesEmptyCompletionHandler flushCompletion = nil;
+    [invocation getArgument:&flushCompletion atIndex:2];
+    if (flushCompletion) {
+      flushCompletion();
+    }
+  });
+  __block QONRemoteConfigCompletionHandler serviceCompletion = nil;
+  OCMStub([self.mockService loadRemoteConfig:[OCMArg any] completion:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
+    __unsafe_unretained QONRemoteConfigCompletionHandler completion = nil;
+    [invocation getArgument:&completion atIndex:3];
+    serviceCompletion = [completion copy];
+  });
+
+  __block QONRemoteConfig *deliveredA = nil;
+  [self.manager obtainRemoteConfigWithContextKey:@"ctx"
+                                      completion:^(QONRemoteConfig * _Nullable remoteConfig, NSError * _Nullable error) {
+    deliveredA = remoteConfig;
+  }];
+  [self.manager invalidateRemoteConfigsCache];
+  userStable = NO;
+  QONRemoteConfig *supersededConfig = OCMClassMock([QONRemoteConfig class]);
+  serviceCompletion(supersededConfig, nil);
+  [self.manager userChangingRequestFailedWithError:[NSError errorWithDomain:@"test" code:1 userInfo:nil]];
+
+  // the snapshot belt still serves the original caller with the baseline
+  XCTAssertEqual(deliveredA, supersededConfig);
+
+  // when - the user stabilises and a later load for the same key fails
+  userStable = YES;
+  __block QONRemoteConfig *lateConfig = nil;
+  __block NSError *lateError = nil;
+  [self.manager obtainRemoteConfigWithContextKey:@"ctx"
+                                      completion:^(QONRemoteConfig * _Nullable remoteConfig, NSError * _Nullable error) {
+    lateConfig = remoteConfig;
+    lateError = error;
+  }];
+  serviceCompletion(nil, [NSError errorWithDomain:@"test" code:400 userInfo:nil]);
+
+  // then - the error surfaces; a leftover stash must not deliver a
+  // long-superseded evaluation as a success
+  XCTAssertNil(lateConfig);
+  XCTAssertNotNil(lateError);
+}
+
 - (void)testUserSwitchMidFlightDoesNotReissue {
   // given - a load is in flight
   [self stubUserStableAndImmediatePropertiesFlush];

--- a/QonversionTests/Managers/QONRemoteConfigManagerInvalidationTests.m
+++ b/QonversionTests/Managers/QONRemoteConfigManagerInvalidationTests.m
@@ -18,6 +18,7 @@
 #import "QONFallbackService.h"
 #import "QONFallbackObject.h"
 #import "QONErrors.h"
+#import "Qonversion.h"
 
 /*
  * Contract tests for the cache invalidation seams (DEV-1231 + DEV-1236 B4).
@@ -340,6 +341,94 @@
   XCTAssertNil(self.manager.loadingStates[@"ctx"].loadedConfig);
 }
 
+- (void)testFailedReissuePrefersBaselineOverBundledFallback {
+  // given - a bundled fallback EXISTS for the key, and a load is in flight
+  [self stubUserStableAndImmediatePropertiesFlush];
+  QONRemoteConfig *bundledConfig = OCMClassMock([QONRemoteConfig class]);
+  QONRemoteConfigurationSource *bundledSource = OCMClassMock([QONRemoteConfigurationSource class]);
+  OCMStub([bundledConfig source]).andReturn(bundledSource);
+  OCMStub([bundledSource contextKey]).andReturn(@"ctx");
+  QONFallbackObject *fallbackObject = [QONFallbackObject new];
+  fallbackObject.remoteConfigList = [[QONRemoteConfigList alloc] initWithRemoteConfigs:@[bundledConfig]];
+  OCMStub([self.mockFallbackService obtainFallbackData]).andReturn(fallbackObject);
+
+  __block NSUInteger singleCalls = 0;
+  __block QONRemoteConfigCompletionHandler serviceCompletion = nil;
+  OCMStub([self.mockService loadRemoteConfig:[OCMArg any] completion:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
+    singleCalls += 1;
+    __unsafe_unretained QONRemoteConfigCompletionHandler completion = nil;
+    [invocation getArgument:&completion atIndex:3];
+    serviceCompletion = [completion copy];
+  });
+
+  __block QONRemoteConfig *deliveredConfig = nil;
+  __block NSError *deliveredError = nil;
+  [self.manager obtainRemoteConfigWithContextKey:@"ctx"
+                                      completion:^(QONRemoteConfig * _Nullable remoteConfig, NSError * _Nullable error) {
+    deliveredConfig = remoteConfig;
+    deliveredError = error;
+  }];
+
+  // when - invalidation mid-flight, the superseded response triggers a
+  // re-issue, and the retry fails in a FALLBACK-ELIGIBLE way
+  [self.manager invalidateRemoteConfigsCache];
+  QONRemoteConfig *supersededConfig = OCMClassMock([QONRemoteConfig class]);
+  QONRemoteConfigCompletionHandler firstServiceCompletion = serviceCompletion;
+  firstServiceCompletion(supersededConfig, nil);
+  XCTAssertEqual(singleCalls, 2);
+  serviceCompletion(nil, [NSError errorWithDomain:NSURLErrorDomain
+                                             code:NSURLErrorNotConnectedToInternet
+                                         userInfo:nil]);
+
+  // then - the real user-specific evaluation seconds old outranks the static
+  // bundled payload
+  XCTAssertEqual(deliveredConfig, supersededConfig);
+  XCTAssertNil(deliveredError);
+  XCTAssertNil(self.manager.loadingStates[@"ctx"].loadedConfig);
+}
+
+- (void)testLateJoinerDuringRetryReceivesBaseline {
+  // given - a load is in flight
+  [self stubUserStableAndImmediatePropertiesFlush];
+  __block QONRemoteConfigCompletionHandler serviceCompletion = nil;
+  OCMStub([self.mockService loadRemoteConfig:[OCMArg any] completion:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
+    __unsafe_unretained QONRemoteConfigCompletionHandler completion = nil;
+    [invocation getArgument:&completion atIndex:3];
+    serviceCompletion = [completion copy];
+  });
+
+  __block QONRemoteConfig *deliveredA = nil;
+  __block NSError *errorA = nil;
+  [self.manager obtainRemoteConfigWithContextKey:@"ctx"
+                                      completion:^(QONRemoteConfig * _Nullable remoteConfig, NSError * _Nullable error) {
+    deliveredA = remoteConfig;
+    errorA = error;
+  }];
+
+  // when - invalidation mid-flight, the superseded response triggers a
+  // re-issue, a SECOND caller joins while the retry is flying, and the
+  // retry fails without a fallback (no bundled data)
+  [self.manager invalidateRemoteConfigsCache];
+  QONRemoteConfig *supersededConfig = OCMClassMock([QONRemoteConfig class]);
+  QONRemoteConfigCompletionHandler firstServiceCompletion = serviceCompletion;
+  firstServiceCompletion(supersededConfig, nil);
+  __block QONRemoteConfig *deliveredB = nil;
+  __block NSError *errorB = nil;
+  [self.manager obtainRemoteConfigWithContextKey:@"ctx"
+                                      completion:^(QONRemoteConfig * _Nullable remoteConfig, NSError * _Nullable error) {
+    deliveredB = remoteConfig;
+    errorB = error;
+  }];
+  serviceCompletion(nil, [NSError errorWithDomain:@"test" code:400 userInfo:nil]);
+
+  // then - the never-worse guarantee is uniform: the late joiner gets the
+  // baseline too, not the retry error
+  XCTAssertEqual(deliveredA, supersededConfig);
+  XCTAssertEqual(deliveredB, supersededConfig);
+  XCTAssertNil(errorA);
+  XCTAssertNil(errorB);
+}
+
 - (void)testUserSwitchMidFlightDoesNotReissue {
   // given - a load is in flight
   [self stubUserStableAndImmediatePropertiesFlush];
@@ -394,8 +483,9 @@
   // when - the request is short-circuited by the local rate limiter (since
   // fallbacks are no longer cached, offline repeat calls hit the limiter
   // instead of the old cached-fallback fast path)
-  // shouldFireFallback matches on the code alone, so the domain is irrelevant
-  serviceCompletion(nil, [NSError errorWithDomain:@"test"
+  // The rate-limit arm of shouldFireFallback is domain-pinned (code 35
+  // collides with unrelated domains, e.g. POSIX EAGAIN)
+  serviceCompletion(nil, [NSError errorWithDomain:QonversionErrorDomain
                                              code:QONErrorCodeApiRateLimitExceeded
                                          userInfo:nil]);
 

--- a/Sample/AppState.swift
+++ b/Sample/AppState.swift
@@ -181,6 +181,11 @@ class AppState: ObservableObject {
         }
     }
     
+    func invalidateRemoteConfigsCache() {
+        Qonversion.shared().invalidateRemoteConfigsCache()
+        successMessage = "Cache invalidated — the next request fetches a fresh evaluation"
+    }
+
     func loadRemoteConfigList(contextKeys: [String]?) async {
         isLoading = true
         errorMessage = nil

--- a/Sample/Views/RemoteConfigsView.swift
+++ b/Sample/Views/RemoteConfigsView.swift
@@ -52,6 +52,10 @@ struct RemoteConfigsView: View {
                             await appState.loadRemoteConfig(contextKey: key)
                         }
                     }
+
+                    ActionButton(title: "Invalidate Remote Configs Cache", color: .orange) {
+                        appState.invalidateRemoteConfigsCache()
+                    }
                 }
                 .padding()
                 .background(Color(.systemGray6))

--- a/Sources/Qonversion/Public/Qonversion.h
+++ b/Sources/Qonversion/Public/Qonversion.h
@@ -317,7 +317,8 @@ NS_SWIFT_NAME(remoteConfigList(contextKeys:includeEmptyContextKey:completion:));
  This method performs no network request itself and has no completion — it only
  marks the cached values as stale. A remoteConfig load that is already in
  flight when this method is called is re-issued once, so its waiting
- completions receive a fresh evaluation rather than the superseded one; an
+ completions receive a fresh evaluation rather than the superseded one (if the
+ re-issued request fails, the superseded evaluation is delivered instead); an
  in-flight remoteConfigList load completes with the evaluation it started
  with, and any subsequent call fetches fresh values.
 
@@ -325,21 +326,20 @@ NS_SWIFT_NAME(remoteConfigList(contextKeys:includeEmptyContextKey:completion:));
  immediately, for example:
  - after setting a batch of user properties via setUserProperty: /
    setCustomUserProperty: that your remote config targeting depends on;
- - after network connectivity is restored, if a previous call could have
-   returned a locally bundled fallback config;
  - on returning to the foreground in long-living sessions, if the targeting
    could have changed server-side.
 
  You do NOT need to call it after identify: — the SDK invalidates the cache on
- identity changes automatically.
+ identity changes automatically. You also do not need it to recover from a
+ locally bundled fallback config — fallbacks are never cached, so the next
+ call retries the network automatically.
 
  @note This method only affects the remoteConfig / remoteConfigList cache.
  No-Codes screens are cached and shown independently and are not affected.
  @note Call it from the same thread you use for the other Qonversion calls
- (typically the main thread). The staleness marker itself is thread-safe, but
- the cached-state cleanup shares the SDK's regular threading model.
+ (typically the main thread).
 
- @see remoteConfig:
+ @see remoteConfig:completion:
  @see remoteConfigList:
  */
 - (void)invalidateRemoteConfigsCache;

--- a/Sources/Qonversion/Public/Qonversion.h
+++ b/Sources/Qonversion/Public/Qonversion.h
@@ -111,6 +111,8 @@ static NSString *const QonversionErrorDomain = @"com.qonversion.io";
  To set custom user property, use `setCustomUserProperty` method instead.
  @param key - Defined enum key that will be transformed to string
  @param value - Property value
+ @see invalidateRemoteConfigsCache if your remote config targeting depends on
+ this property and you need the updated evaluation immediately
  */
 - (void)setUserProperty:(QONUserPropertyKey)key value:(NSString *)value;
 
@@ -118,6 +120,8 @@ static NSString *const QonversionErrorDomain = @"com.qonversion.io";
  Sets custom user property
  @param key - Custom property key
  @param value - Property value
+ @see invalidateRemoteConfigsCache if your remote config targeting depends on
+ this property and you need the updated evaluation immediately
  */
 - (void)setCustomUserProperty:(NSString *)key value:(NSString *)value;
 
@@ -306,13 +310,39 @@ NS_SWIFT_NAME(remoteConfigList(contextKeys:includeEmptyContextKey:completion:));
 - (void)remoteConfigList:(QONRemoteConfigListCompletionHandler)completion;
 
 /**
- Drops the cached remote configs so the next remoteConfig or remoteConfigList
- call fetches a fresh targeting evaluation from the server instead of
- returning the in-memory copy. Call it after changing user properties that
- participate in remote config targeting when you need the updated evaluation
- immediately.
+ Invalidates the in-memory cache of remote configs so the next remoteConfig or
+ remoteConfigList call fetches a fresh targeting evaluation from the server
+ instead of returning the cached copy.
+
+ This method performs no network request itself and has no completion — it only
+ marks the cached values as stale. A remoteConfig load that is already in
+ flight when this method is called is re-issued once, so its waiting
+ completions receive a fresh evaluation rather than the superseded one; an
+ in-flight remoteConfigList load completes with the evaluation it started
+ with, and any subsequent call fetches fresh values.
+
+ Call it when the targeting inputs changed and you need the change reflected
+ immediately, for example:
+ - after setting a batch of user properties via setUserProperty: /
+   setCustomUserProperty: that your remote config targeting depends on;
+ - after network connectivity is restored, if a previous call could have
+   returned a locally bundled fallback config;
+ - on returning to the foreground in long-living sessions, if the targeting
+   could have changed server-side.
+
+ You do NOT need to call it after identify: — the SDK invalidates the cache on
+ identity changes automatically.
+
+ @note This method only affects the remoteConfig / remoteConfigList cache.
+ No-Codes screens are cached and shown independently and are not affected.
+ @note Call it from the same thread you use for the other Qonversion calls
+ (typically the main thread). The staleness marker itself is thread-safe, but
+ the cached-state cleanup shares the SDK's regular threading model.
+
+ @see remoteConfig:
+ @see remoteConfigList:
  */
-- (void)refreshRemoteConfigs NS_SWIFT_NAME(refreshRemoteConfigs());
+- (void)invalidateRemoteConfigsCache;
 
 /**
  This function should be used for the test purposes only.

--- a/Sources/Qonversion/Public/Qonversion.h
+++ b/Sources/Qonversion/Public/Qonversion.h
@@ -306,6 +306,15 @@ NS_SWIFT_NAME(remoteConfigList(contextKeys:includeEmptyContextKey:completion:));
 - (void)remoteConfigList:(QONRemoteConfigListCompletionHandler)completion;
 
 /**
+ Drops the cached remote configs so the next remoteConfig or remoteConfigList
+ call fetches a fresh targeting evaluation from the server instead of
+ returning the in-memory copy. Call it after changing user properties that
+ participate in remote config targeting when you need the updated evaluation
+ immediately.
+ */
+- (void)refreshRemoteConfigs NS_SWIFT_NAME(refreshRemoteConfigs());
+
+/**
  This function should be used for the test purposes only.
  Do not forget to delete the usage of this function before the release.
  Use this function to attach the user to the remote configuration.

--- a/Sources/Qonversion/Public/Qonversion.m
+++ b/Sources/Qonversion/Public/Qonversion.m
@@ -241,16 +241,16 @@ static bool _isInitialized = NO;
   [self.remoteConfigManager obtainRemoteConfigWithContextKey:contextKey completion:completion];
 }
 
-- (void)refreshRemoteConfigs {
-  [self.remoteConfigManager refreshRemoteConfigs];
-}
-
 - (void)remoteConfigList:(NSArray<NSString *> *)contextKeys includeEmptyContextKey:(BOOL)includeEmptyContextKey completion:(QONRemoteConfigListCompletionHandler)completion {
   [self.remoteConfigManager obtainRemoteConfigListWithContextKeys:contextKeys includeEmptyContextKey:includeEmptyContextKey completion:completion];
 }
 
 - (void)remoteConfigList:(QONRemoteConfigListCompletionHandler)completion {
   [self.remoteConfigManager obtainRemoteConfigList:completion];
+}
+
+- (void)invalidateRemoteConfigsCache {
+  [self.remoteConfigManager invalidateRemoteConfigsCache];
 }
 
 - (void)attachUserToExperiment:(NSString *)experimentId groupId:(NSString *)groupId completion:(QONExperimentAttachCompletionHandler)completion {

--- a/Sources/Qonversion/Public/Qonversion.m
+++ b/Sources/Qonversion/Public/Qonversion.m
@@ -241,6 +241,10 @@ static bool _isInitialized = NO;
   [self.remoteConfigManager obtainRemoteConfigWithContextKey:contextKey completion:completion];
 }
 
+- (void)refreshRemoteConfigs {
+  [self.remoteConfigManager refreshRemoteConfigs];
+}
+
 - (void)remoteConfigList:(NSArray<NSString *> *)contextKeys includeEmptyContextKey:(BOOL)includeEmptyContextKey completion:(QONRemoteConfigListCompletionHandler)completion {
   [self.remoteConfigManager obtainRemoteConfigListWithContextKeys:contextKeys includeEmptyContextKey:includeEmptyContextKey completion:completion];
 }

--- a/Sources/Qonversion/Qonversion/Main/QNProductCenterManager/QNProductCenterManager.m
+++ b/Sources/Qonversion/Qonversion/Main/QNProductCenterManager/QNProductCenterManager.m
@@ -312,8 +312,10 @@ static NSString * const kUserDefaultsSuiteName = @"qonversion.product-center.sui
       // external identity are now attached, so cached configs may no longer
       // reflect the server-side targeting evaluation. Drop them
       // (non-destructively) so the next remoteConfig call refetches
-      // (DEV-1236 B4).
-      [weakSelf.remoteConfigManager refreshRemoteConfigs];
+      // (DEV-1236 B4). Invalidate BEFORE handlePendingRequests: the replay
+      // must miss the cache, or queued completions would be served the
+      // pre-identify evaluation and orphaned by the cache-hit path.
+      [weakSelf.remoteConfigManager invalidateRemoteConfigsCache];
       [weakSelf handlePendingRequests:nil];
       [weakSelf fireIdentitySuccess:identityId];
     } else {

--- a/Sources/Qonversion/Qonversion/Main/QNProductCenterManager/QNProductCenterManager.m
+++ b/Sources/Qonversion/Qonversion/Main/QNProductCenterManager/QNProductCenterManager.m
@@ -308,6 +308,12 @@ static NSString * const kUserDefaultsSuiteName = @"qonversion.product-center.sui
     [weakSelf.userInfoService storeCustomIdentityUserID:identityId];
     
     if ([currentUserID isEqualToString:result]) {
+      // The uid did not change, but the identity did — user properties and the
+      // external identity are now attached, so cached configs may no longer
+      // reflect the server-side targeting evaluation. Drop them
+      // (non-destructively) so the next remoteConfig call refetches
+      // (DEV-1236 B4).
+      [weakSelf.remoteConfigManager refreshRemoteConfigs];
       [weakSelf handlePendingRequests:nil];
       [weakSelf fireIdentitySuccess:identityId];
     } else {

--- a/Sources/Qonversion/Qonversion/Main/QONRemoteConfigManager/QONRemoteConfigLoadingState.h
+++ b/Sources/Qonversion/Qonversion/Main/QONRemoteConfigManager/QONRemoteConfigLoadingState.h
@@ -24,4 +24,11 @@
 // and the bump precedes the observation.
 @property (nonatomic, assign) NSUInteger reissuedForGeneration;
 
+// The superseded (but valid) evaluation held while its re-issued retry is in
+// flight. A failed retry degrades to it — for everyone, including callers
+// who join during the retry window — and it outranks the static bundled
+// fallback: a real user-specific evaluation seconds old beats
+// shipped-in-binary defaults.
+@property (nonatomic, strong, nullable) QONRemoteConfig *retryBaseline;
+
 @end

--- a/Sources/Qonversion/Qonversion/Main/QONRemoteConfigManager/QONRemoteConfigLoadingState.h
+++ b/Sources/Qonversion/Qonversion/Main/QONRemoteConfigManager/QONRemoteConfigLoadingState.h
@@ -15,10 +15,13 @@
 @property (nonatomic, strong, nonnull) NSMutableArray<QONRemoteConfigCompletionHandler> *completions;
 @property (nonatomic, assign) BOOL isInProgress;
 
-// Last cache generation an awaited superseded in-flight load was re-issued
-// for — caps the retry at one per invalidation. Zero means "never": a moved
-// generation observed by a response is always >= 1, since the counter only
-// increments and the bump precedes the observation.
+// Last cache generation a superseded in-flight load was re-issued for.
+// Defense-in-depth against a concurrent re-entry: the retry count is bounded
+// structurally by the per-key isInProgress serialisation (one load, hence one
+// superseded response, per invalidation), so this guard is not reachable in
+// the current single-threaded flow. Zero means "never": a moved generation
+// observed by a response is always >= 1, since the counter only increments
+// and the bump precedes the observation.
 @property (nonatomic, assign) NSUInteger reissuedForGeneration;
 
 @end

--- a/Sources/Qonversion/Qonversion/Main/QONRemoteConfigManager/QONRemoteConfigLoadingState.h
+++ b/Sources/Qonversion/Qonversion/Main/QONRemoteConfigManager/QONRemoteConfigLoadingState.h
@@ -15,4 +15,10 @@
 @property (nonatomic, strong, nonnull) NSMutableArray<QONRemoteConfigCompletionHandler> *completions;
 @property (nonatomic, assign) BOOL isInProgress;
 
+// Last cache generation an awaited superseded in-flight load was re-issued
+// for — caps the retry at one per invalidation. Zero means "never": a moved
+// generation observed by a response is always >= 1, since the counter only
+// increments and the bump precedes the observation.
+@property (nonatomic, assign) NSUInteger reissuedForGeneration;
+
 @end

--- a/Sources/Qonversion/Qonversion/Main/QONRemoteConfigManager/QONRemoteConfigManager.h
+++ b/Sources/Qonversion/Qonversion/Main/QONRemoteConfigManager/QONRemoteConfigManager.h
@@ -32,6 +32,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)detachUserFromRemoteConfiguration:(NSString *)remoteConfigurationId completion:(QONRemoteConfigurationAttachCompletionHandler)completion;
 - (void)userHasBeenChanged;
 
+/**
+ Drops every cached remote config so the next load fetches a fresh targeting
+ evaluation. Non-destructive: loading states and pending completions survive,
+ and the cache generation bump keeps in-flight loads from re-caching a
+ pre-refresh response (DEV-1236 B4).
+ */
+- (void)refreshRemoteConfigs;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Qonversion/Qonversion/Main/QONRemoteConfigManager/QONRemoteConfigManager.h
+++ b/Sources/Qonversion/Qonversion/Main/QONRemoteConfigManager/QONRemoteConfigManager.h
@@ -33,12 +33,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)userHasBeenChanged;
 
 /**
- Drops every cached remote config so the next load fetches a fresh targeting
- evaluation. Non-destructive: loading states and pending completions survive,
- and the cache generation bump keeps in-flight loads from re-caching a
- pre-refresh response (DEV-1236 B4).
+ Marks every cached remote config stale so the next load fetches a fresh
+ targeting evaluation. Non-destructive: loading states and pending completions
+ survive; the cache generation bump keeps in-flight loads from re-caching a
+ superseded response and re-issues an awaited in-flight load once
+ (DEV-1236 B4). Runs synchronously on the caller thread — see the
+ implementation note about ordering with handlePendingRequests.
  */
-- (void)refreshRemoteConfigs;
+- (void)invalidateRemoteConfigsCache;
 
 @end
 

--- a/Sources/Qonversion/Qonversion/Main/QONRemoteConfigManager/QONRemoteConfigManager.m
+++ b/Sources/Qonversion/Qonversion/Main/QONRemoteConfigManager/QONRemoteConfigManager.m
@@ -18,6 +18,7 @@
 #import "QONFallbackService.h"
 #import "NSError+Sugare.h"
 #import "QONFallbackObject.h"
+#import "QNUtils.h"
 
 static NSString *const kEmptyContextKey = @"";
 
@@ -125,6 +126,9 @@ static NSString *const kEmptyContextKey = @"";
     // the property flush and the request.
     [self.userPropertiesManager forceSendProperties:nil];
     QONRemoteConfig *cachedConfig = loadingState.loadedConfig;
+    // A retry resolved by a warm cache consumes its stashed baseline — a
+    // leftover stash must not resurface on a later, unrelated failure.
+    loadingState.retryBaseline = nil;
     // Queued completions can be stranded on a warm state (e.g. a list load
     // re-caches a key whose superseded single-key load was re-issued, or a
     // completion queued while the user was unstable meets a warm cache on
@@ -153,6 +157,10 @@ static NSString *const kEmptyContextKey = @"";
           }
 
           if (remoteConfig) {
+            // The only signal a developer gets that this is not a fresh
+            // targeting evaluation — a silently served bundle would let a
+            // stale-config loop ship unnoticed.
+            QONVERSION_LOG(@"⚠️ Serving the bundled fallback remote config for context key '%@' — not a fresh targeting evaluation (%@)", contextKey ?: @"", error.localizedDescription);
             [weakSelf fireRemoteConfig:remoteConfig contextKey:contextKey loadingState:loadingState error:nil generation:generationAtStart isFallback:YES completion:completion];
           } else {
             [weakSelf fireRemoteConfig:nil contextKey:contextKey loadingState:loadingState error:error generation:generationAtStart isFallback:NO completion:completion];
@@ -169,6 +177,16 @@ static NSString *const kEmptyContextKey = @"";
 
 - (void)fireRemoteConfig:(QONRemoteConfig *)remoteConfig contextKey:(NSString *)contextKey loadingState:(QONRemoteConfigLoadingState *)loadingState error:(NSError *)error generation:(NSUInteger)generation isFallback:(BOOL)isFallback completion:(QONRemoteConfigCompletionHandler)completion {
   if (error) {
+    QONRemoteConfig *baseline = loadingState.retryBaseline;
+    loadingState.retryBaseline = nil;
+    if (baseline) {
+      // A failed retry of a superseded load degrades to the baseline — a
+      // real user-specific evaluation seconds old — for everyone, including
+      // callers who joined during the retry window.
+      [self executeRemoteConfigCompletionsWithContextKey:contextKey remoteConfig:baseline error:nil];
+      completion(baseline, nil);
+      return;
+    }
     [self executeRemoteConfigCompletionsWithContextKey:contextKey remoteConfig:nil error:error];
     completion(nil, error);
     return;
@@ -178,12 +196,19 @@ static NSString *const kEmptyContextKey = @"";
     // The bundled fallback is a local last-resort payload, not a fresh
     // targeting evaluation — deliver it without caching so the next call
     // retries the network instead of pinning the fallback until the next
-    // invalidation. No re-issue either: the network just failed.
-    [self executeRemoteConfigCompletionsWithContextKey:contextKey remoteConfig:remoteConfig error:nil];
-    completion(remoteConfig, nil);
+    // invalidation. No re-issue either: the network just failed. A stashed
+    // retry baseline outranks the bundle: a real user-specific evaluation
+    // seconds old beats shipped-in-binary defaults.
+    QONRemoteConfig *baseline = loadingState.retryBaseline;
+    loadingState.retryBaseline = nil;
+    QONRemoteConfig *result = baseline ?: remoteConfig;
+    [self executeRemoteConfigCompletionsWithContextKey:contextKey remoteConfig:result error:nil];
+    completion(result, nil);
     return;
   }
 
+  // A successful (or delivered-as-is) response supersedes any stashed baseline.
+  loadingState.retryBaseline = nil;
   NSUInteger currentGeneration = self.cacheGeneration;
   if (generation == currentGeneration) {
     // Cache only when no invalidation happened while the load was in flight —
@@ -206,6 +231,10 @@ static NSString *const kEmptyContextKey = @"";
     // concurrent re-entry; the retry count is bounded structurally — one
     // load, hence one superseded response, per invalidation.
     loadingState.reissuedForGeneration = currentGeneration;
+    // The stash makes the never-worse guarantee uniform: the retry's failure
+    // handlers prefer it over both the error and the bundled fallback,
+    // reaching late joiners queued during the retry window too.
+    loadingState.retryBaseline = remoteConfig;
     NSArray<QONRemoteConfigCompletionHandler> *waiters = [loadingState.completions copy];
     [loadingState.completions removeAllObjects];
     QONRemoteConfig *baseline = remoteConfig;
@@ -353,6 +382,7 @@ static NSString *const kEmptyContextKey = @"";
         // The bundled fallback is a local last-resort payload, not a fresh
         // targeting evaluation — deliver it without caching (see the
         // single-key path), so the next call retries the network.
+        QONVERSION_LOG(@"⚠️ Serving the bundled fallback remote config list — not a fresh targeting evaluation (%@)", error.localizedDescription);
         completion(remoteConfigList, nil);
       } else {
         completion(nil, error);

--- a/Sources/Qonversion/Qonversion/Main/QONRemoteConfigManager/QONRemoteConfigManager.m
+++ b/Sources/Qonversion/Qonversion/Main/QONRemoteConfigManager/QONRemoteConfigManager.m
@@ -124,7 +124,14 @@ static NSString *const kEmptyContextKey = @"";
     // call must still reach the server — otherwise a cache hit swallows both
     // the property flush and the request.
     [self.userPropertiesManager forceSendProperties:nil];
-    return completion(loadingState.loadedConfig, nil);
+    QONRemoteConfig *cachedConfig = loadingState.loadedConfig;
+    // Queued completions can be stranded on a warm state (e.g. a list load
+    // re-caches a key whose superseded single-key load was re-issued, or a
+    // completion queued while the user was unstable meets a warm cache on
+    // replay) — drain them together with the direct caller, or they never
+    // fire at all.
+    [self executeRemoteConfigCompletionsWithContextKey:contextKey remoteConfig:cachedConfig error:nil];
+    return completion(cachedConfig, nil);
   }
   
   loadingState.isInProgress = YES;
@@ -182,18 +189,34 @@ static NSString *const kEmptyContextKey = @"";
     // Cache only when no invalidation happened while the load was in flight —
     // a superseded evaluation must not be re-cached as fresh.
     loadingState.loadedConfig = remoteConfig;
-  } else if (loadingState.reissuedForGeneration != currentGeneration) {
+  } else if ([self loadingStateForContextKey:contextKey] == loadingState &&
+             loadingState.reissuedForGeneration != currentGeneration) {
     // The cache was invalidated while this load was in flight, so this
-    // evaluation is already superseded. Re-issue the load once per generation
-    // so the waiters receive a fresh evaluation instead of the stale one.
-    // Unlike Android, the initiating caller's completion is NOT queued in
-    // loadingState.completions — it is the `completion` argument here — so the
-    // re-issue must not be gated on completions.count: there is always at
-    // least the direct completion awaiting. If this generation already got its
-    // retry, deliver as-is — an invalidation storm must not turn into a
-    // request loop.
+    // evaluation is already superseded. Re-issue the load once so the waiters
+    // receive a fresh evaluation instead of the stale one. The state must
+    // still be live: a user switch replaces the map, and an orphaned state
+    // must not fire a request nobody awaits. Unlike Android, the initiating
+    // caller's completion is NOT queued in loadingState.completions — it is
+    // the `completion` argument here — so the re-issue is not gated on
+    // completions.count. The queued waiters are snapshotted and carried
+    // through the retry together with the direct completion, keeping the
+    // superseded (but valid) evaluation as a baseline: a failed retry
+    // degrades to the baseline instead of surfacing an error where the
+    // caller previously received a success. The generation cap guards a
+    // concurrent re-entry; the retry count is bounded structurally — one
+    // load, hence one superseded response, per invalidation.
     loadingState.reissuedForGeneration = currentGeneration;
-    [self obtainRemoteConfigWithContextKey:contextKey completion:completion];
+    NSArray<QONRemoteConfigCompletionHandler> *waiters = [loadingState.completions copy];
+    [loadingState.completions removeAllObjects];
+    QONRemoteConfig *baseline = remoteConfig;
+    QONRemoteConfigCompletionHandler deliverToAll = ^(QONRemoteConfig * _Nullable freshConfig, NSError * _Nullable retryError) {
+      QONRemoteConfig *result = freshConfig ?: baseline;
+      for (QONRemoteConfigCompletionHandler waiter in waiters) {
+        waiter(result, nil);
+      }
+      completion(result, nil);
+    };
+    [self obtainRemoteConfigWithContextKey:contextKey completion:deliverToAll];
     return;
   }
   [self executeRemoteConfigCompletionsWithContextKey:contextKey remoteConfig:remoteConfig error:nil];

--- a/Sources/Qonversion/Qonversion/Main/QONRemoteConfigManager/QONRemoteConfigManager.m
+++ b/Sources/Qonversion/Qonversion/Main/QONRemoteConfigManager/QONRemoteConfigManager.m
@@ -80,6 +80,10 @@ static NSString *const kEmptyContextKey = @"";
   }
 }
 
+- (void)refreshRemoteConfigs {
+  [self invalidateLoadedConfigs];
+}
+
 - (void)userHasBeenChanged {
   [self bumpCacheGeneration];
   self.loadingStates = [NSMutableDictionary new];

--- a/Sources/Qonversion/Qonversion/Main/QONRemoteConfigManager/QONRemoteConfigManager.m
+++ b/Sources/Qonversion/Qonversion/Main/QONRemoteConfigManager/QONRemoteConfigManager.m
@@ -80,7 +80,14 @@ static NSString *const kEmptyContextKey = @"";
   }
 }
 
-- (void)refreshRemoteConfigs {
+// Public cache invalidation seam (DEV-1236 B4). Deliberately synchronous on
+// the caller thread: handlePendingRequests is synchronous too, and the
+// same-uid identify path relies on the invalidate-then-replay order — hopping
+// only this call to the main queue would let the replay hit a still-warm
+// cache and orphan queued completions. The generation bump is taken under the
+// lock; the loadingStates sweep shares the manager's pre-existing
+// unsynchronized access pattern (same as handlePendingRequests).
+- (void)invalidateRemoteConfigsCache {
   [self invalidateLoadedConfigs];
 }
 
@@ -139,34 +146,58 @@ static NSString *const kEmptyContextKey = @"";
           }
 
           if (remoteConfig) {
-            [weakSelf fireRemoteConfig:remoteConfig contextKey:contextKey loadingState:loadingState error:nil generation:generationAtStart completion:completion];
+            [weakSelf fireRemoteConfig:remoteConfig contextKey:contextKey loadingState:loadingState error:nil generation:generationAtStart isFallback:YES completion:completion];
           } else {
-            [weakSelf fireRemoteConfig:nil contextKey:contextKey loadingState:loadingState error:error generation:generationAtStart completion:completion];
+            [weakSelf fireRemoteConfig:nil contextKey:contextKey loadingState:loadingState error:error generation:generationAtStart isFallback:NO completion:completion];
           }
         } else {
-          [weakSelf fireRemoteConfig:nil contextKey:contextKey loadingState:loadingState error:error generation:generationAtStart completion:completion];
+          [weakSelf fireRemoteConfig:nil contextKey:contextKey loadingState:loadingState error:error generation:generationAtStart isFallback:NO completion:completion];
         }
       } else {
-        [weakSelf fireRemoteConfig:remoteConfig contextKey:contextKey loadingState:loadingState error:nil generation:generationAtStart completion:completion];
+        [weakSelf fireRemoteConfig:remoteConfig contextKey:contextKey loadingState:loadingState error:nil generation:generationAtStart isFallback:NO completion:completion];
       }
     }];
   }];
 }
 
-- (void)fireRemoteConfig:(QONRemoteConfig *)remoteConfig contextKey:(NSString *)contextKey loadingState:(QONRemoteConfigLoadingState *)loadingState error:(NSError *)error generation:(NSUInteger)generation completion:(QONRemoteConfigCompletionHandler)completion {
+- (void)fireRemoteConfig:(QONRemoteConfig *)remoteConfig contextKey:(NSString *)contextKey loadingState:(QONRemoteConfigLoadingState *)loadingState error:(NSError *)error generation:(NSUInteger)generation isFallback:(BOOL)isFallback completion:(QONRemoteConfigCompletionHandler)completion {
   if (error) {
     [self executeRemoteConfigCompletionsWithContextKey:contextKey remoteConfig:nil error:error];
     completion(nil, error);
-  } else {
-    if (generation == self.cacheGeneration) {
-      // Cache only when no invalidation happened while the load was in flight —
-      // a pre-attach evaluation must not be re-cached as fresh. The response is
-      // still delivered below either way.
-      loadingState.loadedConfig = remoteConfig;
-    }
+    return;
+  }
+
+  if (isFallback) {
+    // The bundled fallback is a local last-resort payload, not a fresh
+    // targeting evaluation — deliver it without caching so the next call
+    // retries the network instead of pinning the fallback until the next
+    // invalidation. No re-issue either: the network just failed.
     [self executeRemoteConfigCompletionsWithContextKey:contextKey remoteConfig:remoteConfig error:nil];
     completion(remoteConfig, nil);
+    return;
   }
+
+  NSUInteger currentGeneration = self.cacheGeneration;
+  if (generation == currentGeneration) {
+    // Cache only when no invalidation happened while the load was in flight —
+    // a superseded evaluation must not be re-cached as fresh.
+    loadingState.loadedConfig = remoteConfig;
+  } else if (loadingState.reissuedForGeneration != currentGeneration) {
+    // The cache was invalidated while this load was in flight, so this
+    // evaluation is already superseded. Re-issue the load once per generation
+    // so the waiters receive a fresh evaluation instead of the stale one.
+    // Unlike Android, the initiating caller's completion is NOT queued in
+    // loadingState.completions — it is the `completion` argument here — so the
+    // re-issue must not be gated on completions.count: there is always at
+    // least the direct completion awaiting. If this generation already got its
+    // retry, deliver as-is — an invalidation storm must not turn into a
+    // request loop.
+    loadingState.reissuedForGeneration = currentGeneration;
+    [self obtainRemoteConfigWithContextKey:contextKey completion:completion];
+    return;
+  }
+  [self executeRemoteConfigCompletionsWithContextKey:contextKey remoteConfig:remoteConfig error:nil];
+  completion(remoteConfig, nil);
 }
 
 - (void)obtainRemoteConfigListWithContextKeys:(NSArray<NSString *> *)contextKeys includeEmptyContextKey:(BOOL)includeEmptyContextKey completion:(QONRemoteConfigListCompletionHandler)completion {
@@ -290,15 +321,20 @@ static NSString *const kEmptyContextKey = @"";
       [weakSelf actualizeFallbackData];
       if (weakSelf.fallbackData.remoteConfigList) {
         if (contextKeys) {
-          NSArray<QONRemoteConfig *> *remoteConfigs = [weakSelf remoteConfigsForContextKeys:contextKeys remoteConfigList:remoteConfigList includeEmptyContextKey:includeEmptyContextKey];
+          // Filter the BUNDLED fallback list — the network list is nil here.
+          NSArray<QONRemoteConfig *> *remoteConfigs = [weakSelf remoteConfigsForContextKeys:contextKeys remoteConfigList:weakSelf.fallbackData.remoteConfigList includeEmptyContextKey:includeEmptyContextKey];
           remoteConfigList = [[QONRemoteConfigList alloc] initWithRemoteConfigs:remoteConfigs];
         } else {
           remoteConfigList = [[QONRemoteConfigList alloc] initWithRemoteConfigs:weakSelf.fallbackData.remoteConfigList.remoteConfigs];
         }
+        // The bundled fallback is a local last-resort payload, not a fresh
+        // targeting evaluation — deliver it without caching (see the
+        // single-key path), so the next call retries the network.
+        completion(remoteConfigList, nil);
       } else {
         completion(nil, error);
-        return;
       }
+      return;
     }
 
     if (remoteConfigList && generationAtStart == weakSelf.cacheGeneration) {

--- a/Sources/Qonversion/Qonversion/Main/QONRemoteConfigManager/QONRemoteConfigManager.m
+++ b/Sources/Qonversion/Qonversion/Main/QONRemoteConfigManager/QONRemoteConfigManager.m
@@ -76,6 +76,11 @@ static NSString *const kEmptyContextKey = @"";
   for (NSString *contextKey in self.loadingStates) {
     QONRemoteConfigLoadingState *loadingState = [self loadingStateForContextKey:contextKey];
     if (loadingState) {
+      // The only drain that bypasses fireRemoteConfig — consume the retry
+      // stash here too, or a leftover masks a later unrelated failure as a
+      // stale success. Cleared before the drain so a re-entrant path cannot
+      // re-read it.
+      loadingState.retryBaseline = nil;
       [self executeRemoteConfigCompletionsWithContextKey:contextKey remoteConfig:nil error:error];
     }
   }

--- a/Sources/Qonversion/Qonversion/Services/QNAPIClient/QNAPIClient.m
+++ b/Sources/Qonversion/Qonversion/Services/QNAPIClient/QNAPIClient.m
@@ -354,8 +354,12 @@ NSUInteger const kUnableToParseEmptyDataDefaultCode = 3840;
 }
 
 - (void)loadRemoteConfig:(NSString * _Nullable)contextKey completion:(QNAPIClientDictCompletionHandler)completion {
+  // The context key must participate in the hash (parity with Android):
+  // otherwise distinct-key loads share one bucket, and a post-invalidation
+  // refetch burst across several context keys trips the limiter with a
+  // nil-config error that has no fallback.
   [self.rateLimiter validateRateLimit:QONRateLimitedRequestTypeRemoteConfig
-                                 hash:[self.userID hash]
+                                 hash:[[NSString stringWithFormat:@"%@|%@", self.userID, contextKey ?: @""] hash]
                            completion:^(NSError *rateLimitError) {
     if (rateLimitError != nil) {
       completion(nil, rateLimitError);

--- a/Sources/Qonversion/Qonversion/Services/QNAPIClient/QNAPIClient.m
+++ b/Sources/Qonversion/Qonversion/Services/QNAPIClient/QNAPIClient.m
@@ -354,12 +354,12 @@ NSUInteger const kUnableToParseEmptyDataDefaultCode = 3840;
 }
 
 - (void)loadRemoteConfig:(NSString * _Nullable)contextKey completion:(QNAPIClientDictCompletionHandler)completion {
-  // The context key must participate in the hash (parity with Android):
-  // otherwise distinct-key loads share one bucket, and a post-invalidation
-  // refetch burst across several context keys trips the limiter with a
-  // nil-config error that has no fallback.
+  // The context key must participate in the hash (Android keys its limiter
+  // on the context key): otherwise distinct-key loads share one bucket, and
+  // a post-invalidation refetch burst across several context keys trips the
+  // limiter with a nil-config error.
   [self.rateLimiter validateRateLimit:QONRateLimitedRequestTypeRemoteConfig
-                                 hash:[[NSString stringWithFormat:@"%@|%@", self.userID, contextKey ?: @""] hash]
+                                 hash:[[NSString stringWithFormat:@"%@|%@", self.userID ?: @"", contextKey ?: @""] hash]
                            completion:^(NSError *rateLimitError) {
     if (rateLimitError != nil) {
       completion(nil, rateLimitError);

--- a/Sources/Qonversion/Qonversion/Utils/NSError+Sugare/NSError+Sugare.m
+++ b/Sources/Qonversion/Qonversion/Utils/NSError+Sugare/NSError+Sugare.m
@@ -9,6 +9,7 @@
 #import "NSError+Sugare.h"
 #import "QNInternalConstants.h"
 #import "QONErrors.h"
+#import "Qonversion.h"
 
 @implementation NSError (Sugare)
 
@@ -17,9 +18,12 @@
   // bundled payload exists for: no network attempt was made, so serving the
   // fallback beats surfacing a hard error. Matters since fallbacks are no
   // longer cached — offline repeat calls hit the limiter instead of the old
-  // cached-fallback fast path.
+  // cached-fallback fast path. The rate-limit arm is domain-pinned: code 35
+  // collides with unrelated domains (e.g. POSIX EAGAIN).
+  BOOL isRateLimited = [self.domain isEqualToString:QonversionErrorDomain] &&
+      self.code == QONErrorCodeApiRateLimitExceeded;
   if (self.code == NSURLErrorNotConnectedToInternet ||
-      self.code == QONErrorCodeApiRateLimitExceeded ||
+      isRateLimited ||
       (self.code >= kInternalServerErrorFirstCode && self.code <= kInternalServerErrorLastCode)) {
     return YES;
   } else {

--- a/Sources/Qonversion/Qonversion/Utils/NSError+Sugare/NSError+Sugare.m
+++ b/Sources/Qonversion/Qonversion/Utils/NSError+Sugare/NSError+Sugare.m
@@ -8,11 +8,19 @@
 
 #import "NSError+Sugare.h"
 #import "QNInternalConstants.h"
+#import "QONErrors.h"
 
 @implementation NSError (Sugare)
 
 - (BOOL)shouldFireFallback {
-  if (self.code == NSURLErrorNotConnectedToInternet || (self.code >= kInternalServerErrorFirstCode && self.code <= kInternalServerErrorLastCode)) {
+  // A locally short-circuited request (rate limiter) is exactly the case the
+  // bundled payload exists for: no network attempt was made, so serving the
+  // fallback beats surfacing a hard error. Matters since fallbacks are no
+  // longer cached — offline repeat calls hit the limiter instead of the old
+  // cached-fallback fast path.
+  if (self.code == NSURLErrorNotConnectedToInternet ||
+      self.code == QONErrorCodeApiRateLimitExceeded ||
+      (self.code >= kInternalServerErrorFirstCode && self.code <= kInternalServerErrorLastCode)) {
     return YES;
   } else {
     return NO;


### PR DESCRIPTION
B4 from the Remote Config targeting review ([dash-mono PR #674](https://github.com/qonversion/dash-mono/pull/674)), iOS mirror of [android-sdk#853](https://github.com/qonversion/android-sdk/pull/853). Linear: [DEV-1236](https://linear.app/qonversion/issue/DEV-1236). Prerequisite of arming server-side dynamic targeting re-evaluation (B2a) in production: re-evaluation is invisible while the SDK serves configs from its process-lifetime in-memory cache.

## What changed

1. **`identify()` resolving to the SAME uid now drops the cached remote configs.** The first identify does not change the uid, so the cache was never invalidated on login and the user stayed on the pre-login targeting evaluation until process restart. The invalidation runs strictly BEFORE the pending-request replay — the reversed order would serve queued completions the pre-identify evaluation from the cache-hit path and orphan them. Both the branch and the order are pinned by a new **wired** contract test file (`QNProductCenterManagerIdentifyRemoteConfigTests.m`, 4 pbxproj refs).
2. **New public API `invalidateRemoteConfigsCache`** — marks the cached configs stale on demand. No network request, no completion; the next `remoteConfig` / `remoteConfigList` call fetches a fresh targeting evaluation. Header doc covers use cases (property batches, foreground returns), the "not needed after identify / not needed for fallback recovery" notes, the NoCodes non-impact note, and the threading contract (synchronous on the caller thread — deliberately NOT hopped to main, because `handlePendingRequests` is synchronous and the hop would invert the identify-path ordering). Redundant `NS_SWIFT_NAME` dropped; facade `.m` placement aligned with the header.
3. **Superseded in-flight loads are re-issued, never worse than before.** If the cache generation moves while a `remoteConfig` request is flying, the load is re-issued instead of delivering the stale evaluation. The queued waiters are snapshotted and carried through the retry together with the direct completion, keeping the superseded (but valid) evaluation as a baseline — a failed retry delivers the baseline as a success instead of an error. The re-issue is gated on the loading state still being live (a user switch must not fire a request nobody awaits). Unlike Android, the initiating caller's completion is not queued in the loading state, so the re-issue is not gated on `completions.count`. The cache-hit branch now drains `loadingState.completions` together with the direct caller — this closes the re-issue-onto-warm-cache orphan found by the panel AND a pre-existing orphan where a completion queued during user instability met a warm cache on replay. An in-flight `remoteConfigList` completes with the evaluation it started with (documented; re-issuing a list would multiply the retry cost across N keys for a one-shot completion — recorded so nobody "fixes" the asymmetry); nothing from it is cached.
4. **Fallback configs are no longer cached** (single-key and list paths). `QONErrorCodeApiRateLimitExceeded` became fallback-eligible (domain-pinned to `QonversionErrorDomain`; `shouldFireFallback` has a single RC consumer on iOS, so the blast radius equals Android's RC-scoped predicate) — offline repeat calls on one context key that hit the local limiter still receive the bundled payload instead of a hard error. A failed retry of a superseded load prefers the stashed baseline over both the error and the bundled payload, uniformly — late joiners during the retry window get the baseline too. Serving a bundled fallback now logs a warning naming the context key — the only signal that the payload is not a fresh targeting evaluation. Bonus fix caught while making this change: the keyed list fallback was filtered from the **nil network response** instead of the bundled list, so it always came back empty — it now filters `fallbackData.remoteConfigList` (pinned by test).
5. **Rate limiter: context key joined the hash** (Android keys its limiter on the context key alone; iOS composes `userID|contextKey`). Previously all single-key RC loads for a user shared one bucket, so a post-invalidation refetch burst across several context keys tripped the limiter with a nil-config error. Note for backend: per-key buckets + retries + uncached fallbacks raise RC request volume on three axes at the same time the B2a targeting gate makes each request more expensive — flagged in DEV-1236 before the rollout.

## Behavior changes for existing integrations (release notes)

- A `remoteConfig` request in flight when `identify` completes is re-issued, so its completion resolves after two round trips instead of one (correct-data-for-latency trade; a failed retry falls back to the first response, so reliability is not reduced).
- Fallback configs are no longer cached: offline apps issue one fast-failing request per read instead of one per session, recover automatically when connectivity returns, and receive the bundled payload even when the local rate limiter short-circuits the request. On flaky (non-airplane-mode) networks each read pays the request timeout before the fallback appears.
- iOS-only bug fix: an offline `remoteConfigList(contextKeys:)` previously returned an empty list (the keyed filter ran against the nil network response); it now returns the bundled configs.
- The DEV-1231 attach/detach named-key invalidation and generation guard are still unreleased on `main` (6.13.1 was tagged before that merge) — this release ships them together.

## Tests

`QONRemoteConfigManagerInvalidationTests`: public API folded into the shared 5-entry-point invalidation sweep; focused re-issue tests (public + attach seams) asserting no stale delivery, exactly one retry, fresh delivery + caching, and `isInProgress` reset; fallback non-caching tests for both paths (the list one also pins the bundled-source fix). `QNProductCenterManagerIdentifyRemoteConfigTests` (new, wired): same-uid invalidation + `userHasBeenChanged` exclusion, invalidate-before-replay order, error-path exclusion. Framework build green; both test files pass `clang -fsyntax-only -Wall` with zero diagnostics; `plutil` validates the pbxproj. The full suite runs in CI (the Sample test host embeds a watch app and needs the watchOS runtime, unavailable locally).

Sample: an "Invalidate Remote Configs Cache" button on the Remote Configs screen.

Follow-up (out of scope): three phantom test files with 0 pbxproj refs (`ProductCenterManagerIdentifyContractTests.m` — also needs a double-paren OCMStub fix to compile, `DeferredPurchaseListenerTests.m`, `QONRedemptionManagerTests.m`) — tracked in Linear.

Android mirror and cross-platform wrappers follow in the same Linear issue. Release note: ships together with the A5 fixes (#728) and DEV-1231 in one release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y4V5cx2SMU4VrfPntwfKJ9
