### PR TITLE
fix: restore API TLS verification

### DIFF
--- a/QonversionTests/APIClientTests.m
+++ b/QonversionTests/APIClientTests.m
@@ -137,4 +137,27 @@ NSString *const kTestAPIKey = @"QNAPIClient_test_api_key";
   [self waitForExpectationsWithTimeout:keyQNTestTimeout handler:nil];
 }
 
+- (void)testThatServerTrustUsesSystemValidation {
+  NSURLProtectionSpace *protectionSpace = [[NSURLProtectionSpace alloc]
+    initWithHost:@"attacker.invalid"
+    port:443
+    protocol:NSURLProtectionSpaceHTTPS
+    realm:nil
+    authenticationMethod:NSURLAuthenticationMethodServerTrust];
+  id challenge = OCMClassMock([NSURLAuthenticationChallenge class]);
+  OCMStub([challenge protectionSpace]).andReturn(protectionSpace);
+
+  __block NSURLSessionAuthChallengeDisposition disposition = NSURLSessionAuthChallengeUseCredential;
+  __block NSURLCredential *credential = [NSURLCredential credentialWithUser:@"unexpected" password:@"unexpected" persistence:NSURLCredentialPersistenceNone];
+
+  [self.client URLSession:nil didReceiveChallenge:challenge completionHandler:^(NSURLSessionAuthChallengeDisposition receivedDisposition, NSURLCredential *receivedCredential) {
+    disposition = receivedDisposition;
+    credential = receivedCredential;
+  }];
+
+  XCTAssertEqual(disposition, NSURLSessionAuthChallengePerformDefaultHandling);
+  XCTAssertNil(credential);
+  [challenge stopMocking];
+}
+
 @end

--- a/Sources/NoCodes/NetworkLayer/NetworkProvider/NetworkProvider.swift
+++ b/Sources/NoCodes/NetworkLayer/NetworkProvider/NetworkProvider.swift
@@ -41,14 +41,9 @@ class NetworkProvider: NSObject, NetworkProviderInterface, URLSessionDelegate {
     }
   }
 
-  // MARK: - Temporary SSL bypass for staging. Remove before release.
   func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
-    if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
-       let serverTrust = challenge.protectionSpace.serverTrust {
-      completionHandler(.useCredential, URLCredential(trust: serverTrust))
-    } else {
-      completionHandler(.performDefaultHandling, nil)
-    }
+    // Keep system trust-chain and hostname validation for every endpoint.
+    completionHandler(.performDefaultHandling, nil)
   }
 }
 

--- a/Sources/Qonversion/Qonversion/Services/QNAPIClient/QNAPIClient.m
+++ b/Sources/Qonversion/Qonversion/Services/QNAPIClient/QNAPIClient.m
@@ -678,14 +678,11 @@ NSUInteger const kUnableToParseEmptyDataDefaultCode = 3840;
   }
 }
 
-// MARK: - Temporary SSL bypass for staging. Remove before release.
 - (void)URLSession:(NSURLSession *)session didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential * _Nullable))completionHandler {
-  if ([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]) {
-    NSURLCredential *credential = [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust];
-    completionHandler(NSURLSessionAuthChallengeUseCredential, credential);
-  } else {
-    completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
-  }
+  // Never manufacture a credential from an unverified SecTrust. Delegating to
+  // URLSession preserves the platform trust chain and hostname checks for the
+  // default API as well as customer-provided HTTPS proxy URLs.
+  completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
 }
 
 @end


### PR DESCRIPTION
## Outcome

Restores Apple platform trust-chain and hostname validation for the primary SDK API client and the NoCodes network provider. The previous delegates accepted any server trust.

## Changes

- delegate every authentication challenge to URLSession default handling
- remove the temporary staging trust bypass from both network stacks
- add an API-client regression test that requires default system handling and no synthesized credential

## Verification

- git diff --check
- no remaining credentialForTrust or URLCredential trust bypass in Sources
- the focused XCTest is included; local execution is unavailable because this host has only Command Line Tools, so CI is the executable evidence

This is independent from the Remote Config targeting rollout and should be released as a security prerequisite.