### PR TITLE
feat: expose frozen remote config assignments

### DIFF
--- a/QonversionTests/QonversionMapperTests.m
+++ b/QonversionTests/QonversionMapperTests.m
@@ -9,6 +9,9 @@
 #import "QONEntitlement.h"
 #import "QONLaunchResult.h"
 #import "QONProduct.h"
+#import "QONRemoteConfig.h"
+#import "QONRemoteConfigMapper.h"
+#import "QONRemoteConfigurationSource.h"
 
 @interface QNMapperTests : XCTestCase
 @property (nonatomic, strong) NSDictionary *userInitSuccess;
@@ -16,6 +19,30 @@
 @end
 
 @implementation QNMapperTests
+
+- (void)testRemoteConfigMapperPreservesFrozenAssignmentProvenance {
+  NSDictionary *data = @{
+    @"payload": @{},
+    @"source": @{
+      @"uid": @"rc-frozen",
+      @"name": @"Frozen config",
+      @"type": @"remote_configuration",
+      @"assignment_type": @"frozen",
+      @"context_key": @""
+    }
+  };
+
+  QONRemoteConfig *config = [[[QONRemoteConfigMapper alloc] init] mapRemoteConfig:data];
+
+  XCTAssertNotNil(config.source);
+  XCTAssertEqual(config.source.assignmentType, QONRemoteConfigurationAssignmentTypeFrozen);
+}
+
+- (void)testRemoteConfigAssignmentTypeKeepsExistingNumericValues {
+  XCTAssertEqual(QONRemoteConfigurationAssignmentTypeUnknown, -1);
+  XCTAssertEqual(QONRemoteConfigurationAssignmentTypeAuto, 0);
+  XCTAssertEqual(QONRemoteConfigurationAssignmentTypeManual, 1);
+}
 
 - (void)setUp {
   [super setUp];

--- a/Sources/Qonversion/Public/QONRemoteConfigurationSource.h
+++ b/Sources/Qonversion/Public/QONRemoteConfigurationSource.h
@@ -13,7 +13,8 @@ NS_ASSUME_NONNULL_BEGIN
 typedef NS_ENUM(NSInteger, QONRemoteConfigurationAssignmentType) {
   QONRemoteConfigurationAssignmentTypeUnknown = -1,
   QONRemoteConfigurationAssignmentTypeAuto = 0,
-  QONRemoteConfigurationAssignmentTypeManual = 1
+  QONRemoteConfigurationAssignmentTypeManual = 1,
+  QONRemoteConfigurationAssignmentTypeFrozen = 2
 } NS_SWIFT_NAME(Qonversion.RemoteConfigurationAssignmentType);
 
 typedef NS_ENUM(NSInteger, QONRemoteConfigurationSourceType) {

--- a/Sources/Qonversion/Public/QONRemoteConfigurationSource.m
+++ b/Sources/Qonversion/Public/QONRemoteConfigurationSource.m
@@ -49,6 +49,9 @@
     
     case QONRemoteConfigurationAssignmentTypeManual:
       result = @"manual"; break;
+
+    case QONRemoteConfigurationAssignmentTypeFrozen:
+      result = @"frozen"; break;
       
     default:
       result = @"unknown"; break;

--- a/Sources/Qonversion/Qonversion/Mappers/QONRemoteConfigMapper/QONRemoteConfigMapper.m
+++ b/Sources/Qonversion/Qonversion/Mappers/QONRemoteConfigMapper/QONRemoteConfigMapper.m
@@ -19,6 +19,7 @@ NSString *const kTreatmentGroupType = @"treatment";
 
 NSString *const kRemoteConfigurationAssignmentTypeAuto = @"auto";
 NSString *const kRemoteConfigurationAssignmentTypeManual = @"manual";
+NSString *const kRemoteConfigurationAssignmentTypeFrozen = @"frozen";
 
 NSString *const kRemoteConfigurationSourceTypeControlGroup = @"experiment_control_group";
 NSString *const kRemoteConfigurationSourceTypeTreatmentGroup = @"experiment_treatment_group";
@@ -46,7 +47,8 @@ NSString *const kRemoteConfigurationSourceTypeRemoteConfiguration = @"remote_con
     
     _remoteConfigurationAssignmentTypes = @{
       kRemoteConfigurationAssignmentTypeAuto: @(QONRemoteConfigurationAssignmentTypeAuto),
-      kRemoteConfigurationAssignmentTypeManual: @(QONRemoteConfigurationAssignmentTypeManual)
+      kRemoteConfigurationAssignmentTypeManual: @(QONRemoteConfigurationAssignmentTypeManual),
+      kRemoteConfigurationAssignmentTypeFrozen: @(QONRemoteConfigurationAssignmentTypeFrozen)
     };
     
     _remoteConfigurationSourceTypes = @{


### PR DESCRIPTION
## Summary

- add Frozen assignment provenance while preserving existing enum values
- decode frozen payloads and preserve unknown fallback
- cover decoder mapping with tests

## Release dependency

Publish as iOS SDK 6.15.0 before the frozen-aware Sandwich bridge release.

## Verification

- source and parser contract tests added
- swift test unavailable locally because full Xcode SDK is not installed