### PR TITLE
feat: validate and durably admit Remote Config snapshots

### DIFF
--- a/QonversionTests/Managers/QONRemoteConfigV2ManagerTests.m
+++ b/QonversionTests/Managers/QONRemoteConfigV2ManagerTests.m
@@ -4,6 +4,8 @@
 //
 
 #import <XCTest/XCTest.h>
+#import <CommonCrypto/CommonDigest.h>
+#import <xlocale.h>
 
 #import "QNInMemoryStorage.h"
 #import "QNLocalStorage.h"
@@ -42,10 +44,420 @@
 - (void)removeObjectForKey:(NSString *)key { [self.objects removeObjectForKey:key]; }
 @end
 
+@interface QONRemoteConfigBlockingEnvelopeDecoder : NSObject <QONRemoteConfigV2EnvelopeDecoding>
+@property (nonatomic, strong) QONRemoteConfigV2EnvelopeParser *parser;
+@property (nonatomic, strong) dispatch_semaphore_t started;
+@property (nonatomic, strong) dispatch_semaphore_t resume;
+@end
+
+@implementation QONRemoteConfigBlockingEnvelopeDecoder
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    _parser = [QONRemoteConfigV2EnvelopeParser new];
+    _started = dispatch_semaphore_create(0);
+    _resume = dispatch_semaphore_create(0);
+  }
+  return self;
+}
+- (QONRemoteConfigV2Envelope *)parseBody:(NSData *)body
+                              strongETag:(NSString *)strongETag
+                             expectation:(QONRemoteConfigV2EnvelopeExpectation *)expectation {
+  QONRemoteConfigV2Envelope *parsed = [self.parser parseBody:body
+      strongETag:strongETag expectation:expectation];
+  dispatch_semaphore_signal(self.started);
+  dispatch_semaphore_wait(self.resume, dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC));
+  return parsed;
+}
+@end
+
 @interface QONRemoteConfigV2ManagerTests : XCTestCase
 @end
 
 @implementation QONRemoteConfigV2ManagerTests
+
+- (NSString *)strongETagForBody:(NSData *)body {
+  uint8_t digest[CC_SHA256_DIGEST_LENGTH];
+  CC_SHA256(body.bytes, (CC_LONG)body.length, digest);
+  NSMutableString *hex = [NSMutableString stringWithCapacity:CC_SHA256_DIGEST_LENGTH * 2 + 2];
+  [hex appendString:@"\""];
+  for (NSUInteger index = 0; index < CC_SHA256_DIGEST_LENGTH; index++) {
+    [hex appendFormat:@"%02x", digest[index]];
+  }
+  [hex appendString:@"\""];
+  return hex;
+}
+
+- (NSString *)wireItemWithRaw:(NSString *)raw
+                     metadata:(NSString *)metadata
+                  variationUID:(NSString *)variationUID
+                         policy:(NSString *)policy {
+  return [NSString stringWithFormat:
+      @"{\"raw\":%@,\"variation_uid\":\"%@\",\"apply_policy\":\"%@\",\"metadata\":%@}",
+      raw, variationUID, policy, metadata];
+}
+
+- (NSString *)wireBodyWithValues:(NSString *)values {
+  return [NSString stringWithFormat:
+      @"{\"schema_version\":1,\"project_id\":42,\"environment_uid\":\"env-production\","
+       "\"release_uid\":\"release\",\"release_number\":7,\"manifest_content_hash\":"
+       "\"05b3abf2579a5eb66403cd78be557fd860633a1fe2103c7642030defe32c657f\","
+       "\"complete_key_set\":true,\"context_fingerprint\":"
+       "\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"values\":{%@}}",
+      values];
+}
+
+- (QONRemoteConfigV2EnvelopeExpectation *)wireExpectation {
+  return [[QONRemoteConfigV2EnvelopeExpectation alloc]
+      initWithProjectID:42 environmentUID:@"env-production"
+      contextFingerprint:[@"a" stringByPaddingToLength:64 withString:@"a" startingAtIndex:0]];
+}
+
+- (QONRemoteConfigV2Scope *)wireScope:(NSString *)userID {
+  return [[QONRemoteConfigV2Scope alloc] initWithProjectKey:@"project"
+      environment:@"env-production" canonicalUserID:userID];
+}
+
+- (QONRemoteConfigV2Envelope *)parseWireBody:(NSString *)body {
+  NSData *data = [self utf8Data:body];
+  return [[QONRemoteConfigV2EnvelopeParser new] parseBody:data
+      strongETag:[self strongETagForBody:data] expectation:[self wireExpectation]];
+}
+
+- (void)testCanonicalResolvedSnapshotWireBodyMatchesAndroidGoldenVectorExactly {
+  NSString *bodyString = @"{\"schema_version\":1,\"project_id\":42,\"environment_uid\":\"env-production\",\"release_uid\":\"release-uid\",\"release_number\":7,\"manifest_content_hash\":\"05b3abf2579a5eb66403cd78be557fd860633a1fe2103c7642030defe32c657f\",\"complete_key_set\":true,\"context_fingerprint\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"values\":{\"alpha\":{\"raw\":\"value\",\"variation_uid\":\"variation-a\",\"apply_policy\":\"on_next_activate\",\"metadata\":null},\"zeta\":{\"raw\":{\"nested\":true},\"variation_uid\":\"variation-z\",\"apply_policy\":\"immediate\",\"metadata\":{\"resetNavigation\":true}}}}";
+  NSData *body = [self utf8Data:bodyString];
+  NSString *etag = @"\"d0c95fec2b0842242efdb0b8a034346538b7db97d6c5ff901501534ed940e3d3\"";
+
+  QONRemoteConfigV2Envelope *envelope = [[QONRemoteConfigV2EnvelopeParser new]
+      parseBody:body strongETag:etag expectation:[self wireExpectation]];
+
+  XCTAssertNotNil(envelope);
+  XCTAssertEqual(envelope.projectID, 42);
+  XCTAssertEqualObjects(envelope.environmentUID, @"env-production");
+  XCTAssertEqualObjects(envelope.eTag, etag);
+  XCTAssertEqualObjects(envelope.bodyDigest,
+                        @"d0c95fec2b0842242efdb0b8a034346538b7db97d6c5ff901501534ed940e3d3");
+  XCTAssertEqualObjects(envelope.canonicalBody, body);
+  XCTAssertEqualObjects(envelope.snapshotRelease.entries[@"alpha"].rawData, [self utf8Data:@"\"value\""]);
+  XCTAssertEqualObjects(envelope.snapshotRelease.entries[@"alpha"].metadataData, [self utf8Data:@"null"]);
+  XCTAssertEqualObjects(envelope.snapshotRelease.entries[@"zeta"].rawData,
+                        [self utf8Data:@"{\"nested\":true}"]);
+  XCTAssertEqualObjects(envelope.snapshotRelease.entries[@"zeta"].metadataData,
+                        [self utf8Data:@"{\"resetNavigation\":true}"]);
+  XCTAssertEqual(envelope.snapshotRelease.entries[@"zeta"].applyPolicy,
+                 QONRemoteConfigApplyPolicyImmediate);
+}
+
+- (void)testWireParserRejectsETagScopeCompletenessAndMemberAmbiguity {
+  NSString *item = [self wireItemWithRaw:@"true" metadata:@"null"
+      variationUID:@"variation" policy:@"on_next_activate"];
+  NSString *bodyString = [self wireBodyWithValues:[NSString stringWithFormat:@"\"only\":%@", item]];
+  NSData *body = [self utf8Data:bodyString];
+  QONRemoteConfigV2EnvelopeParser *parser = [QONRemoteConfigV2EnvelopeParser new];
+  NSString *validETag = [self strongETagForBody:body];
+
+  XCTAssertNotNil([parser parseBody:body strongETag:validETag expectation:[self wireExpectation]]);
+  XCTAssertNil([parser parseBody:body strongETag:[@"W/" stringByAppendingString:validETag]
+      expectation:[self wireExpectation]]);
+  XCTAssertNil([parser parseBody:body strongETag:validETag expectation:
+      [[QONRemoteConfigV2EnvelopeExpectation alloc] initWithProjectID:43
+          environmentUID:@"env-production"
+          contextFingerprint:[@"a" stringByPaddingToLength:64 withString:@"a" startingAtIndex:0]]]);
+  XCTAssertNil([self parseWireBody:[bodyString stringByReplacingOccurrencesOfString:
+      @"\"complete_key_set\":true" withString:@"\"complete_key_set\":false"]]);
+  XCTAssertNil([self parseWireBody:[bodyString stringByReplacingOccurrencesOfString:
+      @"\"schema_version\":1" withString:@"\"unknown\":0,\"schema_version\":1"]]);
+  XCTAssertNil([self parseWireBody:[bodyString stringByReplacingOccurrencesOfString:
+      @"\"schema_version\":1" withString:@"\"schema_version\":1,\"schema_\\u0076ersion\":1"]]);
+}
+
+- (void)testWireParserPreservesExactSpansAndRejectsNonPortableOrAmbiguousNestedJSON {
+  NSString *raw = @" { \"a\" : 1.0 } \n";
+  NSString *metadata = @" [ true ] ";
+  NSString *valid = [self wireBodyWithValues:[NSString stringWithFormat:@"\"only\":%@",
+      [self wireItemWithRaw:raw metadata:metadata variationUID:@"variation"
+      policy:@"on_next_activate"]]];
+  QONRemoteConfigV2Envelope *envelope = [self parseWireBody:valid];
+  XCTAssertEqualObjects(envelope.snapshotRelease.entries[@"only"].rawData, [self utf8Data:raw]);
+  XCTAssertEqualObjects(envelope.snapshotRelease.entries[@"only"].metadataData, [self utf8Data:metadata]);
+
+  NSArray<NSString *> *invalidValues = @[
+    @"{\"duplicate\":1,\"duplicate\":2}",
+    @"{\"a\":1,\"\\u0061\":2}",
+    @"9007199254740992",
+    @"1e400",
+    @"\"\\uD800\"",
+  ];
+  for (NSString *invalid in invalidValues) {
+    NSString *body = [self wireBodyWithValues:[NSString stringWithFormat:@"\"only\":%@",
+        [self wireItemWithRaw:invalid metadata:@"null" variationUID:@"variation"
+        policy:@"on_next_activate"]]];
+    XCTAssertNil([self parseWireBody:body], @"%@", invalid);
+  }
+}
+
+- (void)testWireNumberValidationIsIndependentOfThreadNumericLocale {
+  locale_t commaLocale = newlocale(LC_NUMERIC_MASK, "de_DE.UTF-8", NULL);
+  if (!commaLocale) commaLocale = newlocale(LC_NUMERIC_MASK, "fr_FR.UTF-8", NULL);
+  XCTAssertNotEqual(commaLocale, (locale_t)0);
+  if (!commaLocale) return;
+  locale_t previousLocale = uselocale(commaLocale);
+  @try {
+    NSString *validBody = [self wireBodyWithValues:[NSString stringWithFormat:@"\"only\":%@",
+        [self wireItemWithRaw:@"1.5" metadata:@"null" variationUID:@"variation"
+        policy:@"on_next_activate"]]];
+    NSString *nonFiniteBody = [self wireBodyWithValues:[NSString stringWithFormat:@"\"only\":%@",
+        [self wireItemWithRaw:@"1e400" metadata:@"null" variationUID:@"variation"
+        policy:@"on_next_activate"]]];
+
+    XCTAssertNotNil([self parseWireBody:validBody]);
+    XCTAssertNil([self parseWireBody:nonFiniteBody]);
+  } @finally {
+    uselocale(previousLocale);
+    freelocale(commaLocale);
+  }
+}
+
+- (void)testWireParserEnforcesUTF8DepthPerValueAggregateAndExactFieldBounds {
+  QONRemoteConfigV2EnvelopeParser *parser = [QONRemoteConfigV2EnvelopeParser new];
+  NSMutableData *oversizedBody = [NSMutableData dataWithLength:QONRemoteConfigV2MaximumEnvelopeBytes + 1];
+  XCTAssertNil([parser parseBody:oversizedBody strongETag:@"invalid" expectation:[self wireExpectation]]);
+  NSMutableData *invalidUTF8 = [[self utf8Data:[self wireBodyWithValues:[NSString stringWithFormat:
+      @"\"only\":%@", [self wireItemWithRaw:@"true" metadata:@"null"
+      variationUID:@"variation" policy:@"on_next_activate"]]]] mutableCopy];
+  uint8_t *bytes = invalidUTF8.mutableBytes;
+  bytes[invalidUTF8.length / 2] = 0xff;
+  XCTAssertNil([parser parseBody:invalidUTF8 strongETag:[self strongETagForBody:invalidUTF8]
+      expectation:[self wireExpectation]]);
+
+  NSString *validBody = [self wireBodyWithValues:[NSString stringWithFormat:@"\"only\":%@",
+      [self wireItemWithRaw:@"true" metadata:@"null" variationUID:@"variation"
+      policy:@"on_next_activate"]]];
+  NSArray<NSString *> *invalidBodies = @[
+    [validBody stringByReplacingOccurrencesOfString:@"\"raw\":true,"
+        withString:@"\"unknown\":0,\"raw\":true,"],
+    [validBody stringByReplacingOccurrencesOfString:@"\"raw\":true,"
+        withString:@"\"raw\":false,\"raw\":true,"],
+    [validBody stringByReplacingOccurrencesOfString:@"\"raw\":true," withString:@""],
+    [validBody stringByReplacingOccurrencesOfString:@"\"release_number\":7"
+        withString:@"\"release_number\":9007199254740992"],
+    [validBody stringByReplacingOccurrencesOfString:@"\"variation_uid\":\"variation\""
+        withString:[NSString stringWithFormat:@"\"variation_uid\":\"%@\"",
+        [@"v" stringByPaddingToLength:37 withString:@"v" startingAtIndex:0]]],
+  ];
+  for (NSString *invalidBody in invalidBodies) XCTAssertNil([self parseWireBody:invalidBody]);
+
+  NSMutableString *tooDeep = [NSMutableString new];
+  for (NSUInteger index = 0; index < 65; index++) [tooDeep appendString:@"["];
+  [tooDeep appendString:@"null"];
+  for (NSUInteger index = 0; index < 65; index++) [tooDeep appendString:@"]"];
+  NSString *deepBody = [self wireBodyWithValues:[NSString stringWithFormat:@"\"only\":%@",
+      [self wireItemWithRaw:tooDeep metadata:@"null" variationUID:@"variation"
+      policy:@"on_next_activate"]]];
+  XCTAssertNil([self parseWireBody:deepBody]);
+
+  NSString *exactRaw = [@"true" stringByPaddingToLength:QONRemoteConfigV2MaximumRawValueBytes
+      withString:@" " startingAtIndex:0];
+  NSString *exactMetadata = [@"null" stringByPaddingToLength:QONRemoteConfigV2MaximumMetadataBytes
+      withString:@" " startingAtIndex:0];
+  NSString *exactBody = [self wireBodyWithValues:[NSString stringWithFormat:@"\"only\":%@",
+      [self wireItemWithRaw:exactRaw metadata:exactMetadata variationUID:@"variation"
+      policy:@"on_next_activate"]]];
+  XCTAssertNotNil([self parseWireBody:exactBody]);
+  NSString *oversizedRawItem = [self wireItemWithRaw:[exactRaw stringByAppendingString:@" "]
+      metadata:exactMetadata variationUID:@"variation" policy:@"on_next_activate"];
+  NSString *oversizedRawBody = [self wireBodyWithValues:
+      [NSString stringWithFormat:@"\"only\":%@", oversizedRawItem]];
+  XCTAssertNil([self parseWireBody:oversizedRawBody]);
+  NSString *oversizedMetadataItem = [self wireItemWithRaw:exactRaw
+      metadata:[exactMetadata stringByAppendingString:@" "] variationUID:@"variation"
+      policy:@"on_next_activate"];
+  NSString *oversizedMetadataBody = [self wireBodyWithValues:
+      [NSString stringWithFormat:@"\"only\":%@", oversizedMetadataItem]];
+  XCTAssertNil([self parseWireBody:oversizedMetadataBody]);
+
+  NSMutableArray<NSString *> *items = [NSMutableArray new];
+  NSString *nearMaximumRaw = [NSString stringWithFormat:@"\"%@\"",
+      [@"x" stringByPaddingToLength:QONRemoteConfigV2MaximumRawValueBytes - 2
+      withString:@"x" startingAtIndex:0]];
+  for (NSUInteger index = 0; index < 65; index++) {
+    [items addObject:[NSString stringWithFormat:@"\"key-%lu\":%@", (unsigned long)index,
+        [self wireItemWithRaw:nearMaximumRaw metadata:@"null"
+        variationUID:[NSString stringWithFormat:@"v-%lu", (unsigned long)index]
+        policy:@"on_next_activate"]]];
+  }
+  XCTAssertNil([self parseWireBody:[self wireBodyWithValues:[items componentsJoinedByString:@","]]]);
+}
+
+- (void)testWireEnvelopeAndReleaseOwnImmutableCopiesOfCallerBytes {
+  NSMutableData *body = [[[self wireBodyWithValues:[NSString stringWithFormat:@"\"only\":%@",
+      [self wireItemWithRaw:@"true" metadata:@"null" variationUID:@"variation"
+      policy:@"on_next_activate"]]] dataUsingEncoding:NSUTF8StringEncoding] mutableCopy];
+  NSData *original = [body copy];
+  QONRemoteConfigV2Envelope *envelope = [[QONRemoteConfigV2EnvelopeParser new]
+      parseBody:body strongETag:[self strongETagForBody:body] expectation:[self wireExpectation]];
+  [body resetBytesInRange:NSMakeRange(0, body.length)];
+
+  XCTAssertEqualObjects(envelope.canonicalBody, original);
+  XCTAssertEqualObjects(envelope.snapshotRelease.canonicalBody, original);
+  XCTAssertEqualObjects(envelope.snapshotRelease.entries[@"only"].rawData, [self utf8Data:@"true"]);
+}
+
+- (QONRemoteConfigV2Manager *)managerWithStorage:(id<QNLocalStorage>)storage
+                                         decoder:(id<QONRemoteConfigV2EnvelopeDecoding>)decoder {
+  return [self managerWithStorage:storage decoder:decoder
+      callbackExecutor:dispatch_get_main_queue()];
+}
+
+- (QONRemoteConfigV2Manager *)managerWithStorage:(id<QNLocalStorage>)storage
+                                         decoder:(id<QONRemoteConfigV2EnvelopeDecoding>)decoder
+                                callbackExecutor:(dispatch_queue_t)callbackExecutor {
+  return [[QONRemoteConfigV2Manager alloc]
+      initWithStore:[[QONRemoteConfigV2Store alloc] initWithLocalStorage:storage]
+      fallbackRelease:nil fallbackProjectKey:nil fallbackEnvironment:nil
+      envelopeDecoder:decoder callbackExecutor:callbackExecutor];
+}
+
+- (void)testAdmissionTokenIsManagerScopeExpectationAndLatestRequestBound {
+  QONRemoteConfigV2Manager *first = [self managerWithStorage:[QNInMemoryStorage new]
+      decoder:[QONRemoteConfigV2EnvelopeParser new]];
+  QONRemoteConfigV2Manager *second = [self managerWithStorage:[QNInMemoryStorage new]
+      decoder:[QONRemoteConfigV2EnvelopeParser new]];
+  QONRemoteConfigV2Scope *scope = [self wireScope:@"user"];
+  [first setScope:scope];
+  [second setScope:scope];
+  QONRemoteConfigV2AdmissionToken *old = [first beginAdmissionForScope:scope
+      expectation:[self wireExpectation]];
+  QONRemoteConfigV2AdmissionToken *latest = [first beginAdmissionForScope:scope
+      expectation:[self wireExpectation]];
+  NSString *bodyString = [self wireBodyWithValues:[NSString stringWithFormat:@"\"only\":%@",
+      [self wireItemWithRaw:@"1" metadata:@"null" variationUID:@"variation"
+      policy:@"on_next_activate"]]];
+  NSData *body = [self utf8Data:bodyString];
+  NSString *etag = [self strongETagForBody:body];
+
+  XCTAssertEqual([first admitBody:body strongETag:etag admissionToken:old],
+                 QONRemoteConfigV2TransitionStatusRejected);
+  XCTAssertEqual([second admitBody:body strongETag:etag admissionToken:latest],
+                 QONRemoteConfigV2TransitionStatusRejected);
+  XCTAssertEqual([first admitBody:body strongETag:etag admissionToken:latest],
+                 QONRemoteConfigV2TransitionStatusAccepted);
+  XCTAssertEqualObjects(first.lastFetchedSnapshot.releaseUID, @"release");
+
+  QONRemoteConfigV2AdmissionToken *contextToken = [first beginAdmissionForScope:scope
+      expectation:[[QONRemoteConfigV2EnvelopeExpectation alloc] initWithProjectID:42
+          environmentUID:@"env-production"
+          contextFingerprint:[@"b" stringByPaddingToLength:64 withString:@"b" startingAtIndex:0]]];
+  XCTAssertEqual([first admitBody:body strongETag:etag admissionToken:contextToken],
+                 QONRemoteConfigV2TransitionStatusRejected);
+
+  [first setScope:[self wireScope:@"user-b"]];
+  [first setScope:scope];
+  XCTAssertEqual([first admitBody:body strongETag:etag admissionToken:latest],
+                 QONRemoteConfigV2TransitionStatusRejected);
+}
+
+- (void)testAdmissionRechecksLatestTokenAfterBlockingParseBeforeAnyPersistence {
+  QONRemoteConfigBlockingEnvelopeDecoder *decoder = [QONRemoteConfigBlockingEnvelopeDecoder new];
+  QONRemoteConfigFailingStorage *storage = [QONRemoteConfigFailingStorage new];
+  QONRemoteConfigV2Manager *manager = [self managerWithStorage:storage decoder:decoder];
+  QONRemoteConfigV2Scope *scope = [self wireScope:@"user"];
+  [manager setScope:scope];
+  QONRemoteConfigV2AdmissionToken *superseded = [manager beginAdmissionForScope:scope
+      expectation:[self wireExpectation]];
+  NSString *bodyString = [self wireBodyWithValues:[NSString stringWithFormat:@"\"only\":%@",
+      [self wireItemWithRaw:@"1" metadata:@"null" variationUID:@"variation"
+      policy:@"immediate"]]];
+  NSData *body = [self utf8Data:bodyString];
+  __block QONRemoteConfigV2TransitionStatus result = QONRemoteConfigV2TransitionStatusAccepted;
+  dispatch_group_t group = dispatch_group_create();
+  dispatch_group_async(group, dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    result = [manager admitBody:body strongETag:[self strongETagForBody:body]
+        admissionToken:superseded];
+  });
+  XCTAssertEqual(dispatch_semaphore_wait(decoder.started,
+      dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC)), 0L);
+
+  XCTAssertNotNil([manager beginAdmissionForScope:scope expectation:[self wireExpectation]]);
+  dispatch_semaphore_signal(decoder.resume);
+  XCTAssertEqual(dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC)), 0L);
+
+  XCTAssertEqual(result, QONRemoteConfigV2TransitionStatusRejected);
+  XCTAssertNil(manager.lastFetchedSnapshot);
+  XCTAssertNil(storage.objects[QONRemoteConfigV2StorageKey]);
+}
+
+- (void)testCompleteWireAdmissionTombstonesMissingActiveKeysAndAllowsEqualReleaseContextRerender {
+  QONRemoteConfigV2Manager *manager = [self managerWithStorage:[QNInMemoryStorage new]
+      decoder:[QONRemoteConfigV2EnvelopeParser new]];
+  QONRemoteConfigV2Scope *scope = [self wireScope:@"user"];
+  [manager setScope:scope];
+  [manager acceptFetchedRelease:[self release:@"initial" number:6 values:@{
+    @"kept": @"1", @"removed": @"2",
+  } immediate:NO] forScope:scope];
+  XCTAssertTrue([manager activate]);
+
+  NSString *firstBodyString = [self wireBodyWithValues:[NSString stringWithFormat:@"\"kept\":%@",
+      [self wireItemWithRaw:@"3" metadata:@"null" variationUID:@"variation-a"
+      policy:@"on_next_activate"]]];
+  NSData *firstBody = [self utf8Data:firstBodyString];
+  QONRemoteConfigV2AdmissionToken *firstToken = [manager beginAdmissionForScope:scope
+      expectation:[self wireExpectation]];
+  XCTAssertEqual([manager admitBody:firstBody strongETag:[self strongETagForBody:firstBody]
+      admissionToken:firstToken], QONRemoteConfigV2TransitionStatusAccepted);
+  XCTAssertTrue([manager activate]);
+  XCTAssertNil([manager.currentSnapshot rawValueForKey:@"removed"]);
+
+  NSString *secondBodyString = [firstBodyString
+      stringByReplacingOccurrencesOfString:@"\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\""
+      withString:@"\"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\""];
+  secondBodyString = [secondBodyString stringByReplacingOccurrencesOfString:@"variation-a"
+      withString:@"variation-b"];
+  NSData *secondBody = [self utf8Data:secondBodyString];
+  QONRemoteConfigV2AdmissionToken *secondToken = [manager beginAdmissionForScope:scope
+      expectation:[[QONRemoteConfigV2EnvelopeExpectation alloc] initWithProjectID:42
+          environmentUID:@"env-production"
+          contextFingerprint:[@"b" stringByPaddingToLength:64 withString:@"b" startingAtIndex:0]]];
+  XCTAssertEqual([manager admitBody:secondBody strongETag:[self strongETagForBody:secondBody]
+      admissionToken:secondToken], QONRemoteConfigV2TransitionStatusAccepted);
+  XCTAssertEqualObjects(manager.lastFetchedSnapshot.releaseUID, @"release");
+  XCTAssertTrue([manager activate]);
+  XCTAssertEqualObjects(manager.currentSnapshot.releaseUID, @"release");
+
+  NSString *lowerBodyString = [secondBodyString stringByReplacingOccurrencesOfString:
+      @"\"release_number\":7" withString:@"\"release_number\":6"];
+  NSData *lowerBody = [self utf8Data:lowerBodyString];
+  QONRemoteConfigV2AdmissionToken *lowerToken = [manager beginAdmissionForScope:scope
+      expectation:[[QONRemoteConfigV2EnvelopeExpectation alloc] initWithProjectID:42
+          environmentUID:@"env-production"
+          contextFingerprint:[@"b" stringByPaddingToLength:64 withString:@"b" startingAtIndex:0]]];
+  XCTAssertEqual([manager admitBody:lowerBody strongETag:[self strongETagForBody:lowerBody]
+      admissionToken:lowerToken], QONRemoteConfigV2TransitionStatusRejected);
+  XCTAssertEqual(manager.lastFetchedSnapshot.releaseNumber, 7);
+}
+
+- (void)testCommittedImmediateDeliverySurvivesNewerAdmissionThatNeverCommits {
+  QONRemoteConfigV2Manager *manager = [self managerWithFallback:nil];
+  QONRemoteConfigV2Scope *scope = [self wireScope:@"user"];
+  [manager setScope:scope];
+  __block NSMutableArray<NSString *> *observed = [NSMutableArray new];
+  [manager addUpdateObserver:^(QONRemoteConfigUpdate *update) {
+    if ([update.snapshot.releaseUID isEqualToString:@"blocking"]) {
+      [manager acceptFetchedRelease:[self release:@"release" number:2
+          values:@{@"key": @"2"} immediate:YES] forScope:scope];
+      XCTAssertNotNil([manager beginAdmissionForScope:scope expectation:[self wireExpectation]]);
+    }
+  }];
+  [manager addUpdateObserver:^(QONRemoteConfigUpdate *update) {
+    [observed addObject:update.snapshot.releaseUID];
+  }];
+  [manager acceptFetchedRelease:[self release:@"blocking" number:1
+      values:@{@"key": @"1"} immediate:YES] forScope:scope];
+
+  XCTAssertEqualObjects(observed, (@[@"blocking", @"release"]));
+  XCTAssertEqualObjects(manager.currentSnapshot.releaseUID, @"release");
+}
 
 - (NSData *)utf8Data:(NSString *)string {
   NSData *data = [string dataUsingEncoding:NSUTF8StringEncoding];
@@ -414,16 +826,81 @@
   XCTAssertEqualObjects(observed, (@[@"one", @"two"]));
 }
 
+- (void)testObserverCallbacksAlwaysRunOnMainExecutor {
+  QONRemoteConfigV2Manager *manager = [self managerWithFallback:nil];
+  QONRemoteConfigV2Scope *scope = [self scope:@"user"];
+  [manager setScope:scope];
+  XCTestExpectation *delivered = [self expectationWithDescription:@"main callback"];
+  [manager addUpdateObserver:^(__unused QONRemoteConfigUpdate *update) {
+    XCTAssertTrue(NSThread.isMainThread);
+    [delivered fulfill];
+  }];
+
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    [manager acceptFetchedRelease:[self release:@"one" number:1 values:@{@"key": @"1"}
+        immediate:YES] forScope:scope];
+  });
+
+  [self waitForExpectations:@[delivered] timeout:2];
+}
+
+- (void)testScopeFenceDropsOldDeliveryQueuedBeforeObserverInvocation {
+  QONRemoteConfigV2Manager *manager = [self managerWithFallback:nil];
+  QONRemoteConfigV2Scope *oldScope = [self scope:@"user-a"];
+  [manager setScope:oldScope];
+  dispatch_semaphore_t commitReturned = dispatch_semaphore_create(0);
+  __block NSUInteger oldCallbacks = 0;
+  [manager addUpdateObserver:^(__unused QONRemoteConfigUpdate *update) { oldCallbacks += 1; }];
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    [manager acceptFetchedRelease:[self release:@"private" number:1
+        values:@{@"key": @"1"} immediate:YES] forScope:oldScope];
+    dispatch_semaphore_signal(commitReturned);
+  });
+  XCTAssertEqual(dispatch_semaphore_wait(commitReturned,
+      dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC)), 0L);
+
+  [manager setScope:[self scope:@"user-b"]];
+  NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:0.05];
+  [NSRunLoop.currentRunLoop runUntilDate:deadline];
+
+  XCTAssertEqual(oldCallbacks, 0u);
+}
+
+- (void)testReentrantScopeChangeFencesRemainingObserversAndQueuedPrivateDelivery {
+  QONRemoteConfigV2Manager *manager = [self managerWithFallback:nil];
+  QONRemoteConfigV2Scope *scope = [self scope:@"user"];
+  [manager setScope:scope];
+  __block NSMutableArray<NSString *> *observed = [NSMutableArray new];
+  [manager addUpdateObserver:^(QONRemoteConfigUpdate *update) {
+    if ([update.snapshot.releaseUID isEqualToString:@"one"]) {
+      [manager setScope:nil];
+      [manager acceptFetchedRelease:[self release:@"two" number:2
+          values:@{@"key": @"2"} immediate:YES] forScope:scope];
+    }
+  }];
+  [manager addUpdateObserver:^(QONRemoteConfigUpdate *update) {
+    [observed addObject:update.snapshot.releaseUID];
+  }];
+
+  [manager acceptFetchedRelease:[self release:@"one" number:1 values:@{@"key": @"1"}
+      immediate:YES] forScope:scope];
+
+  XCTAssertEqualObjects(observed, (@[]));
+  XCTAssertEqualObjects(manager.currentSnapshot.releaseUID, @"");
+}
+
 - (void)testConcurrentCommitDuringSlowDeliveryPreservesFIFOOrder {
   QONRemoteConfigFailingStorage *storage = [QONRemoteConfigFailingStorage new];
-  QONRemoteConfigV2Manager *manager = [[QONRemoteConfigV2Manager alloc]
-      initWithStore:[[QONRemoteConfigV2Store alloc] initWithLocalStorage:storage]
-      fallbackRelease:nil fallbackProjectKey:nil fallbackEnvironment:nil];
+  dispatch_queue_t callbacks = dispatch_queue_create(
+      "io.qonversion.remote-config-v2-tests-fifo", DISPATCH_QUEUE_SERIAL);
+  QONRemoteConfigV2Manager *manager = [self managerWithStorage:storage
+      decoder:[QONRemoteConfigV2EnvelopeParser new] callbackExecutor:callbacks];
   QONRemoteConfigV2Scope *scope = [self scope:@"user"];
   [manager setScope:scope];
   dispatch_semaphore_t firstDeliveryStarted = dispatch_semaphore_create(0);
   dispatch_semaphore_t releaseFirstDelivery = dispatch_semaphore_create(0);
   dispatch_semaphore_t secondCommitFinished = dispatch_semaphore_create(0);
+  dispatch_semaphore_t bothDeliveriesObserved = dispatch_semaphore_create(0);
   __block NSMutableArray<NSString *> *observed = [NSMutableArray new];
   storage.writeObserver = ^(NSDictionary *root) {
     NSArray *scopes = root[@"scopes"];
@@ -439,7 +916,10 @@
     }
   }];
   [manager addUpdateObserver:^(QONRemoteConfigUpdate *update) {
-    @synchronized (observed) { [observed addObject:update.snapshot.releaseUID]; }
+    @synchronized (observed) {
+      [observed addObject:update.snapshot.releaseUID];
+      if (observed.count == 2) dispatch_semaphore_signal(bothDeliveriesObserved);
+    }
   }];
   dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
     [manager acceptFetchedRelease:[self release:@"one" number:1 values:@{@"key": @"1"}
@@ -455,20 +935,22 @@
       dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC)), 0);
   dispatch_semaphore_signal(releaseFirstDelivery);
 
-  NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:2];
-  while (observed.count < 2 && deadline.timeIntervalSinceNow > 0) {
-    [NSThread sleepForTimeInterval:0.005];
-  }
-  XCTAssertEqualObjects(observed, (@[@"one", @"two"]));
+  XCTAssertEqual(dispatch_semaphore_wait(bothDeliveriesObserved,
+      dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC)), 0L);
+  @synchronized (observed) { XCTAssertEqualObjects(observed, (@[@"one", @"two"])); }
 }
 
-- (void)testScopeChangeWaitsForInFlightDeliveryAndSuppressesRemainingOldScopeCallbacks {
-  QONRemoteConfigV2Manager *manager = [self managerWithFallback:nil];
+- (void)testScopeChangeCompletesDuringInFlightDeliveryAndSuppressesRemainingOldScopeCallbacks {
+  dispatch_queue_t callbacks = dispatch_queue_create(
+      "io.qonversion.remote-config-v2-tests-scope", DISPATCH_QUEUE_SERIAL);
+  QONRemoteConfigV2Manager *manager = [self managerWithStorage:[QNInMemoryStorage new]
+      decoder:[QONRemoteConfigV2EnvelopeParser new] callbackExecutor:callbacks];
   QONRemoteConfigV2Scope *scope = [self scope:@"user"];
   [manager setScope:scope];
   dispatch_semaphore_t firstObserverStarted = dispatch_semaphore_create(0);
   dispatch_semaphore_t releaseFirstObserver = dispatch_semaphore_create(0);
   dispatch_semaphore_t logoutFinished = dispatch_semaphore_create(0);
+  dispatch_semaphore_t deliveryFinished = dispatch_semaphore_create(0);
   __block BOOL callbackAfterLogout = NO;
   [manager addUpdateObserver:^(__unused QONRemoteConfigUpdate *update) {
     dispatch_semaphore_signal(firstObserverStarted);
@@ -481,6 +963,7 @@
   dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
     [manager acceptFetchedRelease:[self release:@"private" number:1
         values:@{@"key": @"\"private\""} immediate:YES] forScope:scope];
+    dispatch_semaphore_signal(deliveryFinished);
   });
   XCTAssertEqual(dispatch_semaphore_wait(firstObserverStarted,
       dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC)), 0);
@@ -488,13 +971,73 @@
     [manager setScope:nil];
     dispatch_semaphore_signal(logoutFinished);
   });
-  XCTAssertNotEqual(dispatch_semaphore_wait(logoutFinished,
-      dispatch_time(DISPATCH_TIME_NOW, 100 * NSEC_PER_MSEC)), 0);
-  dispatch_semaphore_signal(releaseFirstObserver);
   XCTAssertEqual(dispatch_semaphore_wait(logoutFinished,
-      dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC)), 0);
+      dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC)), 0L);
+  dispatch_semaphore_signal(releaseFirstObserver);
+  XCTAssertEqual(dispatch_semaphore_wait(deliveryFinished,
+      dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC)), 0L);
 
   XCTAssertFalse(callbackAfterLogout);
+  XCTAssertEqualObjects(manager.currentSnapshot.releaseUID, @"");
+}
+
+- (void)testBackgroundObserverMainSyncCannotDeadlockMainScopeFenceOrLeakOldScopeDelivery {
+  XCTAssertTrue(NSThread.isMainThread);
+  QONRemoteConfigFailingStorage *storage = [QONRemoteConfigFailingStorage new];
+  dispatch_queue_t callbacks = dispatch_queue_create(
+      "io.qonversion.remote-config-v2-tests-main-hop", DISPATCH_QUEUE_SERIAL);
+  QONRemoteConfigV2Manager *manager = [self managerWithStorage:storage
+      decoder:[QONRemoteConfigV2EnvelopeParser new] callbackExecutor:callbacks];
+  QONRemoteConfigV2Scope *oldScope = [self scope:@"user-a"];
+  QONRemoteConfigV2Scope *newScope = [self scope:@"user-b"];
+  [manager setScope:oldScope];
+  dispatch_semaphore_t firstObserverStarted = dispatch_semaphore_create(0);
+  dispatch_semaphore_t secondAcceptanceReturned = dispatch_semaphore_create(0);
+  dispatch_semaphore_t callbackQueueDrained = dispatch_semaphore_create(0);
+  __block NSUInteger firstObserverInvocations = 0;
+  __block NSUInteger remainingObserverInvocations = 0;
+  __block BOOL mainHopDidRun = NO;
+  [manager addUpdateObserver:^(QONRemoteConfigUpdate *update) {
+    firstObserverInvocations += 1;
+    if ([update.snapshot.releaseUID isEqualToString:@"one"]) {
+      dispatch_semaphore_signal(firstObserverStarted);
+      dispatch_sync(dispatch_get_main_queue(), ^{ mainHopDidRun = YES; });
+    }
+  }];
+  [manager addUpdateObserver:^(__unused QONRemoteConfigUpdate *update) {
+    remainingObserverInvocations += 1;
+  }];
+
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    [manager acceptFetchedRelease:[self release:@"one" number:1 values:@{@"key": @"1"}
+        immediate:YES] forScope:oldScope];
+  });
+  XCTAssertEqual(dispatch_semaphore_wait(firstObserverStarted,
+      dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC)), 0L);
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    [manager acceptFetchedRelease:[self release:@"two" number:2 values:@{@"key": @"2"}
+        immediate:YES] forScope:oldScope];
+    dispatch_semaphore_signal(secondAcceptanceReturned);
+  });
+  XCTAssertEqual(dispatch_semaphore_wait(secondAcceptanceReturned,
+      dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC)), 0L);
+
+  [manager setScope:newScope];
+  XCTAssertEqualObjects(manager.currentSnapshot.releaseUID, @"");
+  dispatch_async(callbacks, ^{ dispatch_semaphore_signal(callbackQueueDrained); });
+  NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:2];
+  BOOL didDrainCallbackQueue = NO;
+  while (!didDrainCallbackQueue && deadline.timeIntervalSinceNow > 0) {
+    didDrainCallbackQueue = dispatch_semaphore_wait(
+        callbackQueueDrained, DISPATCH_TIME_NOW) == 0;
+    if (didDrainCallbackQueue) break;
+    [NSRunLoop.currentRunLoop runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.005]];
+  }
+
+  XCTAssertTrue(didDrainCallbackQueue);
+  XCTAssertTrue(mainHopDidRun);
+  XCTAssertEqual(firstObserverInvocations, 1u);
+  XCTAssertEqual(remainingObserverInvocations, 0u);
   XCTAssertEqualObjects(manager.currentSnapshot.releaseUID, @"");
 }
 

--- a/QonversionTests/Storage/QONRemoteConfigV2StoreTests.m
+++ b/QonversionTests/Storage/QONRemoteConfigV2StoreTests.m
@@ -4,6 +4,7 @@
 //
 
 #import <XCTest/XCTest.h>
+#import <CommonCrypto/CommonDigest.h>
 
 #import "QNInMemoryStorage.h"
 #import "QONRemoteConfigV2Models.h"
@@ -77,9 +78,57 @@
       initWithProjectKey:@"project" environment:@"production" canonicalUserID:userID];
 }
 
+- (NSString *)strongETagForBody:(NSData *)body {
+  uint8_t digest[CC_SHA256_DIGEST_LENGTH];
+  CC_SHA256(body.bytes, (CC_LONG)body.length, digest);
+  NSMutableString *hex = [NSMutableString stringWithString:@"\""];
+  for (NSUInteger index = 0; index < CC_SHA256_DIGEST_LENGTH; index++) {
+    [hex appendFormat:@"%02x", digest[index]];
+  }
+  [hex appendString:@"\""];
+  return [hex copy];
+}
+
+- (void)refreshDigestForMutableState:(NSMutableDictionary *)state {
+  NSMutableDictionary *payload = [state mutableCopy];
+  [payload removeObjectForKey:@"state_digest"];
+  NSData *data = [NSJSONSerialization dataWithJSONObject:payload
+      options:NSJSONWritingSortedKeys error:nil];
+  uint8_t digest[CC_SHA256_DIGEST_LENGTH];
+  CC_SHA256(data.bytes, (CC_LONG)data.length, digest);
+  NSMutableString *hex = [NSMutableString stringWithCapacity:CC_SHA256_DIGEST_LENGTH * 2];
+  for (NSUInteger index = 0; index < CC_SHA256_DIGEST_LENGTH; index++) {
+    [hex appendFormat:@"%02x", digest[index]];
+  }
+  state[@"state_digest"] = hex;
+}
+
+- (QONRemoteConfigV2Release *)wireReleaseWithUID:(NSString *)releaseUID
+                                           number:(NSInteger)releaseNumber
+                                          ordinal:(int64_t)ordinal
+                                              raw:(NSString *)raw
+                                         metadata:(NSString *)metadata {
+  NSString *context = [@"b" stringByPaddingToLength:64 withString:@"b" startingAtIndex:0];
+  NSString *bodyString = [NSString stringWithFormat:
+      @"{\"schema_version\":1,\"project_id\":42,\"environment_uid\":\"production\","
+       "\"release_uid\":\"%@\",\"release_number\":%ld,\"manifest_content_hash\":"
+       "\"05b3abf2579a5eb66403cd78be557fd860633a1fe2103c7642030defe32c657f\","
+       "\"complete_key_set\":true,\"context_fingerprint\":\"%@\",\"values\":{"
+       "\"key\":{\"raw\":%@,\"variation_uid\":\"variation\","
+       "\"apply_policy\":\"on_next_activate\",\"metadata\":%@}}}",
+      releaseUID, (long)releaseNumber, context, raw, metadata];
+  NSData *body = [self utf8Data:bodyString];
+  QONRemoteConfigV2EnvelopeExpectation *expectation = [[QONRemoteConfigV2EnvelopeExpectation alloc]
+      initWithProjectID:42 environmentUID:@"production" contextFingerprint:context];
+  QONRemoteConfigV2Envelope *envelope = [[QONRemoteConfigV2EnvelopeParser new]
+      parseBody:body strongETag:[self strongETagForBody:body] expectation:expectation];
+  XCTAssertNotNil(envelope);
+  return [envelope.snapshotRelease releaseBySettingAdmissionOrdinal:ordinal];
+}
+
 - (QONRemoteConfigV2Release *)largeRelease:(NSString *)uid fill:(unichar)fill {
   NSMutableDictionary *entries = [NSMutableDictionary new];
-  for (NSUInteger index = 0; index < 44; index++) {
+  for (NSUInteger index = 0; index < 61; index++) {
     NSString *prefix = [NSString stringWithFormat:@"%C-%@-%02lu", fill, uid,
         (unsigned long)index];
     NSMutableString *json = [NSMutableString stringWithString:@"\""];
@@ -96,6 +145,289 @@
   return [[QONRemoteConfigV2Release alloc] initWithReleaseUID:uid releaseNumber:1
       manifestContentHash:[@"a" stringByPaddingToLength:64 withString:@"a" startingAtIndex:0]
       entries:entries];
+}
+
+- (QONRemoteConfigV2Release *)wireReleaseWithOrdinal:(int64_t)ordinal {
+  return [self wireReleaseWithUID:@"wire" number:7 ordinal:ordinal
+      raw:@" { \"nested\" : 1 } " metadata:@" { \"reset\" : true } "];
+}
+
+- (QONRemoteConfigV2Release *)maximumAggregateWireReleaseWithOrdinal:(int64_t)ordinal {
+  NSString *releaseUID = @"maximum-wire";
+  NSString *manifestHash = @"05b3abf2579a5eb66403cd78be557fd860633a1fe2103c7642030defe32c657f";
+  NSString *context = [@"c" stringByPaddingToLength:64 withString:@"c" startingAtIndex:0];
+  NSUInteger remaining = QONRemoteConfigV2MaximumTotalValueBytes -
+      [releaseUID lengthOfBytesUsingEncoding:NSUTF8StringEncoding] -
+      [manifestHash lengthOfBytesUsingEncoding:NSUTF8StringEncoding];
+  NSMutableArray<NSString *> *items = [NSMutableArray new];
+  for (NSUInteger index = 0; remaining > 0; index++) {
+    NSString *key = [NSString stringWithFormat:@"key-%02lu", (unsigned long)index];
+    NSString *variation = [NSString stringWithFormat:@"v-%02lu", (unsigned long)index];
+    NSUInteger fixedBytes = [key lengthOfBytesUsingEncoding:NSUTF8StringEncoding] +
+        [variation lengthOfBytesUsingEncoding:NSUTF8StringEncoding] + 4;
+    XCTAssertGreaterThan(remaining, fixedBytes + 1);
+    NSUInteger rawBytes = MIN(QONRemoteConfigV2MaximumRawValueBytes, remaining - fixedBytes);
+    NSString *raw = [NSString stringWithFormat:@"\"%@\"",
+        [@"x" stringByPaddingToLength:rawBytes - 2 withString:@"x" startingAtIndex:0]];
+    [items addObject:[NSString stringWithFormat:
+        @"\"%@\":{\"raw\":%@,\"variation_uid\":\"%@\","
+         "\"apply_policy\":\"on_next_activate\",\"metadata\":null}",
+        key, raw, variation]];
+    remaining -= fixedBytes + rawBytes;
+  }
+  NSString *bodyString = [NSString stringWithFormat:
+      @"{\"schema_version\":1,\"project_id\":42,\"environment_uid\":\"production\","
+       "\"release_uid\":\"%@\",\"release_number\":7,\"manifest_content_hash\":\"%@\","
+       "\"complete_key_set\":true,\"context_fingerprint\":\"%@\",\"values\":{%@}}",
+      releaseUID, manifestHash, context, [items componentsJoinedByString:@","]];
+  NSData *body = [self utf8Data:bodyString];
+  QONRemoteConfigV2EnvelopeExpectation *expectation = [[QONRemoteConfigV2EnvelopeExpectation alloc]
+      initWithProjectID:42 environmentUID:@"production" contextFingerprint:context];
+  QONRemoteConfigV2Envelope *envelope = [[QONRemoteConfigV2EnvelopeParser new]
+      parseBody:body strongETag:[self strongETagForBody:body] expectation:expectation];
+  XCTAssertNotNil(envelope);
+  return [envelope.snapshotRelease releaseBySettingAdmissionOrdinal:ordinal];
+}
+
+- (void)testWireStateRoundTripsExactBodyETagContextMetadataAndAdmissionHighWater {
+  QNInMemoryStorage *storage = [QNInMemoryStorage new];
+  QONRemoteConfigV2Store *store = [[QONRemoteConfigV2Store alloc] initWithLocalStorage:storage];
+  QONRemoteConfigV2Release *candidate = [self wireReleaseWithOrdinal:5];
+  QONRemoteConfigV2State *state = [[QONRemoteConfigV2State alloc]
+      initWithCandidate:candidate active:nil previous:nil didActivate:NO
+      latestAdmissionOrdinal:7];
+
+  XCTAssertTrue([store saveState:state forScope:[self scopeForUser:@"user"]]);
+  QONRemoteConfigV2State *reloaded = [[[QONRemoteConfigV2Store alloc]
+      initWithLocalStorage:storage] stateForScope:[self scopeForUser:@"user"]];
+
+  XCTAssertEqual(reloaded.latestAdmissionOrdinal, 7);
+  XCTAssertEqual(reloaded.candidate.admissionOrdinal, 5);
+  XCTAssertEqual(reloaded.candidate.projectID, 42);
+  XCTAssertEqualObjects(reloaded.candidate.canonicalBody, candidate.canonicalBody);
+  XCTAssertEqualObjects(reloaded.candidate.strongETag, candidate.strongETag);
+  XCTAssertEqualObjects(reloaded.candidate.contextFingerprint,
+      [@"b" stringByPaddingToLength:64 withString:@"b" startingAtIndex:0]);
+  XCTAssertEqualObjects(reloaded.candidate.entries[@"key"].rawData,
+      [self utf8Data:@" { \"nested\" : 1 } "]);
+  XCTAssertEqualObjects(reloaded.candidate.entries[@"key"].metadataData,
+      [self utf8Data:@" { \"reset\" : true } "]);
+  NSDictionary *archive = [storage loadObjectForKey:QONRemoteConfigV2StorageKey];
+  XCTAssertNotNil(archive[@"scopes"][0][@"state"][@"state_digest"]);
+}
+
+- (void)testDigestMismatchCanonicalReparseRemainsBoundToOriginalProjectExpectation {
+  QNInMemoryStorage *storage = [QNInMemoryStorage new];
+  QONRemoteConfigV2Store *store = [[QONRemoteConfigV2Store alloc] initWithLocalStorage:storage];
+  QONRemoteConfigV2Scope *scope = [self scopeForUser:@"project-bound-user"];
+  QONRemoteConfigV2State *state = [[QONRemoteConfigV2State alloc]
+      initWithCandidate:[self wireReleaseWithOrdinal:5] active:nil previous:nil
+      didActivate:NO latestAdmissionOrdinal:5];
+  XCTAssertTrue([store saveState:state forScope:scope]);
+  NSMutableDictionary *archive = [self mutablePropertyListCopy:
+      [storage loadObjectForKey:QONRemoteConfigV2StorageKey]];
+  NSMutableDictionary *storedCandidate = archive[@"scopes"][0][@"state"][@"candidate"];
+  NSData *originalBody = [[NSData alloc] initWithBase64EncodedString:
+      storedCandidate[@"canonical_body"] options:0];
+  NSString *bodyString = [[NSString alloc] initWithData:originalBody encoding:NSUTF8StringEncoding];
+  NSData *otherProjectBody = [self utf8Data:[bodyString stringByReplacingOccurrencesOfString:
+      @"\"project_id\":42" withString:@"\"project_id\":43"]];
+  storedCandidate[@"canonical_body"] = [otherProjectBody base64EncodedStringWithOptions:0];
+  storedCandidate[@"strong_etag"] = [self strongETagForBody:otherProjectBody];
+  [storage storeObject:archive forKey:QONRemoteConfigV2StorageKey];
+
+  XCTAssertNil([store stateForScope:scope]);
+  XCTAssertNil([storage loadObjectForKey:QONRemoteConfigV2StorageKey]);
+}
+
+- (void)testUserOnlyScopeTamperDiscardsWholeRecordBeforeCanonicalSalvage {
+  QNInMemoryStorage *storage = [QNInMemoryStorage new];
+  QONRemoteConfigV2Store *store = [[QONRemoteConfigV2Store alloc] initWithLocalStorage:storage];
+  QONRemoteConfigV2State *state = [[QONRemoteConfigV2State alloc]
+      initWithCandidate:[self wireReleaseWithOrdinal:5] active:nil previous:nil
+      didActivate:NO latestAdmissionOrdinal:5];
+  XCTAssertTrue([store saveState:state forScope:[self scopeForUser:@"user-a"]]);
+  NSMutableDictionary *archive = [self mutablePropertyListCopy:
+      [storage loadObjectForKey:QONRemoteConfigV2StorageKey]];
+  archive[@"scopes"][0][@"scope"][@"user"] = @"user-b";
+  [storage storeObject:archive forKey:QONRemoteConfigV2StorageKey];
+
+  XCTAssertNil([store stateForScope:[self scopeForUser:@"user-b"]]);
+  XCTAssertNil([storage loadObjectForKey:QONRemoteConfigV2StorageKey]);
+}
+
+- (void)testProjectKeyOnlyScopeTamperDiscardsWholeRecordBeforeCanonicalSalvage {
+  QNInMemoryStorage *storage = [QNInMemoryStorage new];
+  QONRemoteConfigV2Store *store = [[QONRemoteConfigV2Store alloc] initWithLocalStorage:storage];
+  QONRemoteConfigV2State *state = [[QONRemoteConfigV2State alloc]
+      initWithCandidate:[self wireReleaseWithOrdinal:5] active:nil previous:nil
+      didActivate:NO latestAdmissionOrdinal:5];
+  XCTAssertTrue([store saveState:state forScope:[self scopeForUser:@"user"]]);
+  NSMutableDictionary *archive = [self mutablePropertyListCopy:
+      [storage loadObjectForKey:QONRemoteConfigV2StorageKey]];
+  archive[@"scopes"][0][@"scope"][@"project"] = @"other-project";
+  [storage storeObject:archive forKey:QONRemoteConfigV2StorageKey];
+  QONRemoteConfigV2Scope *tamperedScope = [[QONRemoteConfigV2Scope alloc]
+      initWithProjectKey:@"other-project" environment:@"production" canonicalUserID:@"user"];
+
+  XCTAssertNil([store stateForScope:tamperedScope]);
+  XCTAssertNil([storage loadObjectForKey:QONRemoteConfigV2StorageKey]);
+}
+
+- (void)testCoordinatedOuterAndInnerUserTamperStillDiscardsWholeRecord {
+  QNInMemoryStorage *storage = [QNInMemoryStorage new];
+  QONRemoteConfigV2Store *store = [[QONRemoteConfigV2Store alloc] initWithLocalStorage:storage];
+  QONRemoteConfigV2State *state = [[QONRemoteConfigV2State alloc]
+      initWithCandidate:[self wireReleaseWithOrdinal:5] active:nil previous:nil
+      didActivate:NO latestAdmissionOrdinal:5];
+  XCTAssertTrue([store saveState:state forScope:[self scopeForUser:@"user-a"]]);
+  NSMutableDictionary *archive = [self mutablePropertyListCopy:
+      [storage loadObjectForKey:QONRemoteConfigV2StorageKey]];
+  archive[@"scopes"][0][@"scope"][@"user"] = @"user-b";
+  archive[@"scopes"][0][@"state"][@"scope_binding"][@"user"] = @"user-b";
+  [storage storeObject:archive forKey:QONRemoteConfigV2StorageKey];
+
+  XCTAssertNil([store stateForScope:[self scopeForUser:@"user-b"]]);
+  XCTAssertNil([storage loadObjectForKey:QONRemoteConfigV2StorageKey]);
+}
+
+- (void)testCoordinatedOuterAndInnerProjectTamperStillDiscardsWholeRecord {
+  QNInMemoryStorage *storage = [QNInMemoryStorage new];
+  QONRemoteConfigV2Store *store = [[QONRemoteConfigV2Store alloc] initWithLocalStorage:storage];
+  QONRemoteConfigV2State *state = [[QONRemoteConfigV2State alloc]
+      initWithCandidate:[self wireReleaseWithOrdinal:5] active:nil previous:nil
+      didActivate:NO latestAdmissionOrdinal:5];
+  XCTAssertTrue([store saveState:state forScope:[self scopeForUser:@"user"]]);
+  NSMutableDictionary *archive = [self mutablePropertyListCopy:
+      [storage loadObjectForKey:QONRemoteConfigV2StorageKey]];
+  archive[@"scopes"][0][@"scope"][@"project"] = @"other-project";
+  archive[@"scopes"][0][@"state"][@"scope_binding"][@"project"] = @"other-project";
+  [storage storeObject:archive forKey:QONRemoteConfigV2StorageKey];
+  QONRemoteConfigV2Scope *tamperedScope = [[QONRemoteConfigV2Scope alloc]
+      initWithProjectKey:@"other-project" environment:@"production" canonicalUserID:@"user"];
+
+  XCTAssertNil([store stateForScope:tamperedScope]);
+  XCTAssertNil([storage loadObjectForKey:QONRemoteConfigV2StorageKey]);
+}
+
+- (void)testSwappingOtherwiseValidStatesBetweenScopeRecordsDiscardsBothRecords {
+  QNInMemoryStorage *storage = [QNInMemoryStorage new];
+  QONRemoteConfigV2Store *store = [[QONRemoteConfigV2Store alloc] initWithLocalStorage:storage];
+  QONRemoteConfigV2Scope *userA = [self scopeForUser:@"user-a"];
+  QONRemoteConfigV2Scope *userB = [self scopeForUser:@"user-b"];
+  XCTAssertTrue([store saveState:[[QONRemoteConfigV2State alloc]
+      initWithCandidate:[self release:@"release-a" value:@"1"]
+      active:nil previous:nil didActivate:NO] forScope:userA]);
+  XCTAssertTrue([store saveState:[[QONRemoteConfigV2State alloc]
+      initWithCandidate:[self release:@"release-b" value:@"2"]
+      active:nil previous:nil didActivate:NO] forScope:userB]);
+  NSMutableDictionary *archive = [self mutablePropertyListCopy:
+      [storage loadObjectForKey:QONRemoteConfigV2StorageKey]];
+  id firstState = archive[@"scopes"][0][@"state"];
+  archive[@"scopes"][0][@"state"] = archive[@"scopes"][1][@"state"];
+  archive[@"scopes"][1][@"state"] = firstState;
+  [storage storeObject:archive forKey:QONRemoteConfigV2StorageKey];
+
+  XCTAssertNil([store stateForScope:userA]);
+  XCTAssertNil([store stateForScope:userB]);
+  XCTAssertNil([storage loadObjectForKey:QONRemoteConfigV2StorageKey]);
+}
+
+- (void)testDigestConsistentScalarCandidateSlotsFailClosedWithoutDynamicDispatchCrash {
+  NSArray *invalidSlots = @[@"scalar", @42, NSNull.null];
+  for (id invalidSlot in invalidSlots) {
+    QNInMemoryStorage *storage = [QNInMemoryStorage new];
+    QONRemoteConfigV2Store *store = [[QONRemoteConfigV2Store alloc]
+        initWithLocalStorage:storage];
+    QONRemoteConfigV2Scope *scope = [self scopeForUser:@"scalar-user"];
+    QONRemoteConfigV2State *state = [[QONRemoteConfigV2State alloc]
+        initWithCandidate:[self wireReleaseWithOrdinal:5] active:nil previous:nil
+        didActivate:NO latestAdmissionOrdinal:5];
+    XCTAssertTrue([store saveState:state forScope:scope]);
+    NSMutableDictionary *archive = [self mutablePropertyListCopy:
+        [storage loadObjectForKey:QONRemoteConfigV2StorageKey]];
+    NSMutableDictionary *storedState = archive[@"scopes"][0][@"state"];
+    storedState[@"candidate"] = invalidSlot;
+    [self refreshDigestForMutableState:storedState];
+    [storage storeObject:archive forKey:QONRemoteConfigV2StorageKey];
+
+    XCTAssertNil([store stateForScope:scope], @"%@", invalidSlot);
+    XCTAssertNil([storage loadObjectForKey:QONRemoteConfigV2StorageKey]);
+  }
+}
+
+- (void)testDigestMismatchDiscardsWholeRecordEvenWhenCanonicalBodyIsValid {
+  QNInMemoryStorage *storage = [QNInMemoryStorage new];
+  QONRemoteConfigV2Store *store = [[QONRemoteConfigV2Store alloc] initWithLocalStorage:storage];
+  QONRemoteConfigV2Scope *scope = [self scopeForUser:@"user"];
+  QONRemoteConfigV2Release *candidate = [self wireReleaseWithOrdinal:5];
+  QONRemoteConfigV2State *state = [[QONRemoteConfigV2State alloc]
+      initWithCandidate:candidate active:nil previous:nil didActivate:NO
+      latestAdmissionOrdinal:5];
+  XCTAssertTrue([store saveState:state forScope:scope]);
+  NSMutableDictionary *archive = [self mutablePropertyListCopy:
+      [storage loadObjectForKey:QONRemoteConfigV2StorageKey]];
+  NSMutableDictionary *storedCandidate = archive[@"scopes"][0][@"state"][@"candidate"];
+  NSMutableDictionary *storedEntry = storedCandidate[@"entries"][0];
+  NSData *parseValidMutation = [self utf8Data:@" { \"nested\" : 2 } "];
+  storedEntry[@"raw"] = [parseValidMutation base64EncodedStringWithOptions:0];
+  [storage storeObject:archive forKey:QONRemoteConfigV2StorageKey];
+
+  XCTAssertNil([store stateForScope:scope]);
+  XCTAssertNil([storage loadObjectForKey:QONRemoteConfigV2StorageKey]);
+}
+
+- (void)testMaximumAggregateThreeReleaseHistoryProvablyFitsArchiveBudget {
+  QNInMemoryStorage *storage = [QNInMemoryStorage new];
+  QONRemoteConfigV2Store *store = [[QONRemoteConfigV2Store alloc] initWithLocalStorage:storage];
+  QONRemoteConfigV2Release *wire = [self maximumAggregateWireReleaseWithOrdinal:3];
+  QONRemoteConfigV2State *state = [[QONRemoteConfigV2State alloc]
+      initWithCandidate:wire
+      active:[wire releaseBySettingAdmissionOrdinal:2]
+      previous:[wire releaseBySettingAdmissionOrdinal:1]
+      didActivate:YES latestAdmissionOrdinal:3];
+  QONRemoteConfigV2Scope *scope = [self scopeForUser:@"maximum-user"];
+
+  XCTAssertTrue([store saveState:state forScope:scope]);
+  NSDictionary *root = [storage loadObjectForKey:QONRemoteConfigV2StorageKey];
+  NSData *archive = [NSPropertyListSerialization dataWithPropertyList:root
+      format:NSPropertyListBinaryFormat_v1_0 options:0 error:nil];
+  XCTAssertGreaterThan(archive.length, 32 * 1024 * 1024);
+  XCTAssertLessThanOrEqual(archive.length, QONRemoteConfigV2MaximumArchiveBytes);
+  QONRemoteConfigV2State *reloaded = [[[QONRemoteConfigV2Store alloc]
+      initWithLocalStorage:storage] stateForScope:scope];
+  XCTAssertEqual(reloaded.candidate.admissionOrdinal, 3);
+  XCTAssertEqual(reloaded.active.admissionOrdinal, 2);
+  XCTAssertEqual(reloaded.previous.admissionOrdinal, 1);
+}
+
+- (void)testTamperedMaximumAdmissionHighWaterDiscardsWholeRecord {
+  QNInMemoryStorage *storage = [QNInMemoryStorage new];
+  QONRemoteConfigV2Store *store = [[QONRemoteConfigV2Store alloc] initWithLocalStorage:storage];
+  QONRemoteConfigV2State *state = [[QONRemoteConfigV2State alloc]
+      initWithCandidate:[self wireReleaseWithOrdinal:5] active:nil previous:nil
+      didActivate:NO latestAdmissionOrdinal:7];
+  XCTAssertTrue([store saveState:state forScope:[self scopeForUser:@"user"]]);
+  NSMutableDictionary *archive = [self mutablePropertyListCopy:
+      [storage loadObjectForKey:QONRemoteConfigV2StorageKey]];
+  archive[@"scopes"][0][@"state"][@"latest_admission_ordinal"] = @(INT64_MAX);
+  [storage storeObject:archive forKey:QONRemoteConfigV2StorageKey];
+
+  XCTAssertNil([store stateForScope:[self scopeForUser:@"user"]]);
+  XCTAssertNil([storage loadObjectForKey:QONRemoteConfigV2StorageKey]);
+}
+
+- (void)testColdDiscardOfUnshippedSchemaOneDoesNotTouchLegacyRemoteConfigLKG {
+  QNInMemoryStorage *storage = [QNInMemoryStorage new];
+  NSDictionary *legacy = @{@"private": @"still-here"};
+  [storage storeObject:legacy forKey:@"com.qonversion.keys.remote-config-lkg"];
+  [storage storeObject:@{@"schema_version": @1, @"scopes": @[]}
+                 forKey:QONRemoteConfigV2StorageKey];
+  QONRemoteConfigV2Store *store = [[QONRemoteConfigV2Store alloc] initWithLocalStorage:storage];
+
+  XCTAssertNil([store stateForScope:[self scopeForUser:@"user"]]);
+  XCTAssertNil([storage loadObjectForKey:QONRemoteConfigV2StorageKey]);
+  XCTAssertEqualObjects([storage loadObjectForKey:@"com.qonversion.keys.remote-config-lkg"], legacy);
 }
 
 - (void)testStoresWholeVersionedStatePerExactPrivacyScopeWithoutTouchingLegacyLKG {
@@ -210,15 +542,17 @@
   [[NSFileManager defaultManager] removeItemAtURL:directory error:nil];
 }
 
-- (void)testCorruptCandidateIsSalvagedWithoutErasingActivePreviousOrOtherScopes {
+- (void)testDigestCorruptionDiscardsAffectedScopeWithoutErasingOtherScopes {
   QNInMemoryStorage *storage = [QNInMemoryStorage new];
   QONRemoteConfigV2Store *store = [[QONRemoteConfigV2Store alloc] initWithLocalStorage:storage];
   QONRemoteConfigV2Scope *userA = [self scopeForUser:@"user-a"];
   QONRemoteConfigV2Scope *userB = [self scopeForUser:@"user-b"];
   QONRemoteConfigV2State *stateA = [[QONRemoteConfigV2State alloc]
-      initWithCandidate:[self release:@"three" number:3 value:@"3"]
-      active:[self release:@"two" number:2 value:@"2"]
-      previous:[self release:@"one" number:1 value:@"1"] didActivate:YES];
+      initWithCandidate:[self wireReleaseWithUID:@"three" number:3 ordinal:3
+          raw:@"3" metadata:@"null"]
+      active:[self wireReleaseWithUID:@"two" number:2 ordinal:2 raw:@"2" metadata:@"null"]
+      previous:[self wireReleaseWithUID:@"one" number:1 ordinal:1 raw:@"1" metadata:@"null"]
+      didActivate:YES latestAdmissionOrdinal:3];
   QONRemoteConfigV2State *stateB = [[QONRemoteConfigV2State alloc]
       initWithCandidate:[self release:@"other" number:1 value:@"4"]
       active:nil previous:nil didActivate:NO];
@@ -230,16 +564,12 @@
   candidate[@"uid"] = [@"x" stringByPaddingToLength:37 withString:@"x" startingAtIndex:0];
   [storage storeObject:archive forKey:QONRemoteConfigV2StorageKey];
 
-  QONRemoteConfigV2State *salvaged = [store stateForScope:userA];
-
-  XCTAssertNil(salvaged.candidate);
-  XCTAssertEqualObjects(salvaged.active.releaseUID, @"two");
-  XCTAssertEqualObjects(salvaged.previous.releaseUID, @"one");
+  XCTAssertNil([store stateForScope:userA]);
   XCTAssertEqualObjects([store stateForScope:userB].candidate.releaseUID, @"other");
   QONRemoteConfigV2Store *restarted = [[QONRemoteConfigV2Store alloc]
       initWithLocalStorage:storage];
-  XCTAssertNil([restarted stateForScope:userA].candidate);
-  XCTAssertEqualObjects([restarted stateForScope:userA].active.releaseUID, @"two");
+  XCTAssertNil([restarted stateForScope:userA]);
+  XCTAssertEqualObjects([restarted stateForScope:userB].candidate.releaseUID, @"other");
 }
 
 - (void)testTransientReadFailureIsDistinctFromMissingAndNeverDeletesDurableState {
@@ -303,7 +633,7 @@
   QNInMemoryStorage *storage = [QNInMemoryStorage new];
   QONRemoteConfigV2Store *store = [[QONRemoteConfigV2Store alloc] initWithLocalStorage:storage];
   NSMutableArray<QONRemoteConfigV2Scope *> *scopes = [NSMutableArray new];
-  for (NSUInteger index = 0; index < 12; index++) {
+  for (NSUInteger index = 0; index < 14; index++) {
     @autoreleasepool {
       NSString *userID = [NSString stringWithFormat:@"large-user-%02lu", (unsigned long)index];
       NSString *releaseUID = [NSString stringWithFormat:@"large-%02lu", (unsigned long)index];
@@ -319,13 +649,13 @@
   NSData *archive = [NSPropertyListSerialization dataWithPropertyList:root
       format:NSPropertyListBinaryFormat_v1_0 options:0 error:nil];
 
-  XCTAssertLessThanOrEqual(archive.length, 32 * 1024 * 1024);
+  XCTAssertLessThanOrEqual(archive.length, QONRemoteConfigV2MaximumArchiveBytes);
   QONRemoteConfigV2Scope *oldestScope = scopes.firstObject;
   QONRemoteConfigV2Scope *newestScope = scopes.lastObject;
   XCTAssertNotNil(oldestScope);
   XCTAssertNotNil(newestScope);
   XCTAssertNil([store stateForScope:oldestScope]);
-  XCTAssertEqualObjects([store stateForScope:newestScope].candidate.releaseUID, @"large-11");
+  XCTAssertEqualObjects([store stateForScope:newestScope].candidate.releaseUID, @"large-13");
 }
 
 @end

--- a/Sources/Qonversion/Qonversion/Core/QONRemoteConfigV2Store/QONRemoteConfigV2Store.h
+++ b/Sources/Qonversion/Qonversion/Core/QONRemoteConfigV2Store/QONRemoteConfigV2Store.h
@@ -7,6 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 FOUNDATION_EXPORT NSString *const QONRemoteConfigV2StorageKey;
 FOUNDATION_EXPORT NSUInteger const QONRemoteConfigV2MaximumPersistedScopes;
+FOUNDATION_EXPORT NSUInteger const QONRemoteConfigV2MaximumArchiveBytes;
 
 typedef NS_ENUM(NSInteger, QONRemoteConfigV2StoreLoadStatus) {
   QONRemoteConfigV2StoreLoadStatusFound,

--- a/Sources/Qonversion/Qonversion/Core/QONRemoteConfigV2Store/QONRemoteConfigV2Store.m
+++ b/Sources/Qonversion/Qonversion/Core/QONRemoteConfigV2Store/QONRemoteConfigV2Store.m
@@ -2,17 +2,56 @@
 #import "QNLocalStorage.h"
 #import "QONRemoteConfigJSON.h"
 #import "QONRemoteConfigV2Models.h"
+#import <CommonCrypto/CommonDigest.h>
 #import <string.h>
 
 NSString *const QONRemoteConfigV2StorageKey = @"com.qonversion.keys.remote-config-v2-state";
 NSUInteger const QONRemoteConfigV2MaximumPersistedScopes = 16;
 
-static NSInteger const kQONRemoteConfigV2StoreSchema = 1;
-static NSUInteger const kQONRemoteConfigV2MaximumEnvelopeBytes = 32 * 1024 * 1024;
+#define QON_RC_V2_WIRE_LIMIT_BYTES (8u * 1024u * 1024u)
+#define QON_RC_V2_AGGREGATE_LIMIT_BYTES (4u * 1024u * 1024u)
+#define QON_RC_V2_BASE64_BOUND(bytes) ((((bytes) + 2u) / 3u) * 4u)
+#define QON_RC_V2_HISTORY_SLOT_COUNT 3u
+#define QON_RC_V2_ARCHIVE_HEADROOM_BYTES (4u * 1024u * 1024u)
+
+// One release can contain the base64 canonical wire body, base64 entry data,
+// and their bounded identifiers. Three durable history slots plus 4 MiB for
+// plist/scope framing therefore fit by construction without widening ingress.
+NSUInteger const QONRemoteConfigV2MaximumArchiveBytes =
+    QON_RC_V2_HISTORY_SLOT_COUNT *
+        (QON_RC_V2_BASE64_BOUND(QON_RC_V2_WIRE_LIMIT_BYTES) +
+         QON_RC_V2_BASE64_BOUND(QON_RC_V2_AGGREGATE_LIMIT_BYTES) +
+         QON_RC_V2_AGGREGATE_LIMIT_BYTES) +
+    QON_RC_V2_ARCHIVE_HEADROOM_BYTES;
+
+static NSInteger const kQONRemoteConfigV2StoreSchema = 2;
 static NSString *const kSchema = @"schema_version";
 static NSString *const kScopes = @"scopes";
 static NSString *const kScope = @"scope";
 static NSString *const kState = @"state";
+
+@interface QONRemoteConfigV2EnvelopeParser (QONRemoteConfigV2StoreValidation)
+- (nullable QONRemoteConfigV2Envelope *)parseBoundBody:(NSData *)body
+                                             strongETag:(NSString *)strongETag;
+@end
+
+static NSString *QONRemoteConfigV2StoreSHA256Hex(NSData *data) {
+  if (!data || data.length > UINT32_MAX) return nil;
+  uint8_t digest[CC_SHA256_DIGEST_LENGTH];
+  CC_SHA256(data.bytes, (CC_LONG)data.length, digest);
+  NSMutableString *hex = [NSMutableString stringWithCapacity:CC_SHA256_DIGEST_LENGTH * 2];
+  for (NSUInteger index = 0; index < CC_SHA256_DIGEST_LENGTH; index++) {
+    [hex appendFormat:@"%02x", digest[index]];
+  }
+  return [hex copy];
+}
+
+static NSString *QONRemoteConfigV2StateDigest(NSDictionary *payload) {
+  NSError *error = nil;
+  NSData *data = [NSJSONSerialization dataWithJSONObject:payload
+      options:NSJSONWritingSortedKeys error:&error];
+  return data && !error ? QONRemoteConfigV2StoreSHA256Hex(data) : nil;
+}
 
 static BOOL QONRemoteConfigV2ExactInteger(id object, NSInteger *value) {
   if (![object isKindOfClass:NSNumber.class] ||
@@ -28,6 +67,23 @@ static BOOL QONRemoteConfigV2ExactInteger(id object, NSInteger *value) {
     unsigned long long candidate = [object unsignedLongLongValue];
     if (candidate > NSIntegerMax) return NO;
     if (value) *value = (NSInteger)candidate;
+    return YES;
+  }
+  return NO;
+}
+
+static BOOL QONRemoteConfigV2ExactInt64(id object, int64_t *value) {
+  if (![object isKindOfClass:NSNumber.class] ||
+      CFGetTypeID((__bridge CFTypeRef)object) == CFBooleanGetTypeID()) return NO;
+  const char type = [object objCType][0];
+  if (strchr("csiql", type)) {
+    if (value) *value = [object longLongValue];
+    return YES;
+  }
+  if (strchr("CSILQ", type)) {
+    unsigned long long candidate = [object unsignedLongLongValue];
+    if (candidate > INT64_MAX) return NO;
+    if (value) *value = (int64_t)candidate;
     return YES;
   }
   return NO;
@@ -88,10 +144,14 @@ static BOOL QONRemoteConfigV2ExactBoolean(id object, BOOL *value) {
 }
 
 - (NSData *)archiveDataForRoot:(NSDictionary *)root {
+  // Fail closed if ingress limits change without a matching durable-budget review.
+  if (QONRemoteConfigV2MaximumEnvelopeBytes != QON_RC_V2_WIRE_LIMIT_BYTES ||
+      QONRemoteConfigV2MaximumTotalValueBytes != QON_RC_V2_AGGREGATE_LIMIT_BYTES) return nil;
   NSError *error = nil;
   NSData *data = [NSPropertyListSerialization dataWithPropertyList:root
       format:NSPropertyListBinaryFormat_v1_0 options:0 error:&error];
-  if (!data || error || data.length == 0 || data.length > kQONRemoteConfigV2MaximumEnvelopeBytes) return nil;
+  if (!data || error || data.length == 0 ||
+      data.length > QONRemoteConfigV2MaximumArchiveBytes) return nil;
   return data;
 }
 
@@ -120,7 +180,7 @@ static BOOL QONRemoteConfigV2ExactBoolean(id object, BOOL *value) {
       return nil;
     }
     if (fileSize.unsignedLongLongValue == 0 ||
-        fileSize.unsignedLongLongValue > kQONRemoteConfigV2MaximumEnvelopeBytes) {
+        fileSize.unsignedLongLongValue > QONRemoteConfigV2MaximumArchiveBytes) {
       [self clearArchive];
       if (status) *status = QONRemoteConfigV2StoreLoadStatusMissing;
       return nil;
@@ -131,7 +191,7 @@ static BOOL QONRemoteConfigV2ExactBoolean(id object, BOOL *value) {
       if (status) *status = QONRemoteConfigV2StoreLoadStatusFailed;
       return nil;
     }
-    if (data.length == 0 || data.length > kQONRemoteConfigV2MaximumEnvelopeBytes) {
+    if (data.length == 0 || data.length > QONRemoteConfigV2MaximumArchiveBytes) {
       [self clearArchive];
       if (status) *status = QONRemoteConfigV2StoreLoadStatusMissing;
       return nil;
@@ -224,9 +284,7 @@ static BOOL QONRemoteConfigV2ExactBoolean(id object, BOOL *value) {
   NSData *rawData = entry.rawData;
   NSString *variationUID = entry.variationUID;
   if (!rawData || !variationUID) return @{};
-  id metadata = entry.metadata;
-  NSData *metadataData = metadata ? [NSJSONSerialization dataWithJSONObject:metadata
-      options:NSJSONWritingFragmentsAllowed error:nil] : nil;
+  NSData *metadataData = entry.metadataData;
   return @{
     @"key": entry.key,
     @"raw": [rawData base64EncodedStringWithOptions:0],
@@ -258,17 +316,18 @@ static BOOL QONRemoteConfigV2ExactBoolean(id object, BOOL *value) {
   }
   NSData *raw = [[NSData alloc] initWithBase64EncodedString:encodedRaw options:0];
   if (!raw || ![[raw base64EncodedStringWithOptions:0] isEqualToString:encodedRaw]) return nil;
-  id metadata = nil;
+  NSData *metadataData = nil;
   if (encodedMetadata.length > 0) {
-    NSData *metadataData = [[NSData alloc] initWithBase64EncodedString:encodedMetadata options:0];
+    metadataData = [[NSData alloc] initWithBase64EncodedString:encodedMetadata options:0];
     if (!metadataData || metadataData.length > QONRemoteConfigV2MaximumMetadataBytes ||
         ![[metadataData base64EncodedStringWithOptions:0] isEqualToString:encodedMetadata]) return nil;
-    metadata = QONRemoteConfigPortableJSONObject(metadataData, QONRemoteConfigV2MaximumMetadataBytes);
-    if (!metadata) return nil;
+    if (!QONRemoteConfigPortableJSONObject(metadataData, QONRemoteConfigV2MaximumMetadataBytes)) return nil;
   }
-  return [[QONRemoteConfigV2Entry alloc] initWithKey:key rawData:raw
-      variationUID:variationUID applyPolicy:policy
-      metadata:metadata];
+  return metadataData
+      ? [[QONRemoteConfigV2Entry alloc] initWithKey:key rawData:raw variationUID:variationUID
+          applyPolicy:policy metadataData:metadataData]
+      : [[QONRemoteConfigV2Entry alloc] initWithKey:key rawData:raw variationUID:variationUID
+          applyPolicy:policy metadata:nil];
 }
 
 - (id)releaseDictionary:(QONRemoteConfigV2Release *)release {
@@ -278,58 +337,144 @@ static BOOL QONRemoteConfigV2ExactBoolean(id object, BOOL *value) {
     [entries addObject:[self entryDictionary:release.entries[key]]];
   }
   return @{@"uid": release.releaseUID, @"number": @(release.releaseNumber),
-      @"hash": release.manifestContentHash, @"entries": entries};
+      @"hash": release.manifestContentHash, @"entries": entries,
+      @"canonical_body": release.canonicalBody
+          ? [release.canonicalBody base64EncodedStringWithOptions:0] : @"",
+      @"strong_etag": release.strongETag ?: @"",
+      @"project_id": @(release.projectID),
+      @"context_fingerprint": release.contextFingerprint ?: @"",
+      @"admission_ordinal": @(release.admissionOrdinal)};
 }
 
-- (QONRemoteConfigV2Release *)releaseFromObject:(id)object validNull:(BOOL *)validNull {
+- (QONRemoteConfigV2Release *)releaseFromObject:(id)object
+                                      validNull:(BOOL *)validNull
+                                          scope:(QONRemoteConfigV2Scope *)scope {
   if ([object isKindOfClass:NSDictionary.class] && [object count] == 0) {
     if (validNull) *validNull = YES;
     return nil;
   }
   if (![object isKindOfClass:NSDictionary.class]) return nil;
   NSDictionary *dictionary = object;
-  if (dictionary.count != 4 || ![dictionary[@"uid"] isKindOfClass:NSString.class] ||
+  if (dictionary.count != 9 || ![dictionary[@"uid"] isKindOfClass:NSString.class] ||
       ![dictionary[@"hash"] isKindOfClass:NSString.class] ||
-      ![dictionary[@"entries"] isKindOfClass:NSArray.class]) return nil;
+      ![dictionary[@"entries"] isKindOfClass:NSArray.class] ||
+      ![dictionary[@"canonical_body"] isKindOfClass:NSString.class] ||
+      ![dictionary[@"strong_etag"] isKindOfClass:NSString.class] ||
+      ![dictionary[@"context_fingerprint"] isKindOfClass:NSString.class]) return nil;
   NSString *releaseUID = (NSString *)dictionary[@"uid"];
   NSString *manifestContentHash = (NSString *)dictionary[@"hash"];
   NSInteger releaseNumber = 0;
-  if (!QONRemoteConfigV2ExactInteger(dictionary[@"number"], &releaseNumber)) return nil;
+  int64_t admissionOrdinal = 0, projectID = 0;
+  if (!QONRemoteConfigV2ExactInteger(dictionary[@"number"], &releaseNumber) ||
+      !QONRemoteConfigV2ExactInt64(dictionary[@"project_id"], &projectID) ||
+      !QONRemoteConfigV2ExactInt64(dictionary[@"admission_ordinal"], &admissionOrdinal)) return nil;
   NSMutableDictionary *entries = [NSMutableDictionary new];
   for (id entryObject in dictionary[@"entries"]) {
     QONRemoteConfigV2Entry *entry = [self entryFromDictionary:entryObject];
     if (!entry || entries[entry.key]) return nil;
     entries[entry.key] = entry;
   }
-  return [[QONRemoteConfigV2Release alloc] initWithReleaseUID:releaseUID
-      releaseNumber:releaseNumber
-      manifestContentHash:manifestContentHash entries:entries];
+  NSString *encodedBody = dictionary[@"canonical_body"];
+  NSString *strongETag = dictionary[@"strong_etag"];
+  NSString *contextFingerprint = dictionary[@"context_fingerprint"];
+  NSData *canonicalBody = nil;
+  if (encodedBody.length > 0) {
+    canonicalBody = [[NSData alloc] initWithBase64EncodedString:encodedBody options:0];
+    if (!canonicalBody || ![[canonicalBody base64EncodedStringWithOptions:0] isEqualToString:encodedBody] ||
+        strongETag.length == 0) return nil;
+  } else if (strongETag.length > 0) {
+    return nil;
+  }
+  QONRemoteConfigV2Release *storedRelease = [[QONRemoteConfigV2Release alloc]
+      initWithReleaseUID:releaseUID
+      releaseNumber:releaseNumber manifestContentHash:manifestContentHash entries:entries
+      canonicalBody:canonicalBody strongETag:strongETag.length > 0 ? strongETag : nil
+      projectID:projectID contextFingerprint:contextFingerprint.length > 0 ? contextFingerprint : nil
+      admissionOrdinal:admissionOrdinal];
+  if (!storedRelease || !canonicalBody) return storedRelease;
+  if (!scope) return nil;
+
+  QONRemoteConfigV2Envelope *canonicalEnvelope = [[QONRemoteConfigV2EnvelopeParser new]
+      parseBoundBody:canonicalBody strongETag:strongETag];
+  QONRemoteConfigV2Release *canonicalRelease = canonicalEnvelope.snapshotRelease;
+  if (!canonicalEnvelope || !canonicalRelease ||
+      canonicalEnvelope.projectID != storedRelease.projectID ||
+      ![canonicalEnvelope.environmentUID isEqualToString:scope.environment] ||
+      ![canonicalRelease.releaseUID isEqualToString:storedRelease.releaseUID] ||
+      canonicalRelease.releaseNumber != storedRelease.releaseNumber ||
+      ![canonicalRelease.manifestContentHash isEqualToString:storedRelease.manifestContentHash] ||
+      ![canonicalRelease.contextFingerprint isEqualToString:storedRelease.contextFingerprint]) return nil;
+
+  NSUInteger persistedValueCount = 0;
+  for (QONRemoteConfigV2Entry *entry in storedRelease.entries.allValues) {
+    if (entry.isTombstone) continue;
+    persistedValueCount += 1;
+    if (![entry contentEquals:canonicalRelease.entries[entry.key]]) return nil;
+  }
+  if (persistedValueCount != canonicalRelease.entries.count) return nil;
+  return [canonicalRelease releaseBySettingAdmissionOrdinal:admissionOrdinal];
 }
 
-- (NSDictionary *)stateDictionary:(QONRemoteConfigV2State *)state {
+- (NSDictionary *)statePayloadDictionary:(QONRemoteConfigV2State *)state
+                                     scope:(QONRemoteConfigV2Scope *)scope {
   return @{
     @"candidate": [self releaseDictionary:state.candidate],
     @"active": [self releaseDictionary:state.active],
     @"previous": [self releaseDictionary:state.previous],
     @"did_activate": @(state.didActivate),
+    @"latest_admission_ordinal": @(state.latestAdmissionOrdinal),
+    @"scope_binding": [self scopeDictionary:scope],
   };
 }
 
+- (NSDictionary *)stateDictionary:(QONRemoteConfigV2State *)state
+                              scope:(QONRemoteConfigV2Scope *)scope {
+  NSDictionary *payload = [self statePayloadDictionary:state scope:scope];
+  NSMutableDictionary *dictionary = [payload mutableCopy];
+  dictionary[@"state_digest"] = QONRemoteConfigV2StateDigest(payload) ?: @"";
+  return [dictionary copy];
+}
+
 - (QONRemoteConfigV2State *)stateFromDictionary:(id)object
+                                           scope:(QONRemoteConfigV2Scope *)scope
                                  requiresRewrite:(BOOL *)requiresRewrite {
   if (![object isKindOfClass:NSDictionary.class]) return nil;
   NSDictionary *dictionary = object;
-  if (dictionary.count != 4) return nil;
+  if (dictionary.count != 7 || ![dictionary[@"state_digest"] isKindOfClass:NSString.class]) return nil;
+  QONRemoteConfigV2Scope *boundScope = [self scopeFromDictionary:dictionary[@"scope_binding"]];
+  if (!boundScope || !scope || ![boundScope isEqual:scope]) return nil;
+  NSMutableDictionary *storedPayload = [dictionary mutableCopy];
+  NSString *storedDigest = storedPayload[@"state_digest"];
+  [storedPayload removeObjectForKey:@"state_digest"];
+  BOOL digestMatches = storedDigest.length == 64 &&
+      [storedDigest isEqualToString:QONRemoteConfigV2StateDigest(storedPayload)];
+  // The canonical wire body cannot prove which local user/project-key scope it
+  // originally belonged to. Never use it to recover a record whose binding
+  // digest failed: doing so could bless coordinated outer/inner scope damage.
+  if (!digestMatches) return nil;
   BOOL didActivate = NO;
-  if (!QONRemoteConfigV2ExactBoolean(dictionary[@"did_activate"], &didActivate)) return nil;
+  int64_t latestAdmissionOrdinal = 0;
+  if (!QONRemoteConfigV2ExactBoolean(dictionary[@"did_activate"], &didActivate) ||
+      !QONRemoteConfigV2ExactInt64(dictionary[@"latest_admission_ordinal"],
+                                    &latestAdmissionOrdinal)) return nil;
   BOOL candidateNull = NO, activeNull = NO, previousNull = NO;
-  QONRemoteConfigV2Release *candidate = [self releaseFromObject:dictionary[@"candidate"] validNull:&candidateNull];
-  QONRemoteConfigV2Release *active = [self releaseFromObject:dictionary[@"active"] validNull:&activeNull];
-  QONRemoteConfigV2Release *previous = [self releaseFromObject:dictionary[@"previous"] validNull:&previousNull];
+  QONRemoteConfigV2Release *candidate = [self releaseFromObject:dictionary[@"candidate"]
+      validNull:&candidateNull scope:scope];
+  QONRemoteConfigV2Release *active = [self releaseFromObject:dictionary[@"active"]
+      validNull:&activeNull scope:scope];
+  QONRemoteConfigV2Release *previous = [self releaseFromObject:dictionary[@"previous"]
+      validNull:&previousNull scope:scope];
   BOOL rewrite = NO;
   if (!candidate && !candidateNull) rewrite = YES;
   if (!active && !activeNull) rewrite = YES;
   if (!previous && !previousNull) rewrite = YES;
+  int64_t highestSlotOrdinal = MAX(candidate.admissionOrdinal,
+      MAX(active.admissionOrdinal, previous.admissionOrdinal));
+  BOOL usesAdmissionOrdering = highestSlotOrdinal > 0;
+  if (latestAdmissionOrdinal < highestSlotOrdinal) {
+    latestAdmissionOrdinal = highestSlotOrdinal;
+    rewrite = YES;
+  }
   if (!didActivate && active) {
     active = nil;
     previous = nil;
@@ -339,11 +484,15 @@ static BOOL QONRemoteConfigV2ExactBoolean(id object, BOOL *value) {
     previous = nil;
     rewrite = YES;
   }
-  if (candidate && active && candidate.releaseNumber < active.releaseNumber) {
+  if (candidate && active &&
+      ((usesAdmissionOrdering && candidate.admissionOrdinal < active.admissionOrdinal) ||
+       (!usesAdmissionOrdering && candidate.releaseNumber < active.releaseNumber))) {
     candidate = nil;
     rewrite = YES;
   }
-  if (candidate && active && candidate.releaseNumber == active.releaseNumber) {
+  if (candidate && active &&
+      ((usesAdmissionOrdering && candidate.admissionOrdinal == active.admissionOrdinal) ||
+       (!usesAdmissionOrdering && candidate.releaseNumber == active.releaseNumber))) {
     if ([candidate contentEquals:active]) {
       candidate = active;
     } else {
@@ -351,14 +500,19 @@ static BOOL QONRemoteConfigV2ExactBoolean(id object, BOOL *value) {
       rewrite = YES;
     }
   }
-  if (previous && active && previous.releaseNumber >= active.releaseNumber) {
+  if (previous && active &&
+      ((usesAdmissionOrdering && previous.admissionOrdinal >= active.admissionOrdinal) ||
+       (!usesAdmissionOrdering && previous.releaseNumber >= active.releaseNumber))) {
     previous = nil;
     rewrite = YES;
   }
   if (rewrite && !candidate && !active && !previous && !didActivate) return nil;
   if (requiresRewrite) *requiresRewrite = rewrite;
-  return [[QONRemoteConfigV2State alloc] initWithCandidate:candidate active:active previous:previous
-      didActivate:didActivate];
+  QONRemoteConfigV2State *state = [[QONRemoteConfigV2State alloc]
+      initWithCandidate:candidate active:active previous:previous didActivate:didActivate
+      latestAdmissionOrdinal:latestAdmissionOrdinal];
+  if (!state) return nil;
+  return state;
 }
 
 - (NSArray<NSDictionary *> *)validatedRecordsWithStatus:(QONRemoteConfigV2StoreLoadStatus *)status {
@@ -386,14 +540,14 @@ static BOOL QONRemoteConfigV2ExactBoolean(id object, BOOL *value) {
   NSMutableArray<NSDictionary *> *validated = [NSMutableArray new];
   BOOL requiresRewrite = storedRecords.count > QONRemoteConfigV2MaximumPersistedScopes;
   NSUInteger admittedBytes = 0;
-  NSUInteger recordBudget = kQONRemoteConfigV2MaximumEnvelopeBytes - (16 * 1024);
+  NSUInteger recordBudget = QONRemoteConfigV2MaximumArchiveBytes - (16 * 1024);
   for (NSUInteger position = storedRecords.count; position > 0; position--) {
     id recordObject = storedRecords[position - 1];
     if (![recordObject isKindOfClass:NSDictionary.class]) { requiresRewrite = YES; continue; }
     NSDictionary *record = recordObject;
     QONRemoteConfigV2Scope *scope = [self scopeFromDictionary:record[kScope]];
     BOOL stateRequiresRewrite = NO;
-    QONRemoteConfigV2State *state = [self stateFromDictionary:record[kState]
+    QONRemoteConfigV2State *state = [self stateFromDictionary:record[kState] scope:scope
                                                requiresRewrite:&stateRequiresRewrite];
     if (record.count != 2 || !scope || !state || [seenScopes containsObject:scope] ||
         validated.count >= QONRemoteConfigV2MaximumPersistedScopes) {
@@ -402,7 +556,7 @@ static BOOL QONRemoteConfigV2ExactBoolean(id object, BOOL *value) {
     }
     [seenScopes addObject:scope];
     NSDictionary *canonical = @{kScope: [self scopeDictionary:scope],
-                                kState: [self stateDictionary:state]};
+                                kState: [self stateDictionary:state scope:scope]};
     NSData *recordData = [self archiveDataForRoot:canonical];
     if (!recordData || recordData.length > recordBudget - MIN(recordBudget, admittedBytes)) {
       requiresRewrite = YES;
@@ -430,7 +584,7 @@ static BOOL QONRemoteConfigV2ExactBoolean(id object, BOOL *value) {
 }
 
 - (NSArray<NSDictionary *> *)boundedNewestRecords:(NSArray<NSDictionary *> *)records {
-  NSUInteger recordBudget = kQONRemoteConfigV2MaximumEnvelopeBytes - (16 * 1024);
+  NSUInteger recordBudget = QONRemoteConfigV2MaximumArchiveBytes - (16 * 1024);
   NSUInteger admittedBytes = 0;
   NSMutableArray<NSDictionary *> *bounded = [NSMutableArray new];
   for (NSUInteger position = records.count;
@@ -463,6 +617,7 @@ static BOOL QONRemoteConfigV2ExactBoolean(id object, BOOL *value) {
       NSDictionary *record = records[index];
       if ([[self scopeFromDictionary:record[kScope]] isEqual:scope]) {
         QONRemoteConfigV2State *loadedState = [self stateFromDictionary:record[kState]
+                                                            scope:scope
                                                    requiresRewrite:NULL];
         if (index + 1 < records.count) {
           NSMutableArray *promoted = [records mutableCopy];
@@ -492,7 +647,7 @@ static BOOL QONRemoteConfigV2ExactBoolean(id object, BOOL *value) {
     }];
     [records removeObjectsAtIndexes:matches];
     NSDictionary *newRecord = @{kScope: [self scopeDictionary:scope],
-                                kState: [self stateDictionary:state]};
+                                kState: [self stateDictionary:state scope:scope]};
     if (![self archiveDataForRoot:newRecord]) return NO;
     [records addObject:newRecord];
     records = [[self boundedNewestRecords:records] mutableCopy];

--- a/Sources/Qonversion/Qonversion/Main/QONRemoteConfigV2Manager/QONRemoteConfigV2Manager.h
+++ b/Sources/Qonversion/Qonversion/Main/QONRemoteConfigV2Manager/QONRemoteConfigV2Manager.h
@@ -2,11 +2,27 @@
 #import "QONRemoteConfigSnapshot.h"
 #import "QONRemoteConfigUpdate.h"
 
+@class QONRemoteConfigV2AdmissionToken, QONRemoteConfigV2EnvelopeExpectation;
 @class QONRemoteConfigV2Release, QONRemoteConfigV2Scope, QONRemoteConfigV2Store;
+@protocol QONRemoteConfigV2EnvelopeDecoding;
 
 NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^QONRemoteConfigV2UpdateObserver)(QONRemoteConfigUpdate *update);
+
+typedef NS_ENUM(NSInteger, QONRemoteConfigV2TransitionStatus) {
+  QONRemoteConfigV2TransitionStatusAccepted,
+  QONRemoteConfigV2TransitionStatusActivated,
+  QONRemoteConfigV2TransitionStatusIgnored,
+  QONRemoteConfigV2TransitionStatusPersistenceFailed,
+  QONRemoteConfigV2TransitionStatusRejected,
+  QONRemoteConfigV2TransitionStatusUnchanged,
+};
+
+/** Opaque, single-request capability. Tokens are valid only for the manager that issued them. */
+@interface QONRemoteConfigV2AdmissionToken : NSObject
+- (instancetype)init NS_UNAVAILABLE;
+@end
 
 @interface QONRemoteConfigV2Manager : NSObject
 
@@ -17,11 +33,35 @@ typedef void (^QONRemoteConfigV2UpdateObserver)(QONRemoteConfigUpdate *update);
 - (instancetype)initWithStore:(QONRemoteConfigV2Store *)store
                fallbackRelease:(nullable QONRemoteConfigV2Release *)fallbackRelease
              fallbackProjectKey:(nullable NSString *)fallbackProjectKey
-            fallbackEnvironment:(nullable NSString *)fallbackEnvironment NS_DESIGNATED_INITIALIZER;
+            fallbackEnvironment:(nullable NSString *)fallbackEnvironment;
+- (instancetype)initWithStore:(QONRemoteConfigV2Store *)store
+               fallbackRelease:(nullable QONRemoteConfigV2Release *)fallbackRelease
+             fallbackProjectKey:(nullable NSString *)fallbackProjectKey
+            fallbackEnvironment:(nullable NSString *)fallbackEnvironment
+                 envelopeDecoder:(id<QONRemoteConfigV2EnvelopeDecoding>)envelopeDecoder;
+/** Internal deterministic-test seam. callbackExecutor must be serial. */
+- (instancetype)initWithStore:(QONRemoteConfigV2Store *)store
+               fallbackRelease:(nullable QONRemoteConfigV2Release *)fallbackRelease
+             fallbackProjectKey:(nullable NSString *)fallbackProjectKey
+            fallbackEnvironment:(nullable NSString *)fallbackEnvironment
+                 envelopeDecoder:(id<QONRemoteConfigV2EnvelopeDecoding>)envelopeDecoder
+                callbackExecutor:(dispatch_queue_t)callbackExecutor NS_DESIGNATED_INITIALIZER;
+/**
+ Changes current scope and generation synchronously on the state queue without
+ waiting for the callback executor. Queued or not-yet-claimed old-generation
+ callbacks are cancelled. A callback atomically claimed before this boundary
+ may finish after the method returns. No observer runs under an SDK lock.
+ */
 - (void)setScope:(nullable QONRemoteConfigV2Scope *)scope;
+- (nullable QONRemoteConfigV2AdmissionToken *)beginAdmissionForScope:(QONRemoteConfigV2Scope *)scope
+                                                        expectation:(QONRemoteConfigV2EnvelopeExpectation *)expectation;
+- (QONRemoteConfigV2TransitionStatus)admitBody:(NSData *)body
+                                   strongETag:(NSString *)strongETag
+                               admissionToken:(QONRemoteConfigV2AdmissionToken *)admissionToken;
 - (void)acceptFetchedRelease:(QONRemoteConfigV2Release *)release
                      forScope:(QONRemoteConfigV2Scope *)scope;
 - (BOOL)activate;
+/** Observer callbacks use the serial main executor by default. */
 - (id)addUpdateObserver:(QONRemoteConfigV2UpdateObserver)observer;
 - (void)removeUpdateObserver:(id)token;
 

--- a/Sources/Qonversion/Qonversion/Main/QONRemoteConfigV2Manager/QONRemoteConfigV2Manager.m
+++ b/Sources/Qonversion/Qonversion/Main/QONRemoteConfigV2Manager/QONRemoteConfigV2Manager.m
@@ -12,6 +12,19 @@
 @implementation QONRemoteConfigV2Delivery
 @end
 
+@interface QONRemoteConfigV2AdmissionToken ()
+@property (nonatomic, strong) NSUUID *ownerNonce;
+@property (nonatomic, assign) int64_t ordinal;
+@property (nonatomic, strong) QONRemoteConfigV2Scope *scope;
+@property (nonatomic, assign) NSUInteger scopeGeneration;
+@property (nonatomic, strong) QONRemoteConfigV2EnvelopeExpectation *expectation;
+- (instancetype)initPrivate;
+@end
+
+@implementation QONRemoteConfigV2AdmissionToken
+- (instancetype)initPrivate { return [super init]; }
+@end
+
 @interface QONRemoteConfigV2Manager ()
 @property (nonatomic, strong) QONRemoteConfigV2Store *store;
 @property (nonatomic, strong, nullable) QONRemoteConfigV2Release *fallbackRelease;
@@ -23,10 +36,15 @@
 @property (nonatomic, strong) NSMutableDictionary<NSUUID *, id> *observers;
 @property (nonatomic, strong) NSMutableArray<NSUUID *> *observerOrder;
 @property (nonatomic, strong) NSMutableArray<QONRemoteConfigV2Delivery *> *pendingDeliveries;
-@property (nonatomic, strong) NSRecursiveLock *deliveryLock;
 @property (nonatomic, assign) BOOL isDrainingDeliveries;
 @property (nonatomic, assign) BOOL scopeLoadFailed;
 @property (nonatomic, assign) NSUInteger scopeGeneration;
+@property (nonatomic, assign) int64_t nextAdmissionOrdinal;
+@property (nonatomic, strong) NSUUID *admissionOwnerNonce;
+@property (nonatomic, strong) id<QONRemoteConfigV2EnvelopeDecoding> envelopeDecoder;
+@property (nonatomic, strong) dispatch_queue_t callbackExecutor;
+@property (nonatomic, strong) NSObject *callbackExecutorToken;
+@property (nonatomic, assign) BOOL callbackExecutorIsMain;
 @end
 
 @implementation QONRemoteConfigV2Manager
@@ -35,7 +53,30 @@
                fallbackRelease:(QONRemoteConfigV2Release *)fallbackRelease
              fallbackProjectKey:(NSString *)fallbackProjectKey
             fallbackEnvironment:(NSString *)fallbackEnvironment {
-  if (!store || (fallbackRelease && (!fallbackProjectKey || !fallbackEnvironment))) return nil;
+  return [self initWithStore:store fallbackRelease:fallbackRelease
+      fallbackProjectKey:fallbackProjectKey fallbackEnvironment:fallbackEnvironment
+      envelopeDecoder:[QONRemoteConfigV2EnvelopeParser new]
+      callbackExecutor:dispatch_get_main_queue()];
+}
+
+- (instancetype)initWithStore:(QONRemoteConfigV2Store *)store
+               fallbackRelease:(QONRemoteConfigV2Release *)fallbackRelease
+             fallbackProjectKey:(NSString *)fallbackProjectKey
+            fallbackEnvironment:(NSString *)fallbackEnvironment
+                 envelopeDecoder:(id<QONRemoteConfigV2EnvelopeDecoding>)envelopeDecoder {
+  return [self initWithStore:store fallbackRelease:fallbackRelease
+      fallbackProjectKey:fallbackProjectKey fallbackEnvironment:fallbackEnvironment
+      envelopeDecoder:envelopeDecoder callbackExecutor:dispatch_get_main_queue()];
+}
+
+- (instancetype)initWithStore:(QONRemoteConfigV2Store *)store
+               fallbackRelease:(QONRemoteConfigV2Release *)fallbackRelease
+             fallbackProjectKey:(NSString *)fallbackProjectKey
+            fallbackEnvironment:(NSString *)fallbackEnvironment
+                 envelopeDecoder:(id<QONRemoteConfigV2EnvelopeDecoding>)envelopeDecoder
+                callbackExecutor:(dispatch_queue_t)callbackExecutor {
+  if (!store || !envelopeDecoder || !callbackExecutor ||
+      (fallbackRelease && (!fallbackProjectKey || !fallbackEnvironment))) return nil;
   if (fallbackRelease && ![[QONRemoteConfigV2Scope alloc]
       initWithProjectKey:fallbackProjectKey environment:fallbackEnvironment
       canonicalUserID:@"bundle-scope-validation"]) return nil;
@@ -50,7 +91,13 @@
     _observers = [NSMutableDictionary new];
     _observerOrder = [NSMutableArray new];
     _pendingDeliveries = [NSMutableArray new];
-    _deliveryLock = [NSRecursiveLock new];
+    _admissionOwnerNonce = NSUUID.UUID;
+    _envelopeDecoder = envelopeDecoder;
+    _callbackExecutor = callbackExecutor;
+    _callbackExecutorToken = [NSObject new];
+    _callbackExecutorIsMain = callbackExecutor == dispatch_get_main_queue();
+    const void *key = (__bridge const void *)_callbackExecutorToken;
+    dispatch_queue_set_specific(callbackExecutor, key, (void *)key, NULL);
   }
   return self;
 }
@@ -76,11 +123,21 @@
   return snapshot;
 }
 
+- (BOOL)release:(QONRemoteConfigV2Release *)release
+    representsSameLocalAdmissionAs:(QONRemoteConfigV2Release *)other {
+  if (!release || !other) return NO;
+  if (release.admissionOrdinal > 0 || other.admissionOrdinal > 0) {
+    return release.admissionOrdinal > 0 && release.admissionOrdinal == other.admissionOrdinal;
+  }
+  return [release contentEquals:other];
+}
+
 - (QONRemoteConfigSnapshot *)lastFetchedSnapshot {
   __block QONRemoteConfigSnapshot *snapshot = nil;
   dispatch_sync(self.stateQueue, ^{
     if (self.state.candidate) {
-      QONRemoteConfigV2Release *previous = [self.state.candidate contentEquals:self.state.active]
+      QONRemoteConfigV2Release *previous = [self release:self.state.candidate
+          representsSameLocalAdmissionAs:self.state.active]
           ? self.state.previous : self.state.active;
       snapshot = [[QONRemoteConfigSnapshot alloc] initWithPrimaryRelease:self.state.candidate
           previousRelease:previous fallbackRelease:[self fallbackReleaseForCurrentScopeLocked]];
@@ -89,8 +146,7 @@
   return snapshot;
 }
 
-- (void)setScope:(QONRemoteConfigV2Scope *)scope {
-  [self.deliveryLock lock];
+- (void)applyScopeLocked:(QONRemoteConfigV2Scope *)scope {
   dispatch_sync(self.stateQueue, ^{
     BOOL sameScope = (self.currentScope == nil && scope == nil) || [self.currentScope isEqual:scope];
     if (sameScope && !(scope && self.scopeLoadFailed)) return;
@@ -99,11 +155,15 @@
       self.state = [[QONRemoteConfigV2State alloc]
           initWithCandidate:nil active:nil previous:nil didActivate:NO];
       self.scopeLoadFailed = NO;
+      self.nextAdmissionOrdinal = 0;
       self.scopeGeneration += 1;
     }
     if (scope) [self loadScopeStateLocked:scope];
   });
-  [self.deliveryLock unlock];
+}
+
+- (void)setScope:(QONRemoteConfigV2Scope *)scope {
+  [self applyScopeLocked:[scope copy]];
 }
 
 - (void)loadScopeStateLocked:(QONRemoteConfigV2Scope *)scope {
@@ -112,11 +172,13 @@
   switch (status) {
     case QONRemoteConfigV2StoreLoadStatusFound:
       self.state = loadedState;
+      self.nextAdmissionOrdinal = loadedState.latestAdmissionOrdinal;
       self.scopeLoadFailed = NO;
       break;
     case QONRemoteConfigV2StoreLoadStatusMissing:
       self.state = [[QONRemoteConfigV2State alloc]
           initWithCandidate:nil active:nil previous:nil didActivate:NO];
+      self.nextAdmissionOrdinal = 0;
       self.scopeLoadFailed = NO;
       break;
     case QONRemoteConfigV2StoreLoadStatusFailed:
@@ -147,8 +209,11 @@
 - (QONRemoteConfigUpdate *)transitionToCandidateLocked:(QONRemoteConfigV2Release *)candidate {
   QONRemoteConfigSnapshot *oldSnapshot = [self snapshotForState:self.state];
   if (!candidate) return nil;
+  int64_t latestAdmissionOrdinal = MAX(self.state.latestAdmissionOrdinal,
+                                       candidate.admissionOrdinal);
   QONRemoteConfigV2State *nextState = [[QONRemoteConfigV2State alloc] initWithCandidate:candidate
-      active:candidate previous:self.state.active didActivate:YES];
+      active:candidate previous:self.state.active didActivate:YES
+      latestAdmissionOrdinal:latestAdmissionOrdinal];
   QONRemoteConfigV2Scope *scope = self.currentScope;
   if (!scope || ![self.store saveState:nextState forScope:scope]) return nil;
   self.state = nextState;
@@ -180,29 +245,36 @@
   [self.pendingDeliveries addObject:delivery];
 }
 
-- (void)drainDeliveries {
-  [self.deliveryLock lock];
-  if (self.isDrainingDeliveries) {
-    [self.deliveryLock unlock];
-    return;
-  }
+- (BOOL)isOnCallbackExecutor {
+  if (self.callbackExecutorIsMain && NSThread.isMainThread) return YES;
+  const void *key = (__bridge const void *)self.callbackExecutorToken;
+  return dispatch_get_specific(key) == key;
+}
+
+- (void)drainDeliveriesOnCallbackExecutor {
+  NSAssert([self isOnCallbackExecutor], @"Remote Config callback executor must be serial");
+  if (self.isDrainingDeliveries) return;
   self.isDrainingDeliveries = YES;
   @try {
     while (YES) {
       __block QONRemoteConfigV2Delivery *delivery = nil;
       dispatch_sync(self.stateQueue, ^{
-        if (self.pendingDeliveries.count > 0) {
-          delivery = self.pendingDeliveries.firstObject;
+        while (self.pendingDeliveries.count > 0 && !delivery) {
+          QONRemoteConfigV2Delivery *candidate = self.pendingDeliveries.firstObject;
           [self.pendingDeliveries removeObjectAtIndex:0];
+          if (candidate.scopeGeneration == self.scopeGeneration) delivery = candidate;
         }
       });
-      if (!delivery) break;
+      if (!delivery) return;
+
       for (QONRemoteConfigV2UpdateObserver observer in delivery.observers) {
-        __block BOOL isCurrent = NO;
+        // The generation check is the atomic claim point. setScope may return
+        // after this point while this one callback is still executing.
+        __block BOOL claimed = NO;
         dispatch_sync(self.stateQueue, ^{
-          isCurrent = delivery.scopeGeneration == self.scopeGeneration;
+          claimed = delivery.scopeGeneration == self.scopeGeneration;
         });
-        if (!isCurrent) break;
+        if (!claimed) break;
         @try {
           observer(delivery.update);
         } @catch (__unused NSException *exception) {
@@ -212,17 +284,136 @@
     }
   } @finally {
     self.isDrainingDeliveries = NO;
-    [self.deliveryLock unlock];
   }
+}
+
+- (void)drainDeliveries {
+  if ([self isOnCallbackExecutor]) {
+    [self drainDeliveriesOnCallbackExecutor];
+  } else {
+    dispatch_async(self.callbackExecutor, ^{
+      [self drainDeliveriesOnCallbackExecutor];
+    });
+  }
+}
+
+- (QONRemoteConfigV2AdmissionToken *)beginAdmissionForScope:(QONRemoteConfigV2Scope *)scope
+                                                expectation:(QONRemoteConfigV2EnvelopeExpectation *)expectation {
+  if (!scope || !expectation || ![scope.environment isEqualToString:expectation.environmentUID]) return nil;
+  __block QONRemoteConfigV2AdmissionToken *token = nil;
+  dispatch_sync(self.stateQueue, ^{
+    if (![self.currentScope isEqual:scope] || ![self ensureCurrentScopeLoadedLocked] ||
+        self.nextAdmissionOrdinal == INT64_MAX) return;
+    self.nextAdmissionOrdinal += 1;
+    token = [[QONRemoteConfigV2AdmissionToken alloc] initPrivate];
+    token.ownerNonce = self.admissionOwnerNonce;
+    token.ordinal = self.nextAdmissionOrdinal;
+    token.scope = [scope copy];
+    token.scopeGeneration = self.scopeGeneration;
+    token.expectation = [expectation copy];
+  });
+  return token;
+}
+
+- (BOOL)admissionTokenIsCurrentLocked:(QONRemoteConfigV2AdmissionToken *)token {
+  return token && [token.ownerNonce isEqual:self.admissionOwnerNonce] &&
+      [token.scope isEqual:self.currentScope] && token.scopeGeneration == self.scopeGeneration &&
+      token.ordinal == self.nextAdmissionOrdinal &&
+      token.ordinal > self.state.latestAdmissionOrdinal;
+}
+
+- (QONRemoteConfigV2Release *)releaseByTombstoningMissingActiveKeys:
+    (QONRemoteConfigV2Release *)release {
+  if (!self.state.active) return release;
+  NSMutableDictionary *entries = [release.entries mutableCopy];
+  for (NSString *key in self.state.active.entries) {
+    QONRemoteConfigV2Entry *activeEntry = self.state.active.entries[key];
+    if (!activeEntry.isTombstone && !entries[key]) {
+      QONRemoteConfigV2Entry *tombstone = [[QONRemoteConfigV2Entry alloc] initWithTombstoneKey:key];
+      if (!tombstone) return nil;
+      entries[key] = tombstone;
+    }
+  }
+  if (entries.count == release.entries.count) return release;
+  return [[QONRemoteConfigV2Release alloc] initWithReleaseUID:release.releaseUID
+      releaseNumber:release.releaseNumber manifestContentHash:release.manifestContentHash
+      entries:entries canonicalBody:release.canonicalBody strongETag:release.strongETag
+      projectID:release.projectID contextFingerprint:release.contextFingerprint
+      admissionOrdinal:release.admissionOrdinal];
+}
+
+- (QONRemoteConfigUpdate *)updateFromSnapshot:(QONRemoteConfigSnapshot *)oldSnapshot
+                                     toState:(QONRemoteConfigV2State *)state {
+  QONRemoteConfigSnapshot *newSnapshot = [self snapshotForState:state];
+  NSSet *changed = [self changedKeysFrom:oldSnapshot to:newSnapshot];
+  NSMutableDictionary *metadata = [NSMutableDictionary new];
+  for (NSString *key in changed) {
+    id value = [newSnapshot metadataForKey:key];
+    if (value) metadata[key] = value;
+  }
+  return [[QONRemoteConfigUpdate alloc] initWithSnapshot:newSnapshot
+      changedKeys:changed metadataByKey:metadata];
+}
+
+- (QONRemoteConfigV2TransitionStatus)admitBody:(NSData *)body
+                                   strongETag:(NSString *)strongETag
+                               admissionToken:(QONRemoteConfigV2AdmissionToken *)admissionToken {
+  if (!body || !strongETag || !admissionToken) return QONRemoteConfigV2TransitionStatusRejected;
+  __block BOOL tokenWasCurrent = NO;
+  dispatch_sync(self.stateQueue, ^{
+    tokenWasCurrent = [self admissionTokenIsCurrentLocked:admissionToken];
+  });
+  if (!tokenWasCurrent) return QONRemoteConfigV2TransitionStatusRejected;
+  QONRemoteConfigV2Envelope *envelope = [self.envelopeDecoder parseBody:body
+      strongETag:strongETag expectation:admissionToken.expectation];
+  if (!envelope) return QONRemoteConfigV2TransitionStatusRejected;
+
+  __block QONRemoteConfigV2TransitionStatus status = QONRemoteConfigV2TransitionStatusRejected;
+  dispatch_sync(self.stateQueue, ^{
+    if (![self admissionTokenIsCurrentLocked:admissionToken] ||
+        ![self ensureCurrentScopeLoadedLocked]) return;
+    NSInteger releaseFloor = MAX(self.state.candidate.releaseNumber,
+                                 self.state.active.releaseNumber);
+    if (envelope.snapshotRelease.releaseNumber < releaseFloor) return;
+    QONRemoteConfigV2Release *tokenized = [envelope.snapshotRelease
+        releaseBySettingAdmissionOrdinal:admissionToken.ordinal];
+    QONRemoteConfigV2Release *admitted = [self releaseByTombstoningMissingActiveKeys:tokenized];
+    if (!admitted) return;
+    QONRemoteConfigSnapshot *oldSnapshot = [self snapshotForState:self.state];
+    BOOL immediate = admitted.containsImmediateEntry;
+    QONRemoteConfigV2State *nextState = [[QONRemoteConfigV2State alloc]
+        initWithCandidate:admitted
+                   active:immediate ? admitted : self.state.active
+                 previous:immediate ? self.state.active : self.state.previous
+              didActivate:immediate ? YES : self.state.didActivate
+   latestAdmissionOrdinal:admissionToken.ordinal];
+    if (!nextState || !self.currentScope ||
+        ![self.store saveState:nextState forScope:self.currentScope]) {
+      status = QONRemoteConfigV2TransitionStatusPersistenceFailed;
+      return;
+    }
+    self.state = nextState;
+    if (immediate) {
+      QONRemoteConfigUpdate *update = [self updateFromSnapshot:oldSnapshot toState:nextState];
+      [self enqueueUpdateLocked:update];
+      status = QONRemoteConfigV2TransitionStatusActivated;
+    } else {
+      status = QONRemoteConfigV2TransitionStatusAccepted;
+    }
+  });
+  [self drainDeliveries];
+  return status;
 }
 
 - (void)acceptFetchedRelease:(QONRemoteConfigV2Release *)release
                      forScope:(QONRemoteConfigV2Scope *)scope {
   if (!release || !scope) return;
   __block QONRemoteConfigUpdate *update = nil;
+  __block int64_t admissionOrdinal = 0;
   dispatch_sync(self.stateQueue, ^{
     if (!self.currentScope || ![self.currentScope isEqual:scope]) return;
     if (![self ensureCurrentScopeLoadedLocked]) return;
+    if (self.nextAdmissionOrdinal == INT64_MAX) return;
     QONRemoteConfigV2Release *latest = self.state.candidate;
     if (!latest || self.state.active.releaseNumber > latest.releaseNumber) latest = self.state.active;
     if (latest && release.releaseNumber <= latest.releaseNumber) {
@@ -231,11 +422,17 @@
       // older late response must never replace the freshest durable candidate.
       return;
     }
+    self.nextAdmissionOrdinal += 1;
+    admissionOrdinal = self.nextAdmissionOrdinal;
+    QONRemoteConfigV2Release *orderedRelease = [release
+        releaseBySettingAdmissionOrdinal:admissionOrdinal];
+    if (!orderedRelease) return;
     QONRemoteConfigV2State *nextState = [[QONRemoteConfigV2State alloc]
-        initWithCandidate:release active:self.state.active
-        previous:self.state.previous didActivate:self.state.didActivate];
-    if ([release containsImmediateEntry]) {
-      update = [self transitionToCandidateLocked:release];
+        initWithCandidate:orderedRelease active:self.state.active
+        previous:self.state.previous didActivate:self.state.didActivate
+        latestAdmissionOrdinal:admissionOrdinal];
+    if ([orderedRelease containsImmediateEntry]) {
+      update = [self transitionToCandidateLocked:orderedRelease];
     } else {
       QONRemoteConfigV2Scope *currentScope = self.currentScope;
       if (currentScope && [self.store saveState:nextState forScope:currentScope]) self.state = nextState;
@@ -251,7 +448,8 @@
   dispatch_sync(self.stateQueue, ^{
     if (![self ensureCurrentScopeLoadedLocked]) return;
     if (self.state.candidate) {
-      if (self.state.didActivate && [self.state.candidate contentEquals:self.state.active]) return;
+      if (self.state.didActivate && [self release:self.state.candidate
+          representsSameLocalAdmissionAs:self.state.active]) return;
       update = [self transitionToCandidateLocked:self.state.candidate];
       changed = update.changedKeys.count > 0;
     } else if (!self.state.didActivate) {

--- a/Sources/Qonversion/Qonversion/Main/QONRemoteConfigV2Manager/QONRemoteConfigV2Models.h
+++ b/Sources/Qonversion/Qonversion/Main/QONRemoteConfigV2Manager/QONRemoteConfigV2Models.h
@@ -10,6 +10,7 @@ FOUNDATION_EXPORT NSUInteger const QONRemoteConfigV2MaximumTotalValueBytes;
 FOUNDATION_EXPORT NSUInteger const QONRemoteConfigV2MaximumKeyBytes;
 FOUNDATION_EXPORT NSUInteger const QONRemoteConfigV2MaximumUIDCodePoints;
 FOUNDATION_EXPORT NSUInteger const QONRemoteConfigV2MaximumScopeComponentBytes;
+FOUNDATION_EXPORT NSUInteger const QONRemoteConfigV2MaximumEnvelopeBytes;
 FOUNDATION_EXPORT int64_t const QONRemoteConfigV2MaximumSafeInteger;
 
 @interface QONRemoteConfigV2Scope : NSObject <NSCopying>
@@ -27,6 +28,8 @@ FOUNDATION_EXPORT int64_t const QONRemoteConfigV2MaximumSafeInteger;
 @property (nonatomic, copy, nullable, readonly) NSString *variationUID;
 @property (nonatomic, assign, readonly) QONRemoteConfigApplyPolicy applyPolicy;
 @property (nonatomic, copy, nullable, readonly) id metadata;
+/** Exact JSON bytes supplied by the server, including insignificant whitespace. */
+@property (nonatomic, copy, nullable, readonly) NSData *metadataData;
 @property (nonatomic, assign, readonly, getter=isTombstone) BOOL tombstone;
 - (nullable instancetype)initWithKey:(NSString *)key
                              rawData:(NSData *)rawData
@@ -34,6 +37,11 @@ FOUNDATION_EXPORT int64_t const QONRemoteConfigV2MaximumSafeInteger;
                          applyPolicy:(QONRemoteConfigApplyPolicy)applyPolicy
                             metadata:(nullable id)metadata;
 - (nullable instancetype)initWithTombstoneKey:(NSString *)key;
+- (nullable instancetype)initWithKey:(NSString *)key
+                             rawData:(NSData *)rawData
+                        variationUID:(NSString *)variationUID
+                         applyPolicy:(QONRemoteConfigApplyPolicy)applyPolicy
+                        metadataData:(NSData *)metadataData;
 - (BOOL)contentEquals:(nullable QONRemoteConfigV2Entry *)other;
 @end
 
@@ -42,10 +50,25 @@ FOUNDATION_EXPORT int64_t const QONRemoteConfigV2MaximumSafeInteger;
 @property (nonatomic, assign, readonly) NSInteger releaseNumber;
 @property (nonatomic, copy, readonly) NSString *manifestContentHash;
 @property (nonatomic, copy, readonly) NSDictionary<NSString *, QONRemoteConfigV2Entry *> *entries;
+@property (nonatomic, copy, nullable, readonly) NSData *canonicalBody;
+@property (nonatomic, copy, nullable, readonly) NSString *strongETag;
+@property (nonatomic, assign, readonly) int64_t projectID;
+@property (nonatomic, copy, nullable, readonly) NSString *contextFingerprint;
+@property (nonatomic, assign, readonly) int64_t admissionOrdinal;
 - (nullable instancetype)initWithReleaseUID:(NSString *)releaseUID
                               releaseNumber:(NSInteger)releaseNumber
                         manifestContentHash:(NSString *)manifestContentHash
                                     entries:(NSDictionary<NSString *, QONRemoteConfigV2Entry *> *)entries;
+- (nullable instancetype)initWithReleaseUID:(NSString *)releaseUID
+                              releaseNumber:(NSInteger)releaseNumber
+                        manifestContentHash:(NSString *)manifestContentHash
+                                    entries:(NSDictionary<NSString *, QONRemoteConfigV2Entry *> *)entries
+                              canonicalBody:(nullable NSData *)canonicalBody
+                                  strongETag:(nullable NSString *)strongETag
+                                   projectID:(int64_t)projectID
+                          contextFingerprint:(nullable NSString *)contextFingerprint
+                           admissionOrdinal:(int64_t)admissionOrdinal;
+- (nullable QONRemoteConfigV2Release *)releaseBySettingAdmissionOrdinal:(int64_t)admissionOrdinal;
 - (BOOL)containsImmediateEntry;
 - (BOOL)contentEquals:(nullable QONRemoteConfigV2Release *)other;
 @end
@@ -55,10 +78,46 @@ FOUNDATION_EXPORT int64_t const QONRemoteConfigV2MaximumSafeInteger;
 @property (nonatomic, strong, nullable, readonly) QONRemoteConfigV2Release *active;
 @property (nonatomic, strong, nullable, readonly) QONRemoteConfigV2Release *previous;
 @property (nonatomic, assign, readonly) BOOL didActivate;
+@property (nonatomic, assign, readonly) int64_t latestAdmissionOrdinal;
 - (nullable instancetype)initWithCandidate:(nullable QONRemoteConfigV2Release *)candidate
                             active:(nullable QONRemoteConfigV2Release *)active
                           previous:(nullable QONRemoteConfigV2Release *)previous
                        didActivate:(BOOL)didActivate;
+- (nullable instancetype)initWithCandidate:(nullable QONRemoteConfigV2Release *)candidate
+                                    active:(nullable QONRemoteConfigV2Release *)active
+                                  previous:(nullable QONRemoteConfigV2Release *)previous
+                               didActivate:(BOOL)didActivate
+                    latestAdmissionOrdinal:(int64_t)latestAdmissionOrdinal;
+@end
+
+/** Expected privacy and rendering boundary for one exact resolved-snapshot response. */
+@interface QONRemoteConfigV2EnvelopeExpectation : NSObject <NSCopying>
+@property (nonatomic, assign, readonly) int64_t projectID;
+@property (nonatomic, copy, readonly) NSString *environmentUID;
+@property (nonatomic, copy, readonly) NSString *contextFingerprint;
+- (nullable instancetype)initWithProjectID:(int64_t)projectID
+                            environmentUID:(NSString *)environmentUID
+                        contextFingerprint:(NSString *)contextFingerprint;
+@end
+
+@interface QONRemoteConfigV2Envelope : NSObject
+@property (nonatomic, assign, readonly) int64_t projectID;
+@property (nonatomic, copy, readonly) NSString *environmentUID;
+@property (nonatomic, copy, readonly) NSString *contextFingerprint;
+@property (nonatomic, strong, readonly) QONRemoteConfigV2Release *snapshotRelease;
+@property (nonatomic, copy, readonly) NSString *eTag;
+@property (nonatomic, copy, readonly) NSString *bodyDigest;
+@property (nonatomic, copy, readonly) NSData *canonicalBody;
+@end
+
+/** Strict schema-1 parser. It never performs networking and returns nil on any ambiguity. */
+@protocol QONRemoteConfigV2EnvelopeDecoding <NSObject>
+- (nullable QONRemoteConfigV2Envelope *)parseBody:(NSData *)body
+                                      strongETag:(NSString *)strongETag
+                                     expectation:(QONRemoteConfigV2EnvelopeExpectation *)expectation;
+@end
+
+@interface QONRemoteConfigV2EnvelopeParser : NSObject <QONRemoteConfigV2EnvelopeDecoding>
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Qonversion/Qonversion/Main/QONRemoteConfigV2Manager/QONRemoteConfigV2Models.m
+++ b/Sources/Qonversion/Qonversion/Main/QONRemoteConfigV2Manager/QONRemoteConfigV2Models.m
@@ -1,5 +1,7 @@
 #import "QONRemoteConfigV2Models.h"
 #import "QONRemoteConfigJSON.h"
+#import <CommonCrypto/CommonDigest.h>
+#import <math.h>
 
 NSUInteger const QONRemoteConfigV2MaximumEntryCount = 1000;
 NSUInteger const QONRemoteConfigV2MaximumRawValueBytes = 64 * 1024;
@@ -8,6 +10,7 @@ NSUInteger const QONRemoteConfigV2MaximumTotalValueBytes = 4 * 1024 * 1024;
 NSUInteger const QONRemoteConfigV2MaximumKeyBytes = 256;
 NSUInteger const QONRemoteConfigV2MaximumUIDCodePoints = 36;
 NSUInteger const QONRemoteConfigV2MaximumScopeComponentBytes = 256;
+NSUInteger const QONRemoteConfigV2MaximumEnvelopeBytes = 8 * 1024 * 1024;
 int64_t const QONRemoteConfigV2MaximumSafeInteger = 9007199254740991LL;
 
 static NSUInteger QONRemoteConfigV2CodePointCount(NSString *value) {
@@ -35,6 +38,28 @@ static BOOL QONRemoteConfigV2ValidSHA256(NSString *value) {
   if (value.length != 64 || ![value isEqualToString:value.lowercaseString]) return NO;
   NSCharacterSet *invalid = [[NSCharacterSet characterSetWithCharactersInString:@"0123456789abcdef"] invertedSet];
   return [value rangeOfCharacterFromSet:invalid].location == NSNotFound;
+}
+
+static NSString *QONRemoteConfigV2SHA256Hex(NSData *data) {
+  if (!data || data.length > UINT32_MAX) return nil;
+  uint8_t digest[CC_SHA256_DIGEST_LENGTH];
+  CC_SHA256(data.bytes, (CC_LONG)data.length, digest);
+  NSMutableString *hex = [NSMutableString stringWithCapacity:CC_SHA256_DIGEST_LENGTH * 2];
+  for (NSUInteger index = 0; index < CC_SHA256_DIGEST_LENGTH; index++) {
+    [hex appendFormat:@"%02x", digest[index]];
+  }
+  return [hex copy];
+}
+
+static BOOL QONRemoteConfigV2ValidStrongETag(NSString *eTag, NSData *body,
+                                             NSString **bodyDigest) {
+  if (eTag.length != 66 || ![eTag hasPrefix:@"\""] || ![eTag hasSuffix:@"\""]) return NO;
+  NSString *digest = [eTag substringWithRange:NSMakeRange(1, 64)];
+  if (!QONRemoteConfigV2ValidSHA256(digest) || ![digest isEqualToString:QONRemoteConfigV2SHA256Hex(body)]) {
+    return NO;
+  }
+  if (bodyDigest) *bodyDigest = digest;
+  return YES;
 }
 
 static id QONRemoteConfigV2DeepJSONCopy(id value) {
@@ -77,6 +102,456 @@ static id QONRemoteConfigV2DeepJSONCopy(id value) {
 
 @end
 
+@implementation QONRemoteConfigV2EnvelopeExpectation
+
+- (instancetype)initWithProjectID:(int64_t)projectID
+                    environmentUID:(NSString *)environmentUID
+                contextFingerprint:(NSString *)contextFingerprint {
+  if (projectID <= 0 || projectID > QONRemoteConfigV2MaximumSafeInteger ||
+      !QONRemoteConfigV2ValidUID(environmentUID) ||
+      !QONRemoteConfigV2ValidSHA256(contextFingerprint)) return nil;
+  self = [super init];
+  if (self) {
+    _projectID = projectID;
+    _environmentUID = [environmentUID copy];
+    _contextFingerprint = [contextFingerprint copy];
+  }
+  return self;
+}
+
+- (id)copyWithZone:(NSZone *)zone { return self; }
+
+@end
+
+@interface QONRemoteConfigV2Envelope ()
+@property (nonatomic, assign, readwrite) int64_t projectID;
+@property (nonatomic, copy, readwrite) NSString *environmentUID;
+@property (nonatomic, copy, readwrite) NSString *contextFingerprint;
+@property (nonatomic, strong, readwrite) QONRemoteConfigV2Release *snapshotRelease;
+@property (nonatomic, copy, readwrite) NSString *eTag;
+@property (nonatomic, copy, readwrite) NSString *bodyDigest;
+@property (nonatomic, copy, readwrite) NSData *canonicalBody;
+@end
+
+@implementation QONRemoteConfigV2Envelope
+@end
+
+typedef struct {
+  const uint8_t *bytes;
+  NSUInteger length;
+  NSUInteger index;
+  NSUInteger limit;
+} QONRemoteConfigV2JSONReader;
+
+static void QONRemoteConfigV2SkipWhitespace(QONRemoteConfigV2JSONReader *reader) {
+  while (reader->index < reader->limit) {
+    uint8_t byte = reader->bytes[reader->index];
+    if (byte != ' ' && byte != '\t' && byte != '\r' && byte != '\n') break;
+    reader->index += 1;
+  }
+}
+
+static BOOL QONRemoteConfigV2Consume(QONRemoteConfigV2JSONReader *reader, uint8_t byte) {
+  if (reader->index >= reader->limit || reader->bytes[reader->index] != byte) return NO;
+  reader->index += 1;
+  return YES;
+}
+
+static BOOL QONRemoteConfigV2Expect(QONRemoteConfigV2JSONReader *reader, uint8_t byte) {
+  return QONRemoteConfigV2Consume(reader, byte);
+}
+
+static BOOL QONRemoteConfigV2IsHex(uint8_t byte) {
+  return (byte >= '0' && byte <= '9') || (byte >= 'a' && byte <= 'f') ||
+      (byte >= 'A' && byte <= 'F');
+}
+
+static NSString *QONRemoteConfigV2ReadString(QONRemoteConfigV2JSONReader *reader) {
+  NSUInteger start = reader->index;
+  if (!QONRemoteConfigV2Expect(reader, '"')) return nil;
+  BOOL escaped = NO;
+  while (reader->index < reader->limit) {
+    uint8_t byte = reader->bytes[reader->index++];
+    if (escaped) {
+      if (byte == 'u') {
+        for (NSUInteger count = 0; count < 4; count++) {
+          if (reader->index >= reader->limit ||
+              !QONRemoteConfigV2IsHex(reader->bytes[reader->index++])) return nil;
+        }
+      } else if (byte != '"' && byte != '\\' && byte != '/' && byte != 'b' &&
+                 byte != 'f' && byte != 'n' && byte != 'r' && byte != 't') {
+        return nil;
+      }
+      escaped = NO;
+      continue;
+    }
+    if (byte == '\\') {
+      escaped = YES;
+    } else if (byte == '"') {
+      NSData *quoted = [NSData dataWithBytes:reader->bytes + start
+                                      length:reader->index - start];
+      NSError *error = nil;
+      id decoded = [NSJSONSerialization JSONObjectWithData:quoted
+          options:NSJSONReadingFragmentsAllowed error:&error];
+      if (error || ![decoded isKindOfClass:NSString.class]) return nil;
+      NSData *utf8 = [decoded dataUsingEncoding:NSUTF8StringEncoding];
+      return utf8 ? decoded : nil;
+    } else if (byte < 0x20) {
+      return nil;
+    }
+  }
+  return nil;
+}
+
+static NSString *QONRemoteConfigV2ReadNumberToken(QONRemoteConfigV2JSONReader *reader) {
+  NSUInteger start = reader->index;
+  QONRemoteConfigV2Consume(reader, '-');
+  if (QONRemoteConfigV2Consume(reader, '0')) {
+    if (reader->index < reader->limit && reader->bytes[reader->index] >= '0' &&
+        reader->bytes[reader->index] <= '9') return nil;
+  } else {
+    if (reader->index >= reader->limit || reader->bytes[reader->index] < '1' ||
+        reader->bytes[reader->index] > '9') return nil;
+    while (reader->index < reader->limit && reader->bytes[reader->index] >= '0' &&
+           reader->bytes[reader->index] <= '9') reader->index += 1;
+  }
+  if (QONRemoteConfigV2Consume(reader, '.')) {
+    if (reader->index >= reader->limit || reader->bytes[reader->index] < '0' ||
+        reader->bytes[reader->index] > '9') return nil;
+    while (reader->index < reader->limit && reader->bytes[reader->index] >= '0' &&
+           reader->bytes[reader->index] <= '9') reader->index += 1;
+  }
+  if (reader->index < reader->limit &&
+      (reader->bytes[reader->index] == 'e' || reader->bytes[reader->index] == 'E')) {
+    reader->index += 1;
+    if (reader->index < reader->limit &&
+        (reader->bytes[reader->index] == '+' || reader->bytes[reader->index] == '-')) {
+      reader->index += 1;
+    }
+    if (reader->index >= reader->limit || reader->bytes[reader->index] < '0' ||
+        reader->bytes[reader->index] > '9') return nil;
+    while (reader->index < reader->limit && reader->bytes[reader->index] >= '0' &&
+           reader->bytes[reader->index] <= '9') reader->index += 1;
+  }
+  if (reader->index == start) return nil;
+  return [[NSString alloc] initWithBytes:reader->bytes + start
+      length:reader->index - start encoding:NSASCIIStringEncoding];
+}
+
+static BOOL QONRemoteConfigV2ValidatePortableNumber(NSString *token) {
+  if (!token) return NO;
+  if ([token rangeOfCharacterFromSet:
+      [NSCharacterSet characterSetWithCharactersInString:@".eE"]].location == NSNotFound) {
+    if (token.length > 17) return NO;
+    NSDecimalNumber *number = [NSDecimalNumber decimalNumberWithString:token
+        locale:@{NSLocaleDecimalSeparator: @"."}];
+    if ([number isEqual:NSDecimalNumber.notANumber]) return NO;
+    NSDecimalNumber *maximum = [NSDecimalNumber decimalNumberWithMantissa:
+        (uint64_t)QONRemoteConfigV2MaximumSafeInteger exponent:0 isNegative:NO];
+    NSDecimalNumber *minimum = [maximum decimalNumberByMultiplyingBy:[NSDecimalNumber decimalNumberWithString:@"-1"]];
+    if ([number compare:minimum] == NSOrderedAscending || [number compare:maximum] == NSOrderedDescending) {
+      return NO;
+    }
+  }
+  NSData *tokenData = [token dataUsingEncoding:NSASCIIStringEncoding];
+  if (!tokenData) return NO;
+  NSError *error = nil;
+  id object = [NSJSONSerialization JSONObjectWithData:tokenData
+      options:NSJSONReadingFragmentsAllowed error:&error];
+  if (error || ![object isKindOfClass:NSNumber.class] ||
+      CFGetTypeID((__bridge CFTypeRef)object) == CFBooleanGetTypeID()) return NO;
+  return isfinite([(NSNumber *)object doubleValue]);
+}
+
+static BOOL QONRemoteConfigV2ScanPortableValue(QONRemoteConfigV2JSONReader *reader,
+                                                NSUInteger depth);
+
+static BOOL QONRemoteConfigV2ScanPortableObject(QONRemoteConfigV2JSONReader *reader,
+                                                 NSUInteger depth) {
+  if (depth > 64 || !QONRemoteConfigV2Expect(reader, '{')) return NO;
+  QONRemoteConfigV2SkipWhitespace(reader);
+  if (QONRemoteConfigV2Consume(reader, '}')) return YES;
+  NSMutableSet<NSString *> *members = [NSMutableSet new];
+  while (YES) {
+    NSString *name = QONRemoteConfigV2ReadString(reader);
+    if (!name || [members containsObject:name]) return NO;
+    [members addObject:name];
+    QONRemoteConfigV2SkipWhitespace(reader);
+    if (!QONRemoteConfigV2Expect(reader, ':')) return NO;
+    QONRemoteConfigV2SkipWhitespace(reader);
+    if (!QONRemoteConfigV2ScanPortableValue(reader, depth + 1)) return NO;
+    QONRemoteConfigV2SkipWhitespace(reader);
+    if (QONRemoteConfigV2Consume(reader, '}')) return YES;
+    if (!QONRemoteConfigV2Expect(reader, ',')) return NO;
+    QONRemoteConfigV2SkipWhitespace(reader);
+  }
+}
+
+static BOOL QONRemoteConfigV2ScanPortableArray(QONRemoteConfigV2JSONReader *reader,
+                                                NSUInteger depth) {
+  if (depth > 64 || !QONRemoteConfigV2Expect(reader, '[')) return NO;
+  QONRemoteConfigV2SkipWhitespace(reader);
+  if (QONRemoteConfigV2Consume(reader, ']')) return YES;
+  while (YES) {
+    if (!QONRemoteConfigV2ScanPortableValue(reader, depth + 1)) return NO;
+    QONRemoteConfigV2SkipWhitespace(reader);
+    if (QONRemoteConfigV2Consume(reader, ']')) return YES;
+    if (!QONRemoteConfigV2Expect(reader, ',')) return NO;
+    QONRemoteConfigV2SkipWhitespace(reader);
+  }
+}
+
+static BOOL QONRemoteConfigV2ExpectLiteral(QONRemoteConfigV2JSONReader *reader,
+                                            const char *literal) {
+  for (const char *cursor = literal; *cursor; cursor++) {
+    if (!QONRemoteConfigV2Expect(reader, (uint8_t)*cursor)) return NO;
+  }
+  return YES;
+}
+
+static BOOL QONRemoteConfigV2ScanPortableValue(QONRemoteConfigV2JSONReader *reader,
+                                                NSUInteger depth) {
+  if (reader->index >= reader->limit) return NO;
+  switch (reader->bytes[reader->index]) {
+    case '{': return QONRemoteConfigV2ScanPortableObject(reader, depth);
+    case '[': return QONRemoteConfigV2ScanPortableArray(reader, depth);
+    case '"': return QONRemoteConfigV2ReadString(reader) != nil;
+    case 't': return QONRemoteConfigV2ExpectLiteral(reader, "true");
+    case 'f': return QONRemoteConfigV2ExpectLiteral(reader, "false");
+    case 'n': return QONRemoteConfigV2ExpectLiteral(reader, "null");
+    default: return QONRemoteConfigV2ValidatePortableNumber(QONRemoteConfigV2ReadNumberToken(reader));
+  }
+}
+
+static NSData *QONRemoteConfigV2ReadPortableSpan(QONRemoteConfigV2JSONReader *reader,
+                                                 NSUInteger maximumBytes) {
+  NSUInteger start = reader->index;
+  NSUInteger outerLimit = reader->limit;
+  NSUInteger valueLimit = MIN(outerLimit, start + maximumBytes);
+  reader->limit = valueLimit;
+  QONRemoteConfigV2SkipWhitespace(reader);
+  BOOL valid = QONRemoteConfigV2ScanPortableValue(reader, 1);
+  QONRemoteConfigV2SkipWhitespace(reader);
+  NSUInteger end = reader->index;
+  reader->limit = outerLimit;
+  if (!valid || end <= start || end - start > maximumBytes) return nil;
+  if (end == valueLimit && valueLimit < outerLimit) {
+    uint8_t next = reader->bytes[end];
+    if (next != ',' && next != '}' && next != ']') return nil;
+  }
+  return [NSData dataWithBytes:reader->bytes + start length:end - start];
+}
+
+static BOOL QONRemoteConfigV2ReadExactInteger(QONRemoteConfigV2JSONReader *reader,
+                                               int64_t *value) {
+  QONRemoteConfigV2SkipWhitespace(reader);
+  NSString *token = QONRemoteConfigV2ReadNumberToken(reader);
+  if (!token || [token rangeOfCharacterFromSet:
+      [NSCharacterSet characterSetWithCharactersInString:@".eE"]].location != NSNotFound ||
+      !QONRemoteConfigV2ValidatePortableNumber(token)) return NO;
+  if (value) *value = token.longLongValue;
+  return YES;
+}
+
+static NSString *QONRemoteConfigV2ReadStringValue(QONRemoteConfigV2JSONReader *reader) {
+  QONRemoteConfigV2SkipWhitespace(reader);
+  return QONRemoteConfigV2ReadString(reader);
+}
+
+static BOOL QONRemoteConfigV2ReadBooleanValue(QONRemoteConfigV2JSONReader *reader,
+                                               BOOL *value) {
+  QONRemoteConfigV2SkipWhitespace(reader);
+  if (QONRemoteConfigV2ExpectLiteral(reader, "true")) {
+    if (value) *value = YES;
+    return YES;
+  }
+  if (QONRemoteConfigV2ExpectLiteral(reader, "false")) {
+    if (value) *value = NO;
+    return YES;
+  }
+  return NO;
+}
+
+static QONRemoteConfigV2Entry *QONRemoteConfigV2ReadWireEntry(
+    QONRemoteConfigV2JSONReader *reader, NSString *key) {
+  QONRemoteConfigV2SkipWhitespace(reader);
+  if (!QONRemoteConfigV2Expect(reader, '{')) return nil;
+  QONRemoteConfigV2SkipWhitespace(reader);
+  if (QONRemoteConfigV2Consume(reader, '}')) return nil;
+  NSMutableSet<NSString *> *members = [NSMutableSet new];
+  NSData *raw = nil, *metadata = nil;
+  NSString *variationUID = nil, *policyValue = nil;
+  while (YES) {
+    NSString *name = QONRemoteConfigV2ReadString(reader);
+    if (!name || [members containsObject:name]) return nil;
+    [members addObject:name];
+    QONRemoteConfigV2SkipWhitespace(reader);
+    if (!QONRemoteConfigV2Expect(reader, ':')) return nil;
+    if ([name isEqualToString:@"raw"]) {
+      raw = QONRemoteConfigV2ReadPortableSpan(reader, QONRemoteConfigV2MaximumRawValueBytes);
+    } else if ([name isEqualToString:@"variation_uid"]) {
+      variationUID = QONRemoteConfigV2ReadStringValue(reader);
+    } else if ([name isEqualToString:@"apply_policy"]) {
+      policyValue = QONRemoteConfigV2ReadStringValue(reader);
+    } else if ([name isEqualToString:@"metadata"]) {
+      metadata = QONRemoteConfigV2ReadPortableSpan(reader, QONRemoteConfigV2MaximumMetadataBytes);
+    } else {
+      return nil;
+    }
+    if (([name isEqualToString:@"raw"] && !raw) ||
+        ([name isEqualToString:@"variation_uid"] && !variationUID) ||
+        ([name isEqualToString:@"apply_policy"] && !policyValue) ||
+        ([name isEqualToString:@"metadata"] && !metadata)) return nil;
+    QONRemoteConfigV2SkipWhitespace(reader);
+    if (QONRemoteConfigV2Consume(reader, '}')) break;
+    if (!QONRemoteConfigV2Expect(reader, ',')) return nil;
+    QONRemoteConfigV2SkipWhitespace(reader);
+  }
+  if (members.count != 4 || !raw || !metadata || !QONRemoteConfigV2ValidUID(variationUID)) return nil;
+  QONRemoteConfigApplyPolicy policy;
+  if ([policyValue isEqualToString:@"on_next_activate"]) {
+    policy = QONRemoteConfigApplyPolicyOnNextActivate;
+  } else if ([policyValue isEqualToString:@"immediate"]) {
+    policy = QONRemoteConfigApplyPolicyImmediate;
+  } else {
+    return nil;
+  }
+  return [[QONRemoteConfigV2Entry alloc] initWithKey:key rawData:raw
+      variationUID:variationUID applyPolicy:policy metadataData:metadata];
+}
+
+static NSDictionary<NSString *, QONRemoteConfigV2Entry *> *QONRemoteConfigV2ReadWireValues(
+    QONRemoteConfigV2JSONReader *reader) {
+  QONRemoteConfigV2SkipWhitespace(reader);
+  if (!QONRemoteConfigV2Expect(reader, '{')) return nil;
+  QONRemoteConfigV2SkipWhitespace(reader);
+  NSMutableDictionary *values = [NSMutableDictionary new];
+  if (QONRemoteConfigV2Consume(reader, '}')) return values;
+  while (YES) {
+    if (values.count >= QONRemoteConfigV2MaximumEntryCount) return nil;
+    NSString *key = QONRemoteConfigV2ReadString(reader);
+    if (!QONRemoteConfigV2ValidBoundedString(key, QONRemoteConfigV2MaximumKeyBytes) || values[key]) return nil;
+    QONRemoteConfigV2SkipWhitespace(reader);
+    if (!QONRemoteConfigV2Expect(reader, ':')) return nil;
+    QONRemoteConfigV2Entry *entry = QONRemoteConfigV2ReadWireEntry(reader, key);
+    if (!entry) return nil;
+    values[key] = entry;
+    QONRemoteConfigV2SkipWhitespace(reader);
+    if (QONRemoteConfigV2Consume(reader, '}')) break;
+    if (!QONRemoteConfigV2Expect(reader, ',')) return nil;
+    QONRemoteConfigV2SkipWhitespace(reader);
+  }
+  return [values copy];
+}
+
+@interface QONRemoteConfigV2EnvelopeParser ()
+- (nullable QONRemoteConfigV2Envelope *)parseBoundBody:(NSData *)body
+                                             strongETag:(NSString *)strongETag;
+@end
+
+@implementation QONRemoteConfigV2EnvelopeParser
+
+- (QONRemoteConfigV2Envelope *)parseBody:(NSData *)body
+                              strongETag:(NSString *)strongETag
+                             expectation:(QONRemoteConfigV2EnvelopeExpectation *)expectation {
+  if (!expectation) return nil;
+  QONRemoteConfigV2Envelope *envelope = [self parseBoundBody:body strongETag:strongETag];
+  if (!envelope || envelope.projectID != expectation.projectID ||
+      ![envelope.environmentUID isEqualToString:expectation.environmentUID] ||
+      ![envelope.contextFingerprint isEqualToString:expectation.contextFingerprint]) return nil;
+  return envelope;
+}
+
+- (QONRemoteConfigV2Envelope *)parseBoundBody:(NSData *)body
+                                    strongETag:(NSString *)strongETag {
+  if (!body || body.length == 0 || body.length > QONRemoteConfigV2MaximumEnvelopeBytes) return nil;
+  NSString *bodyDigest = nil;
+  if (!QONRemoteConfigV2ValidStrongETag(strongETag, body, &bodyDigest)) return nil;
+  NSString *strictUTF8 = [[NSString alloc] initWithData:body encoding:NSUTF8StringEncoding];
+  if (!strictUTF8 || ![[strictUTF8 dataUsingEncoding:NSUTF8StringEncoding] isEqual:body]) return nil;
+
+  QONRemoteConfigV2JSONReader reader = {
+    .bytes = body.bytes, .length = body.length, .index = 0, .limit = body.length,
+  };
+  int64_t schemaVersion = 0, projectID = 0, releaseNumber = 0;
+  NSString *environmentUID = nil, *releaseUID = nil, *manifestHash = nil, *contextFingerprint = nil;
+  NSDictionary<NSString *, QONRemoteConfigV2Entry *> *values = nil;
+  BOOL completeKeySet = NO;
+  BOOL hasSchema = NO, hasProject = NO, hasComplete = NO;
+  NSMutableSet<NSString *> *members = [NSMutableSet new];
+  QONRemoteConfigV2SkipWhitespace(&reader);
+  if (!QONRemoteConfigV2Expect(&reader, '{')) return nil;
+  QONRemoteConfigV2SkipWhitespace(&reader);
+  if (QONRemoteConfigV2Consume(&reader, '}')) return nil;
+  while (YES) {
+    NSString *name = QONRemoteConfigV2ReadString(&reader);
+    if (!name || [members containsObject:name]) return nil;
+    [members addObject:name];
+    QONRemoteConfigV2SkipWhitespace(&reader);
+    if (!QONRemoteConfigV2Expect(&reader, ':')) return nil;
+    if ([name isEqualToString:@"schema_version"]) {
+      hasSchema = QONRemoteConfigV2ReadExactInteger(&reader, &schemaVersion);
+    } else if ([name isEqualToString:@"project_id"]) {
+      hasProject = QONRemoteConfigV2ReadExactInteger(&reader, &projectID);
+    } else if ([name isEqualToString:@"environment_uid"]) {
+      environmentUID = QONRemoteConfigV2ReadStringValue(&reader);
+    } else if ([name isEqualToString:@"release_uid"]) {
+      releaseUID = QONRemoteConfigV2ReadStringValue(&reader);
+    } else if ([name isEqualToString:@"release_number"]) {
+      if (!QONRemoteConfigV2ReadExactInteger(&reader, &releaseNumber)) return nil;
+    } else if ([name isEqualToString:@"manifest_content_hash"]) {
+      manifestHash = QONRemoteConfigV2ReadStringValue(&reader);
+    } else if ([name isEqualToString:@"complete_key_set"]) {
+      hasComplete = QONRemoteConfigV2ReadBooleanValue(&reader, &completeKeySet);
+    } else if ([name isEqualToString:@"context_fingerprint"]) {
+      contextFingerprint = QONRemoteConfigV2ReadStringValue(&reader);
+    } else if ([name isEqualToString:@"values"]) {
+      values = QONRemoteConfigV2ReadWireValues(&reader);
+    } else {
+      return nil;
+    }
+    if ((!hasSchema && [name isEqualToString:@"schema_version"]) ||
+        (!hasProject && [name isEqualToString:@"project_id"]) ||
+        (!hasComplete && [name isEqualToString:@"complete_key_set"]) ||
+        ([name isEqualToString:@"environment_uid"] && !environmentUID) ||
+        ([name isEqualToString:@"release_uid"] && !releaseUID) ||
+        ([name isEqualToString:@"manifest_content_hash"] && !manifestHash) ||
+        ([name isEqualToString:@"context_fingerprint"] && !contextFingerprint) ||
+        ([name isEqualToString:@"values"] && !values)) return nil;
+    QONRemoteConfigV2SkipWhitespace(&reader);
+    if (QONRemoteConfigV2Consume(&reader, '}')) break;
+    if (!QONRemoteConfigV2Expect(&reader, ',')) return nil;
+    QONRemoteConfigV2SkipWhitespace(&reader);
+  }
+  QONRemoteConfigV2SkipWhitespace(&reader);
+  if (reader.index != reader.length || members.count != 9 || schemaVersion != 1 || !completeKeySet ||
+      projectID <= 0 || projectID > QONRemoteConfigV2MaximumSafeInteger ||
+      releaseNumber <= 0 || releaseNumber > QONRemoteConfigV2MaximumSafeInteger ||
+      releaseNumber > NSIntegerMax ||
+      !QONRemoteConfigV2ValidUID(environmentUID) || !QONRemoteConfigV2ValidUID(releaseUID) ||
+      !QONRemoteConfigV2ValidSHA256(manifestHash) ||
+      [manifestHash isEqualToString:[@"0" stringByPaddingToLength:64 withString:@"0" startingAtIndex:0]] ||
+      !QONRemoteConfigV2ValidSHA256(contextFingerprint) || !values) return nil;
+
+  QONRemoteConfigV2Release *release = [[QONRemoteConfigV2Release alloc]
+      initWithReleaseUID:releaseUID releaseNumber:(NSInteger)releaseNumber
+      manifestContentHash:manifestHash entries:values canonicalBody:body
+      strongETag:strongETag projectID:projectID contextFingerprint:contextFingerprint
+      admissionOrdinal:0];
+  if (!release) return nil;
+  QONRemoteConfigV2Envelope *envelope = [QONRemoteConfigV2Envelope new];
+  envelope.projectID = projectID;
+  envelope.environmentUID = environmentUID;
+  envelope.contextFingerprint = contextFingerprint;
+  envelope.snapshotRelease = release;
+  envelope.eTag = strongETag;
+  envelope.bodyDigest = bodyDigest;
+  envelope.canonicalBody = body;
+  return envelope;
+}
+
+@end
+
 @implementation QONRemoteConfigV2Entry
 
 - (instancetype)initWithTombstoneKey:(NSString *)key {
@@ -95,16 +570,38 @@ static id QONRemoteConfigV2DeepJSONCopy(id value) {
                 variationUID:(NSString *)variationUID
                  applyPolicy:(QONRemoteConfigApplyPolicy)applyPolicy
                     metadata:(id)metadata {
+  id metadataCopy = QONRemoteConfigV2DeepJSONCopy(metadata);
+  if (metadata && !metadataCopy) return nil;
+  NSData *metadataData = metadataCopy ? [NSJSONSerialization dataWithJSONObject:metadataCopy
+      options:NSJSONWritingFragmentsAllowed error:nil] : nil;
+  return [self initWithKey:key rawData:rawData variationUID:variationUID
+      applyPolicy:applyPolicy metadataObject:metadataCopy metadataData:metadataData];
+}
+
+- (instancetype)initWithKey:(NSString *)key
+                     rawData:(NSData *)rawData
+                variationUID:(NSString *)variationUID
+                 applyPolicy:(QONRemoteConfigApplyPolicy)applyPolicy
+                metadataData:(NSData *)metadataData {
+  id metadataObject = QONRemoteConfigPortableJSONObject(metadataData,
+      QONRemoteConfigV2MaximumMetadataBytes);
+  if (!metadataObject) return nil;
+  return [self initWithKey:key rawData:rawData variationUID:variationUID
+      applyPolicy:applyPolicy metadataObject:metadataObject metadataData:metadataData];
+}
+
+- (instancetype)initWithKey:(NSString *)key
+                     rawData:(NSData *)rawData
+                variationUID:(NSString *)variationUID
+                 applyPolicy:(QONRemoteConfigApplyPolicy)applyPolicy
+              metadataObject:(id)metadataObject
+                metadataData:(NSData *)metadataData {
   if (!QONRemoteConfigV2ValidBoundedString(key, QONRemoteConfigV2MaximumKeyBytes) ||
       rawData.length == 0 || rawData.length > QONRemoteConfigV2MaximumRawValueBytes ||
       !QONRemoteConfigV2ValidUID(variationUID) ||
       (applyPolicy != QONRemoteConfigApplyPolicyOnNextActivate &&
        applyPolicy != QONRemoteConfigApplyPolicyImmediate)) return nil;
   if (!QONRemoteConfigPortableJSONObject(rawData, QONRemoteConfigV2MaximumRawValueBytes)) return nil;
-  id metadataCopy = QONRemoteConfigV2DeepJSONCopy(metadata);
-  if (metadata && !metadataCopy) return nil;
-  NSData *metadataData = metadataCopy ? [NSJSONSerialization dataWithJSONObject:metadataCopy
-      options:NSJSONWritingFragmentsAllowed error:nil] : nil;
   if (metadataData.length > QONRemoteConfigV2MaximumMetadataBytes) return nil;
   self = [super init];
   if (self) {
@@ -112,7 +609,8 @@ static id QONRemoteConfigV2DeepJSONCopy(id value) {
     _rawData = [rawData copy];
     _variationUID = [variationUID copy];
     _applyPolicy = applyPolicy;
-    _metadata = metadataCopy;
+    _metadata = metadataObject == NSNull.null ? nil : metadataObject;
+    _metadataData = [metadataData copy];
     _tombstone = NO;
   }
   return self;
@@ -126,7 +624,7 @@ static id QONRemoteConfigV2DeepJSONCopy(id value) {
       ((self.rawData == nil && other.rawData == nil) || [self.rawData isEqual:other.rawData]) &&
       ((self.variationUID == nil && other.variationUID == nil) || [self.variationUID isEqual:other.variationUID]) &&
       self.applyPolicy == other.applyPolicy &&
-      ((self.metadata == nil && other.metadata == nil) || [self.metadata isEqual:other.metadata]);
+      ((self.metadataData == nil && other.metadataData == nil) || [self.metadataData isEqual:other.metadataData]);
 }
 
 @end
@@ -137,11 +635,32 @@ static id QONRemoteConfigV2DeepJSONCopy(id value) {
                       releaseNumber:(NSInteger)releaseNumber
                 manifestContentHash:(NSString *)manifestContentHash
                             entries:(NSDictionary<NSString *,QONRemoteConfigV2Entry *> *)entries {
+  return [self initWithReleaseUID:releaseUID releaseNumber:releaseNumber
+      manifestContentHash:manifestContentHash entries:entries canonicalBody:nil
+      strongETag:nil projectID:0 contextFingerprint:nil admissionOrdinal:0];
+}
+
+- (instancetype)initWithReleaseUID:(NSString *)releaseUID
+                      releaseNumber:(NSInteger)releaseNumber
+                manifestContentHash:(NSString *)manifestContentHash
+                            entries:(NSDictionary<NSString *,QONRemoteConfigV2Entry *> *)entries
+                      canonicalBody:(NSData *)canonicalBody
+                          strongETag:(NSString *)strongETag
+                           projectID:(int64_t)projectID
+                  contextFingerprint:(NSString *)contextFingerprint
+                   admissionOrdinal:(int64_t)admissionOrdinal {
   if (!QONRemoteConfigV2ValidUID(releaseUID) || releaseNumber <= 0 ||
       releaseNumber > QONRemoteConfigV2MaximumSafeInteger ||
       !QONRemoteConfigV2ValidSHA256(manifestContentHash) || !entries ||
-      entries.count > QONRemoteConfigV2MaximumEntryCount) return nil;
+      admissionOrdinal < 0 ||
+      projectID < 0 || projectID > QONRemoteConfigV2MaximumSafeInteger ||
+      (contextFingerprint && !QONRemoteConfigV2ValidSHA256(contextFingerprint)) ||
+      ((canonicalBody == nil) != (strongETag == nil)) ||
+      ((canonicalBody == nil) != (projectID == 0)) ||
+      canonicalBody.length > QONRemoteConfigV2MaximumEnvelopeBytes) return nil;
+  if (canonicalBody && !QONRemoteConfigV2ValidStrongETag(strongETag, canonicalBody, NULL)) return nil;
   NSMutableDictionary *copy = [NSMutableDictionary dictionaryWithCapacity:entries.count];
+  NSUInteger valueCount = 0, tombstoneCount = 0;
   NSUInteger totalValueBytes = [releaseUID lengthOfBytesUsingEncoding:NSUTF8StringEncoding] +
       [manifestContentHash lengthOfBytesUsingEncoding:NSUTF8StringEncoding];
   if (totalValueBytes > QONRemoteConfigV2MaximumTotalValueBytes) return nil;
@@ -149,9 +668,10 @@ static id QONRemoteConfigV2DeepJSONCopy(id value) {
     QONRemoteConfigV2Entry *entry = entries[key];
     if (![key isKindOfClass:NSString.class] || ![entry isKindOfClass:QONRemoteConfigV2Entry.class] ||
         ![key isEqualToString:entry.key]) return nil;
-    id metadata = entry.metadata;
-    NSData *metadataData = metadata ? [NSJSONSerialization dataWithJSONObject:metadata
-        options:NSJSONWritingFragmentsAllowed error:nil] : nil;
+    if (entry.isTombstone) tombstoneCount += 1; else valueCount += 1;
+    if (valueCount > QONRemoteConfigV2MaximumEntryCount ||
+        tombstoneCount > QONRemoteConfigV2MaximumEntryCount) return nil;
+    NSData *metadataData = entry.metadataData;
     NSUInteger entryBytes = [entry.key lengthOfBytesUsingEncoding:NSUTF8StringEncoding] +
         [entry.variationUID lengthOfBytesUsingEncoding:NSUTF8StringEncoding] +
         entry.rawData.length + metadataData.length;
@@ -165,8 +685,21 @@ static id QONRemoteConfigV2DeepJSONCopy(id value) {
     _releaseNumber = releaseNumber;
     _manifestContentHash = [manifestContentHash copy];
     _entries = [copy copy];
+    _canonicalBody = [canonicalBody copy];
+    _strongETag = [strongETag copy];
+    _projectID = projectID;
+    _contextFingerprint = [contextFingerprint copy];
+    _admissionOrdinal = admissionOrdinal;
   }
   return self;
+}
+
+- (QONRemoteConfigV2Release *)releaseBySettingAdmissionOrdinal:(int64_t)admissionOrdinal {
+  return [[QONRemoteConfigV2Release alloc] initWithReleaseUID:self.releaseUID
+      releaseNumber:self.releaseNumber manifestContentHash:self.manifestContentHash
+      entries:self.entries canonicalBody:self.canonicalBody strongETag:self.strongETag
+      projectID:self.projectID contextFingerprint:self.contextFingerprint
+      admissionOrdinal:admissionOrdinal];
 }
 
 - (id)copyWithZone:(NSZone *)zone { return self; }
@@ -181,6 +714,8 @@ static id QONRemoteConfigV2DeepJSONCopy(id value) {
   if (!other || ![self.releaseUID isEqualToString:other.releaseUID] ||
       self.releaseNumber != other.releaseNumber ||
       ![self.manifestContentHash isEqualToString:other.manifestContentHash] ||
+      !((self.contextFingerprint == nil && other.contextFingerprint == nil) ||
+        [self.contextFingerprint isEqual:other.contextFingerprint]) ||
       self.entries.count != other.entries.count) return NO;
   for (NSString *key in self.entries) {
     if (![self.entries[key] contentEquals:other.entries[key]]) return NO;
@@ -196,17 +731,42 @@ static id QONRemoteConfigV2DeepJSONCopy(id value) {
                             active:(QONRemoteConfigV2Release *)active
                           previous:(QONRemoteConfigV2Release *)previous
                        didActivate:(BOOL)didActivate {
+  int64_t latest = MAX(candidate.admissionOrdinal,
+      MAX(active.admissionOrdinal, previous.admissionOrdinal));
+  return [self initWithCandidate:candidate active:active previous:previous
+      didActivate:didActivate latestAdmissionOrdinal:latest];
+}
+
+- (instancetype)initWithCandidate:(QONRemoteConfigV2Release *)candidate
+                            active:(QONRemoteConfigV2Release *)active
+                          previous:(QONRemoteConfigV2Release *)previous
+                       didActivate:(BOOL)didActivate
+            latestAdmissionOrdinal:(int64_t)latestAdmissionOrdinal {
+  int64_t highestSlotOrdinal = MAX(candidate.admissionOrdinal,
+      MAX(active.admissionOrdinal, previous.admissionOrdinal));
+  BOOL usesAdmissionOrdering = highestSlotOrdinal > 0;
   if ((!active && previous) || (!didActivate && (active || previous)) ||
-      (candidate && active && candidate.releaseNumber < active.releaseNumber) ||
-      (candidate && active && candidate.releaseNumber == active.releaseNumber &&
+      latestAdmissionOrdinal < 0 || latestAdmissionOrdinal < highestSlotOrdinal ||
+      (candidate && active && usesAdmissionOrdering &&
+       candidate.admissionOrdinal < active.admissionOrdinal) ||
+      (candidate && active && usesAdmissionOrdering &&
+       candidate.admissionOrdinal == active.admissionOrdinal &&
        ![candidate contentEquals:active]) ||
-      (previous && active && previous.releaseNumber >= active.releaseNumber)) return nil;
+      (previous && active && usesAdmissionOrdering &&
+       previous.admissionOrdinal >= active.admissionOrdinal) ||
+      (candidate && active && !usesAdmissionOrdering &&
+       candidate.releaseNumber < active.releaseNumber) ||
+      (candidate && active && !usesAdmissionOrdering &&
+       candidate.releaseNumber == active.releaseNumber && ![candidate contentEquals:active]) ||
+      (previous && active && !usesAdmissionOrdering &&
+       previous.releaseNumber >= active.releaseNumber)) return nil;
   self = [super init];
   if (self) {
     _candidate = candidate;
     _active = active;
     _previous = previous;
     _didActivate = didActivate;
+    _latestAdmissionOrdinal = latestAdmissionOrdinal;
   }
   return self;
 }


### PR DESCRIPTION
## Summary

Adds the internal/dark iOS strict wire and durable admission layer on top of #755. It does not add a public network endpoint or public fetch API.

- strict bounded schema-1 parser with exact canonical bytes and strong SHA-256 ETag
- project/environment/context expectation and manager/scope/generation/latest-request admission fencing
- complete-release atomic admission with missing-key tombstones
- durable schema-2 Candidate/Active/Previous state with exact scope binding
- immediate whole-release activation and main-executor update callbacks

## Fail-closed reliability

Independent adversarial reviews found and this PR fixes:

- committed callback loss and callback-under-lock deadlocks
- late scope/admission races and old-scope queued callbacks
- digest salvage blessing mutated entries or coordinated scope tampering
- scalar persisted slots crashing dynamic dispatch
- max valid three-slot history exceeding the archive cap
- locale-dependent JSON number validation

Any state digest mismatch now discards the affected record; canonical wire bytes cannot prove a local user/project-key scope. Callback scope semantics are explicit: `setScope` synchronously changes current generation, cancels not-yet-claimed old callbacks, and never waits for user code; an already claimed callback may finish. Default callbacks run on the serial main executor and no observer executes under SDK locks.

## Verification

- multiple independent adversarial review cycles; final verdict CLEAN
- production Objective-C source: `clang -fsyntax-only -fobjc-arc -Werror` green
- static analyzer green for Models/Manager/Store
- executable focused harness covered parser, persistence/restart, admission races, scope tamper, archive bounds, locale and callback fencing
- `git diff --check`

Full XCTest requires hosted Xcode; local host provides CommandLineTools only.

## Deliberate boundary

No public route, caller-supplied user ID, token/session or URL is introduced. Fetch policy remains a separate stacked increment after hosted CI.