### PR TITLE
Release 6.14.0

### DIFF
--- a/Framework/Info.plist
+++ b/Framework/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.13.1</string>
+	<string>6.14.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Qonversion.podspec
+++ b/Qonversion.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   idfa_exclude_files = ['Sources/Qonversion/IDFA']
   s.name         = 'Qonversion'
   s.swift_version = '5.5'
-  s.version      = '6.13.1'
+  s.version      = '6.14.0'
   s.summary      = 'qonversion.io'
   s.description  = <<-DESC
   Deep Analytics for iOS Subscriptions

--- a/Sources/Qonversion/Public/QONConfiguration.m
+++ b/Sources/Qonversion/Public/QONConfiguration.m
@@ -9,7 +9,7 @@
 #import "QONConfiguration.h"
 #import "QNAPIConstants.h"
 
-static NSString *const kSDKVersion = @"6.13.1";
+static NSString *const kSDKVersion = @"6.14.0";
 
 @interface QONConfiguration ()
 

--- a/fastlane/report.xml
+++ b/fastlane/report.xml
@@ -5,12 +5,12 @@
     
     
       
-      <testcase classname="fastlane.lanes" name="0: update_plist" time="0.046459191">
+      <testcase classname="fastlane.lanes" name="0: update_plist" time="0.021542535">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="1: version_bump_podspec" time="0.000690117">
+      <testcase classname="fastlane.lanes" name="1: version_bump_podspec" time="0.000828321">
         
       </testcase>
     


### PR DESCRIPTION
Release PR

<!-- release-notes:start -->
## New

* New public API `invalidateRemoteConfigsCache` — invalidates the in-memory cache of remote configs so the next `remoteConfig` / `remoteConfigList` call fetches a fresh targeting evaluation. No network request itself; call it after changing user properties your targeting depends on. Not needed after `identify:` — see below (#749).

## Improvements & fixes

* `identify:` resolving to the same Qonversion user now invalidates the remote configs cache automatically, so the first login no longer serves the pre-login targeting evaluation for the rest of the process lifetime (#749).
* A remote config load in flight during an invalidation is re-issued so its completions receive a fresh evaluation; if the retry fails, the superseded evaluation is delivered instead of an error (#749).
* Bundled fallback configs are no longer cached: offline apps recover automatically when connectivity returns, and a request short-circuited by the local rate limiter still receives the bundled payload. Serving a bundled fallback now logs a warning (#749).
* Fixed an offline `remoteConfigList(contextKeys:)` returning an empty list — the keyed filter ran against the empty network response instead of the bundled fallback list (#749).
* The remote config rate limiter now buckets per context key, so loading several context keys in a burst no longer trips the limit (#749).
* Attach/detach of experiments and remote configurations now invalidates configs cached under named context keys, and an in-flight load can no longer re-cache a superseded evaluation (#728).
* `setUserProperty:` batches are reliably flushed before a remote config evaluation, including on cache hits and queued force-flushes (#728).

## Behavior changes

* A `remoteConfig` request in flight when `identify:` completes resolves after two round trips instead of one (fresh-data-for-latency trade; reliability is not reduced).
<!-- release-notes:end -->
