### PR TITLE
feat: add resilient Remote Config fetch policy

### DIFF
--- a/Qonversion.xcodeproj/project.pbxproj
+++ b/Qonversion.xcodeproj/project.pbxproj
@@ -8,6 +8,11 @@
 
 /* Begin PBXBuildFile section */
 		00379E6044AEA7065E82A15F /* QONRemoteConfigV2ManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 296B5764F9B02F668DEBA22A /* QONRemoteConfigV2ManagerTests.m */; };
+		F00100000000000000000001 /* QONRemoteConfigV2FetchCoordinator.m in Sources */ = {isa = PBXBuildFile; fileRef = F00200000000000000000002 /* QONRemoteConfigV2FetchCoordinator.m */; };
+		F00100000000000000000002 /* QONRemoteConfigV2FetchCoordinator.h in Headers */ = {isa = PBXBuildFile; fileRef = F00200000000000000000001 /* QONRemoteConfigV2FetchCoordinator.h */; };
+		F00100000000000000000003 /* QONRemoteConfigV2FetchPolicyStore.m in Sources */ = {isa = PBXBuildFile; fileRef = F00200000000000000000004 /* QONRemoteConfigV2FetchPolicyStore.m */; };
+		F00100000000000000000004 /* QONRemoteConfigV2FetchPolicyStore.h in Headers */ = {isa = PBXBuildFile; fileRef = F00200000000000000000003 /* QONRemoteConfigV2FetchPolicyStore.h */; };
+		F00100000000000000000005 /* QONRemoteConfigV2FetchCoordinatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F00200000000000000000005 /* QONRemoteConfigV2FetchCoordinatorTests.m */; };
 		0260C539214A6A48356042F3 /* QONRemoteConfigSnapshot.m in Sources */ = {isa = PBXBuildFile; fileRef = E06E1B12300B7B060F723462 /* QONRemoteConfigSnapshot.m */; };
 		0721DD7665C511B906263E71 /* QONRemoteConfigV2Models.m in Sources */ = {isa = PBXBuildFile; fileRef = 663D27E868396EE04A7698D5 /* QONRemoteConfigV2Models.m */; };
 		0A17440D00C09DABC1E2B1D3 /* QONEntitlementsUpdateListenerAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B69D8BEFE710A9EF0697B28 /* QONEntitlementsUpdateListenerAdapter.m */; };
@@ -375,6 +380,11 @@
 
 /* Begin PBXFileReference section */
 		02B82604A89181D262616958 /* NoCodesContextBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NoCodesContextBuilder.swift; sourceTree = "<group>"; };
+		F00200000000000000000001 /* QONRemoteConfigV2FetchCoordinator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = QONRemoteConfigV2FetchCoordinator.h; sourceTree = "<group>"; };
+		F00200000000000000000002 /* QONRemoteConfigV2FetchCoordinator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = QONRemoteConfigV2FetchCoordinator.m; sourceTree = "<group>"; };
+		F00200000000000000000003 /* QONRemoteConfigV2FetchPolicyStore.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = QONRemoteConfigV2FetchPolicyStore.h; sourceTree = "<group>"; };
+		F00200000000000000000004 /* QONRemoteConfigV2FetchPolicyStore.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = QONRemoteConfigV2FetchPolicyStore.m; sourceTree = "<group>"; };
+		F00200000000000000000005 /* QONRemoteConfigV2FetchCoordinatorTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = QONRemoteConfigV2FetchCoordinatorTests.m; sourceTree = "<group>"; };
 		0B69D8BEFE710A9EF0697B28 /* QONEntitlementsUpdateListenerAdapter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = QONEntitlementsUpdateListenerAdapter.m; sourceTree = "<group>"; };
 		1037791CABEE4F1611A8561E /* Pods-Watch Sample Watch App.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Watch Sample Watch App.release.xcconfig"; path = "Target Support Files/Pods-Watch Sample Watch App/Pods-Watch Sample Watch App.release.xcconfig"; sourceTree = "<group>"; };
 		2865A58C95F0B475399053F2 /* ScreenEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenEvent.swift; sourceTree = "<group>"; };
@@ -798,6 +808,8 @@
 		3CFBF37E035D2E3A844EF7AC /* QONRemoteConfigV2Manager */ = {
 			isa = PBXGroup;
 			children = (
+				F00200000000000000000001 /* QONRemoteConfigV2FetchCoordinator.h */,
+				F00200000000000000000002 /* QONRemoteConfigV2FetchCoordinator.m */,
 				46B3E8F2B8C771F30BB01808 /* QONRemoteConfigV2Models.h */,
 				663D27E868396EE04A7698D5 /* QONRemoteConfigV2Models.m */,
 				A640027C629834C825BB849B /* QONRemoteConfigV2Manager.h */,
@@ -1021,6 +1033,8 @@
 		5EF70F7176C6CC56EE42B282 /* QONRemoteConfigV2Store */ = {
 			isa = PBXGroup;
 			children = (
+				F00200000000000000000003 /* QONRemoteConfigV2FetchPolicyStore.h */,
+				F00200000000000000000004 /* QONRemoteConfigV2FetchPolicyStore.m */,
 				4DDC15CD05353A25BDD0219B /* QONRemoteConfigV2Store.h */,
 				6B409D30498F93D8C79BBFD9 /* QONRemoteConfigV2Store.m */,
 			);
@@ -1864,6 +1878,7 @@
 		89673C2D26F49B6A008D209A /* Managers */ = {
 			isa = PBXGroup;
 			children = (
+				F00200000000000000000005 /* QONRemoteConfigV2FetchCoordinatorTests.m */,
 				89673C2E26F49BA9008D209A /* QNIdentityManagerTests.m */,
 				A1DEF1231000000000000002 /* QNUserPropertiesManagerTests.m */,
 				A1DEF1231000000000000004 /* QONRemoteConfigManagerInvalidationTests.m */,
@@ -2041,6 +2056,8 @@
 				2B1F005A892934909DD29314 /* QONRemoteConfigSnapshot.h in Headers */,
 				DFE1EF01074069227192E6F0 /* QONRemoteConfigUpdate.h in Headers */,
 				FC2C99538CFA4EE0D42F50D7 /* QONRemoteConfigSnapshot+Protected.h in Headers */,
+				F00100000000000000000002 /* QONRemoteConfigV2FetchCoordinator.h in Headers */,
+				F00100000000000000000004 /* QONRemoteConfigV2FetchPolicyStore.h in Headers */,
 				2BF67036E25BB95C1B40140F /* QONRemoteConfigV2Store.h in Headers */,
 				64F83E8CBC08EE7FE52D2716 /* QONRemoteConfigV2Models.h in Headers */,
 				376D4522095E99309960A672 /* QONRemoteConfigV2Manager.h in Headers */,
@@ -2544,6 +2561,8 @@
 				D72FC697AF6B3F5882CDFD6B /* QONRemoteConfigValue.m in Sources */,
 				0260C539214A6A48356042F3 /* QONRemoteConfigSnapshot.m in Sources */,
 				57DD1304CDDECA1B68CFA807 /* QONRemoteConfigUpdate.m in Sources */,
+				F00100000000000000000001 /* QONRemoteConfigV2FetchCoordinator.m in Sources */,
+				F00100000000000000000003 /* QONRemoteConfigV2FetchPolicyStore.m in Sources */,
 				2F6875D2E552C466B8E1C9A3 /* QONRemoteConfigV2Store.m in Sources */,
 				0721DD7665C511B906263E71 /* QONRemoteConfigV2Models.m in Sources */,
 				3A64B8327750874853ACD949 /* QONRemoteConfigV2Manager.m in Sources */,
@@ -2580,6 +2599,7 @@
 				15619C2C7D8402ED82C085BB /* QONRemoteConfigSnapshotTests.m in Sources */,
 				D9C671C7AD41EDCE9D4F0822 /* QONRemoteConfigV2StoreTests.m in Sources */,
 				00379E6044AEA7065E82A15F /* QONRemoteConfigV2ManagerTests.m in Sources */,
+				F00100000000000000000005 /* QONRemoteConfigV2FetchCoordinatorTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/QonversionTests/Managers/QONRemoteConfigV2FetchCoordinatorHarness.m
+++ b/QonversionTests/Managers/QONRemoteConfigV2FetchCoordinatorHarness.m
@@ -1,0 +1,673 @@
+#import <Foundation/Foundation.h>
+#import "QONRemoteConfigV2FetchCoordinator.h"
+#import "QONRemoteConfigV2FetchPolicyStore.h"
+#import "QNLocalStorage.h"
+
+// The harness links only the fetch-policy slice. The full SDK owns this parser helper.
+id QONRemoteConfigPortableJSONObject(__unused NSData *data, __unused NSUInteger maximumBytes) {
+  return @{};
+}
+
+static NSUInteger failures = 0;
+#define QON_CHECK(condition, message) do { if (!(condition)) { \
+  failures += 1; fprintf(stderr, "FAIL: %s\n", message); } } while (0)
+
+@interface HarnessTask : NSObject <QONRemoteConfigV2FetchScheduledTask>
+@property(nonatomic, copy) dispatch_block_t action;
+@property(nonatomic) BOOL cancelled;
+@end
+@implementation HarnessTask
+- (void)cancel { self.cancelled = YES; }
+@end
+
+@interface HarnessScheduler : NSObject <QONRemoteConfigV2FetchScheduler>
+@property(nonatomic, strong) NSMutableArray<HarnessTask *> *tasks;
+@property(nonatomic) BOOL throws;
+- (void)fire:(NSUInteger)index;
+@end
+@implementation HarnessScheduler
+- (instancetype)init { self = [super init]; if (self) _tasks = [NSMutableArray new]; return self; }
+- (id<QONRemoteConfigV2FetchScheduledTask>)scheduleAfterMilliseconds:(__unused int64_t)delay
+                                                              action:(dispatch_block_t)action {
+  if (self.throws) @throw [NSException exceptionWithName:@"scheduler" reason:nil userInfo:nil];
+  HarnessTask *task = [HarnessTask new]; task.action = action; [self.tasks addObject:task]; return task;
+}
+- (void)fire:(NSUInteger)index { HarnessTask *task = self.tasks[index]; if (!task.cancelled) task.action(); }
+@end
+
+@interface HarnessClock : NSObject <QONRemoteConfigV2FetchClock>
+@property(nonatomic) int64_t now;
+@end
+@implementation HarnessClock
+- (int64_t)nowMilliseconds { return self.now; }
+@end
+
+@interface HarnessRandom : NSObject <QONRemoteConfigV2FetchRandom>
+@property(nonatomic) double value;
+@end
+@implementation HarnessRandom
+- (double)nextUnitInterval { return self.value; }
+@end
+
+@interface HarnessStore : NSObject <QONRemoteConfigV2FetchPolicyStoring>
+@property(nonatomic, strong) NSMutableDictionary *states;
+@property(nonatomic) BOOL saveSucceeds;
+@property(nonatomic) BOOL throwsOnLoad;
+@property(nonatomic, strong) NSNumber *forcedLoadStatus;
+@end
+@implementation HarnessStore
+- (instancetype)init { self = [super init]; if (self) { _states = [NSMutableDictionary new]; _saveSucceeds = YES; } return self; }
+- (NSString *)key:(QONRemoteConfigV2FetchPolicyScope *)scope {
+  return [NSString stringWithFormat:@"%@/%@", scope.projectKey, scope.environment];
+}
+- (QONRemoteConfigV2FetchPolicyLoadResult *)loadResultForScope:(QONRemoteConfigV2FetchPolicyScope *)scope {
+  if (self.throwsOnLoad) @throw [NSException exceptionWithName:@"load" reason:nil userInfo:nil];
+  if (self.forcedLoadStatus) {
+    return [[QONRemoteConfigV2FetchPolicyLoadResult alloc]
+        initWithStatus:self.forcedLoadStatus.integerValue state:nil];
+  }
+  QONRemoteConfigV2FetchPolicyState *state = self.states[[self key:scope]];
+  return [[QONRemoteConfigV2FetchPolicyLoadResult alloc]
+      initWithStatus:state ? QONRemoteConfigV2FetchPolicyLoadStatusFound
+                         : QONRemoteConfigV2FetchPolicyLoadStatusMissing
+               state:state];
+}
+- (BOOL)saveState:(QONRemoteConfigV2FetchPolicyState *)state forScope:(QONRemoteConfigV2FetchPolicyScope *)scope {
+  if (!self.saveSucceeds) return NO; self.states[[self key:scope]] = state; return YES;
+}
+@end
+
+@interface HarnessLocalStorage : NSObject <QNLocalStorage>
+@property(nonatomic, strong) NSMutableDictionary *objects;
+@property(nonatomic) BOOL ignoreWrites;
+@property(nonatomic) BOOL throwsOnRead;
+@end
+@implementation HarnessLocalStorage
+- (instancetype)init { self = [super init]; if (self) _objects = [NSMutableDictionary new]; return self; }
+- (void)storeObject:(id)object forKey:(NSString *)key { if (!self.ignoreWrites) self.objects[key] = object; }
+- (id)loadObjectForKey:(NSString *)key {
+  if (self.throwsOnRead) @throw [NSException exceptionWithName:@"read" reason:nil userInfo:nil];
+  return self.objects[key];
+}
+- (void)loadObjectForKey:(NSString *)key withCompletion:(void (^)(id))completion { completion(self.objects[key]); }
+- (void)removeObjectForKey:(NSString *)key { [self.objects removeObjectForKey:key]; }
+@end
+
+@interface HarnessTransport : NSObject <QONRemoteConfigV2FetchTransport>
+@property(nonatomic, strong) NSMutableArray *requests;
+@property(nonatomic, strong) NSMutableArray *completions;
+@property(nonatomic) BOOL throws;
+- (void)complete:(NSUInteger)index response:(QONRemoteConfigV2FetchResponse *)response;
+@end
+@implementation HarnessTransport
+- (instancetype)init { self = [super init]; if (self) { _requests = [NSMutableArray new]; _completions = [NSMutableArray new]; } return self; }
+- (void)fetchRequest:(QONRemoteConfigV2FetchRequest *)request completion:(QONRemoteConfigV2FetchTransportCompletion)completion {
+  if (self.throws) @throw [NSException exceptionWithName:@"transport" reason:nil userInfo:nil];
+  [self.requests addObject:request]; [self.completions addObject:[completion copy]];
+}
+- (void)complete:(NSUInteger)index response:(QONRemoteConfigV2FetchResponse *)response {
+  QONRemoteConfigV2FetchTransportCompletion completion = self.completions[index]; completion(response);
+}
+@end
+
+@interface HarnessCore : NSObject <QONRemoteConfigV2FetchCore>
+@property(nonatomic, strong) QONRemoteConfigV2Scope *scope;
+@property(nonatomic, strong) QONRemoteConfigV2ConditionalRequestValidator *validator;
+@property(nonatomic, strong) QONRemoteConfigSnapshot *snapshot;
+@property(nonatomic) NSUInteger admissions;
+@property(nonatomic) NSUInteger admittedBodies;
+@property(nonatomic) QONRemoteConfigV2TransitionStatus transitionStatus;
+@end
+@implementation HarnessCore
+- (void)setScope:(QONRemoteConfigV2Scope *)scope { _scope = scope; }
+- (QONRemoteConfigSnapshot *)currentSnapshot { return self.snapshot; }
+- (QONRemoteConfigV2AdmissionToken *)beginAdmissionForScope:(__unused QONRemoteConfigV2Scope *)scope
+                                                expectation:(__unused QONRemoteConfigV2EnvelopeExpectation *)expectation {
+  self.admissions += 1; return (id)[NSObject new];
+}
+- (QONRemoteConfigV2TransitionStatus)admitBody:(__unused NSData *)body
+                                   strongETag:(__unused NSString *)strongETag
+                               admissionToken:(__unused QONRemoteConfigV2AdmissionToken *)admissionToken {
+  self.admittedBodies += 1; return self.transitionStatus;
+}
+- (QONRemoteConfigV2ConditionalRequestValidator *)conditionalRequestValidator { return self.validator; }
+- (BOOL)isConditionalRequestValidatorCurrent:(QONRemoteConfigV2ConditionalRequestValidator *)validator {
+  return [self.validator isEqual:validator];
+}
+@end
+
+static QONRemoteConfigV2FetchBinding *Binding(NSString *user) {
+  QONRemoteConfigV2Scope *scope = [[QONRemoteConfigV2Scope alloc]
+      initWithProjectKey:@"project" environment:@"production" canonicalUserID:user];
+  QONRemoteConfigV2EnvelopeExpectation *expectation = [[QONRemoteConfigV2EnvelopeExpectation alloc]
+      initWithProjectID:42 environmentUID:@"production"
+      contextFingerprint:[@"a" stringByPaddingToLength:64 withString:@"a" startingAtIndex:0]];
+  return [[QONRemoteConfigV2FetchBinding alloc] initWithScope:scope expectation:expectation];
+}
+
+static QONRemoteConfigV2FetchPolicy *Policy(int64_t minimum, NSNumber *timeout) {
+  return [[QONRemoteConfigV2FetchPolicy alloc]
+      initWithMinimumFetchIntervalMilliseconds:minimum timeoutMilliseconds:timeout
+      initialBackoffMilliseconds:1000 maximumBackoffMilliseconds:60000];
+}
+
+static QONRemoteConfigV2FetchCoordinator *Coordinator(HarnessCore *core, HarnessTransport *transport,
+    id<QONRemoteConfigV2FetchPolicyStoring> store, HarnessClock *clock, HarnessRandom *random,
+    HarnessScheduler *scheduler,
+    QONRemoteConfigV2FetchPolicy *policy, dispatch_queue_t callbacks,
+    QONRemoteConfigV2FetchPolicyPersistenceFailureObserver observer) {
+  return [[QONRemoteConfigV2FetchCoordinator alloc] initWithCore:core transport:transport
+      policyStore:store clock:clock random:random scheduler:scheduler policy:policy
+      callbackExecutor:callbacks policyPersistenceFailureObserver:observer];
+}
+
+static void Drain(dispatch_queue_t callbacks) { dispatch_sync(callbacks, ^{}); }
+
+static void TestCoalescingAndCallbackIsolation(void) {
+  HarnessCore *core = [HarnessCore new]; core.transitionStatus = QONRemoteConfigV2TransitionStatusAccepted;
+  HarnessTransport *transport = [HarnessTransport new]; HarnessStore *store = [HarnessStore new];
+  HarnessClock *clock = [HarnessClock new]; HarnessRandom *random = [HarnessRandom new];
+  HarnessScheduler *scheduler = [HarnessScheduler new];
+  dispatch_queue_t callbacks = dispatch_queue_create("fetch.harness.coalesce", DISPATCH_QUEUE_SERIAL);
+  QONRemoteConfigV2FetchCoordinator *coordinator = Coordinator(core, transport, store, clock,
+      random, scheduler, Policy(0, nil), callbacks, nil);
+  [coordinator transitionToBinding:Binding(@"a")];
+  __block NSUInteger delivered = 0;
+  [coordinator fetchWithForceReason:QONRemoteConfigV2FetchForceReasonNone completion:^(__unused id result) {
+    delivered += 1; @throw [NSException exceptionWithName:@"consumer" reason:nil userInfo:nil];
+  }];
+  [coordinator fetchWithForceReason:QONRemoteConfigV2FetchForceReasonBuild completion:^(__unused id result) {
+    delivered += 1;
+  }];
+  QON_CHECK(transport.requests.count == 1, "coalesced callers must share one HTTP request");
+  [transport complete:0 response:[QONRemoteConfigV2FetchResponse successWithBody:[NSData data]
+      strongETag:@"etag"]];
+  Drain(callbacks);
+  QON_CHECK(delivered == 2, "throwing callback must not starve the next waiter");
+  QON_CHECK(core.admissions == 1 && core.admittedBodies == 1, "coalesced operation admits once");
+}
+
+static void TestBackoffScopeAndForce(void) {
+  HarnessCore *core = [HarnessCore new]; HarnessTransport *transport = [HarnessTransport new];
+  HarnessStore *store = [HarnessStore new]; HarnessClock *clock = [HarnessClock new]; clock.now = 1000;
+  HarnessRandom *random = [HarnessRandom new]; random.value = 0.25; HarnessScheduler *scheduler = [HarnessScheduler new];
+  dispatch_queue_t callbacks = dispatch_queue_create("fetch.harness.backoff", DISPATCH_QUEUE_SERIAL);
+  QONRemoteConfigV2FetchCoordinator *coordinator = Coordinator(core, transport, store, clock,
+      random, scheduler, Policy(0, nil), callbacks, nil);
+  [coordinator transitionToBinding:Binding(@"a")];
+  __block QONRemoteConfigV2FetchResult *failure = nil;
+  [coordinator fetchWithForceReason:QONRemoteConfigV2FetchForceReasonNone completion:^(id result) { failure = result; }];
+  [transport complete:0 response:[QONRemoteConfigV2FetchResponse failureWithStatusCode:@503
+      retryAfterMilliseconds:@5000]];
+  Drain(callbacks);
+  QONRemoteConfigV2FetchPolicyState *saved = store.states[@"project/production"];
+  QON_CHECK(failure.kind == QONRemoteConfigV2FetchResultKindFailed, "retryable HTTP completes the waiter");
+  QON_CHECK(saved.nextAllowedFetchAtMilliseconds == 6000, "Retry-After must override jitter");
+  [coordinator transitionToBinding:Binding(@"b")];
+  __block QONRemoteConfigV2FetchResult *gated = nil;
+  [coordinator fetchWithForceReason:QONRemoteConfigV2FetchForceReasonIdentify completion:^(id result) { gated = result; }];
+  Drain(callbacks);
+  QON_CHECK(gated.kind == QONRemoteConfigV2FetchResultKindBackoff,
+      "identity and lifecycle force must not bypass project-environment backoff");
+  QON_CHECK(transport.requests.count == 1, "backoff must suppress transport");
+}
+
+static void TestMinimumIntervalForceOnly(void) {
+  HarnessCore *core = [HarnessCore new]; HarnessTransport *transport = [HarnessTransport new];
+  HarnessStore *store = [HarnessStore new]; HarnessClock *clock = [HarnessClock new]; clock.now = 1500;
+  HarnessRandom *random = [HarnessRandom new]; HarnessScheduler *scheduler = [HarnessScheduler new];
+  store.states[@"project/production"] = [[QONRemoteConfigV2FetchPolicyState alloc]
+      initWithLastSuccessfulFetchAtMilliseconds:1000 consecutiveRetryableFailures:0
+      nextAllowedFetchAtMilliseconds:0];
+  dispatch_queue_t callbacks = dispatch_queue_create("fetch.harness.minimum", DISPATCH_QUEUE_SERIAL);
+  QONRemoteConfigV2FetchCoordinator *coordinator = Coordinator(core, transport, store, clock,
+      random, scheduler, Policy(1000, nil), callbacks, nil);
+  [coordinator transitionToBinding:Binding(@"a")];
+  __block QONRemoteConfigV2FetchResult *gated = nil;
+  [coordinator fetchWithForceReason:QONRemoteConfigV2FetchForceReasonNone completion:^(id result) { gated = result; }];
+  Drain(callbacks);
+  QON_CHECK(gated.kind == QONRemoteConfigV2FetchResultKindMinimumInterval,
+      "ordinary fetch must honor minimum interval");
+  [coordinator fetchWithForceReason:QONRemoteConfigV2FetchForceReasonBuild completion:^(__unused id result) {}];
+  QON_CHECK(transport.requests.count == 1, "lifecycle force may bypass only minimum interval");
+}
+
+static void TestTimeoutAndZombieFence(void) {
+  HarnessCore *core = [HarnessCore new]; core.transitionStatus = QONRemoteConfigV2TransitionStatusAccepted;
+  core.snapshot = (id)[NSObject new];
+  HarnessTransport *transport = [HarnessTransport new]; HarnessStore *store = [HarnessStore new];
+  HarnessClock *clock = [HarnessClock new]; HarnessRandom *random = [HarnessRandom new];
+  HarnessScheduler *scheduler = [HarnessScheduler new];
+  dispatch_queue_t callbacks = dispatch_queue_create("fetch.harness.timeout", DISPATCH_QUEUE_SERIAL);
+  QONRemoteConfigV2FetchCoordinator *coordinator = Coordinator(core, transport, store, clock,
+      random, scheduler, Policy(0, @100), callbacks, nil);
+  [coordinator transitionToBinding:Binding(@"a")];
+  __block NSMutableArray *results = [NSMutableArray new];
+  [coordinator fetchWithForceReason:QONRemoteConfigV2FetchForceReasonNone completion:^(id result) { [results addObject:result]; }];
+  [scheduler fire:0]; Drain(callbacks);
+  QONRemoteConfigV2FetchResult *timeout = results.firstObject;
+  QON_CHECK(timeout.kind == QONRemoteConfigV2FetchResultKindTimedOut && timeout.snapshot == core.snapshot,
+      "timeout must return best current Active-to-bundle snapshot");
+  [coordinator fetchWithForceReason:QONRemoteConfigV2FetchForceReasonNone completion:^(id result) { [results addObject:result]; }];
+  QON_CHECK(transport.requests.count == 2 && core.admissions == 2,
+      "new fetch after all waiters timeout must supersede zombie without cancelling HTTP");
+  [transport complete:0 response:[QONRemoteConfigV2FetchResponse successWithBody:[NSData data]
+      strongETag:@"old"]];
+  [transport complete:1 response:[QONRemoteConfigV2FetchResponse successWithBody:[NSData data]
+      strongETag:@"new"]];
+  Drain(callbacks);
+  QON_CHECK(results.count == 2 && core.admittedBodies == 1,
+      "late zombie response must be fenced while new response persists Candidate");
+}
+
+static void TestConditional304Retry(void) {
+  HarnessCore *core = [HarnessCore new];
+  core.validator = [[QONRemoteConfigV2ConditionalRequestValidator alloc]
+      initWithStrongETag:@"\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\""
+      bodyDigest:[@"a" stringByPaddingToLength:64 withString:@"a" startingAtIndex:0]
+      headAdmissionOrdinal:1];
+  HarnessTransport *transport = [HarnessTransport new]; HarnessStore *store = [HarnessStore new];
+  HarnessClock *clock = [HarnessClock new]; HarnessRandom *random = [HarnessRandom new];
+  HarnessScheduler *scheduler = [HarnessScheduler new];
+  dispatch_queue_t callbacks = dispatch_queue_create("fetch.harness.etag", DISPATCH_QUEUE_SERIAL);
+  QONRemoteConfigV2FetchCoordinator *coordinator = Coordinator(core, transport, store, clock,
+      random, scheduler, Policy(0, nil), callbacks, nil);
+  [coordinator transitionToBinding:Binding(@"a")];
+  __block QONRemoteConfigV2FetchResult *result = nil;
+  [coordinator fetchWithForceReason:QONRemoteConfigV2FetchForceReasonNone completion:^(id value) { result = value; }];
+  QON_CHECK([transport.requests[0] ifNoneMatch] != nil, "exact current head must send its ETag");
+  core.validator = nil;
+  [transport complete:0 response:[QONRemoteConfigV2FetchResponse notModifiedWithStrongETag:nil]];
+  QON_CHECK(transport.requests.count == 2 && [transport.requests[1] ifNoneMatch] == nil,
+      "stale 304 must retry once without ETag");
+  [transport complete:1 response:[QONRemoteConfigV2FetchResponse notModifiedWithStrongETag:nil]];
+  Drain(callbacks);
+  QON_CHECK(result.kind == QONRemoteConfigV2FetchResultKindInvalidNotModified && transport.requests.count == 2,
+      "second invalid 304 must terminate without a retry loop");
+}
+
+static void TestMatching304IsAccepted(void) {
+  HarnessCore *core = [HarnessCore new];
+  core.validator = [[QONRemoteConfigV2ConditionalRequestValidator alloc]
+      initWithStrongETag:@"\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\""
+      bodyDigest:[@"a" stringByPaddingToLength:64 withString:@"a" startingAtIndex:0]
+      headAdmissionOrdinal:1];
+  HarnessTransport *transport = [HarnessTransport new]; HarnessStore *store = [HarnessStore new];
+  HarnessClock *clock = [HarnessClock new]; clock.now = 777;
+  HarnessRandom *random = [HarnessRandom new]; HarnessScheduler *scheduler = [HarnessScheduler new];
+  dispatch_queue_t callbacks = dispatch_queue_create("fetch.harness.etag.match", DISPATCH_QUEUE_SERIAL);
+  QONRemoteConfigV2FetchCoordinator *coordinator = Coordinator(core, transport, store, clock,
+      random, scheduler, Policy(0, nil), callbacks, nil);
+  [coordinator transitionToBinding:Binding(@"a")];
+  __block QONRemoteConfigV2FetchResult *result = nil;
+  [coordinator fetchWithForceReason:QONRemoteConfigV2FetchForceReasonNone
+      completion:^(id value) { result = value; }];
+  NSString *etag = core.validator.strongETag;
+  [transport complete:0 response:[QONRemoteConfigV2FetchResponse notModifiedWithStrongETag:etag]];
+  Drain(callbacks);
+  QONRemoteConfigV2FetchPolicyState *saved = store.states[@"project/production"];
+  QON_CHECK(result.kind == QONRemoteConfigV2FetchResultKindNotModified && transport.requests.count == 1,
+      "304 may be accepted only for the exact current canonical head validator");
+  QON_CHECK(saved.lastSuccessfulFetchAtMilliseconds == 777,
+      "accepted 304 must refresh the successful-fetch policy timestamp");
+}
+
+static void TestCappedExponentialFullJitter(void) {
+  HarnessCore *core = [HarnessCore new]; HarnessTransport *transport = [HarnessTransport new];
+  HarnessStore *store = [HarnessStore new]; HarnessClock *clock = [HarnessClock new]; clock.now = 100;
+  HarnessRandom *random = [HarnessRandom new]; random.value = 0.25;
+  HarnessScheduler *scheduler = [HarnessScheduler new];
+  dispatch_queue_t callbacks = dispatch_queue_create("fetch.harness.jitter", DISPATCH_QUEUE_SERIAL);
+  QONRemoteConfigV2FetchPolicy *policy = [[QONRemoteConfigV2FetchPolicy alloc]
+      initWithMinimumFetchIntervalMilliseconds:0 timeoutMilliseconds:nil
+      initialBackoffMilliseconds:1000 maximumBackoffMilliseconds:4000];
+  QONRemoteConfigV2FetchCoordinator *coordinator = Coordinator(core, transport, store, clock,
+      random, scheduler, policy, callbacks, nil);
+  [coordinator transitionToBinding:Binding(@"a")];
+  int64_t expectedDeadlines[] = {350, 850, 1850, 2850};
+  for (NSUInteger index = 0; index < 4; index++) {
+    [coordinator fetchWithForceReason:QONRemoteConfigV2FetchForceReasonNone
+        completion:^(__unused id value) {}];
+    [transport complete:index response:[QONRemoteConfigV2FetchResponse
+        failureWithStatusCode:@503 retryAfterMilliseconds:nil]];
+    Drain(callbacks);
+    QONRemoteConfigV2FetchPolicyState *saved = store.states[@"project/production"];
+    QON_CHECK(saved.consecutiveRetryableFailures == (NSInteger)index + 1,
+        "retryable failures must increment the durable counter");
+    QON_CHECK(saved.nextAllowedFetchAtMilliseconds == expectedDeadlines[index],
+        "backoff must use capped exponential full jitter");
+    clock.now = expectedDeadlines[index];
+  }
+}
+
+static void TestTransportAndSchedulerExceptionsCannotHangWaiters(void) {
+  HarnessCore *core = [HarnessCore new]; core.transitionStatus = QONRemoteConfigV2TransitionStatusAccepted;
+  HarnessTransport *transport = [HarnessTransport new]; transport.throws = YES;
+  HarnessStore *store = [HarnessStore new]; HarnessClock *clock = [HarnessClock new];
+  HarnessRandom *random = [HarnessRandom new]; HarnessScheduler *scheduler = [HarnessScheduler new];
+  dispatch_queue_t callbacks = dispatch_queue_create("fetch.harness.exceptions", DISPATCH_QUEUE_SERIAL);
+  QONRemoteConfigV2FetchCoordinator *coordinator = Coordinator(core, transport, store, clock,
+      random, scheduler, Policy(0, @100), callbacks, nil);
+  [coordinator transitionToBinding:Binding(@"a")];
+  __block QONRemoteConfigV2FetchResult *transportResult = nil;
+  [coordinator fetchWithForceReason:QONRemoteConfigV2FetchForceReasonNone
+      completion:^(id value) { transportResult = value; }];
+  Drain(callbacks);
+  QON_CHECK(transportResult.kind == QONRemoteConfigV2FetchResultKindFailed,
+      "transport exception must terminate every waiter exactly once");
+
+  HarnessCore *secondCore = [HarnessCore new]; secondCore.transitionStatus = QONRemoteConfigV2TransitionStatusAccepted;
+  HarnessTransport *secondTransport = [HarnessTransport new];
+  HarnessScheduler *throwingScheduler = [HarnessScheduler new]; throwingScheduler.throws = YES;
+  QONRemoteConfigV2FetchCoordinator *secondCoordinator = Coordinator(secondCore, secondTransport,
+      [HarnessStore new], clock, random, throwingScheduler, Policy(0, @100), callbacks, nil);
+  [secondCoordinator transitionToBinding:Binding(@"a")];
+  __block QONRemoteConfigV2FetchResult *schedulerResult = nil;
+  [secondCoordinator fetchWithForceReason:QONRemoteConfigV2FetchForceReasonNone
+      completion:^(id value) { schedulerResult = value; }];
+  [secondTransport complete:0 response:[QONRemoteConfigV2FetchResponse successWithBody:[NSData data]
+      strongETag:@"etag"]];
+  Drain(callbacks);
+  QON_CHECK(schedulerResult.kind == QONRemoteConfigV2FetchResultKindFetched,
+      "scheduler exception must not block transport completion");
+}
+
+static void TestNilStatusAndTransportExceptionPersistBackoffAcrossRestart(void) {
+  HarnessStore *store = [HarnessStore new]; HarnessClock *clock = [HarnessClock new]; clock.now = 1000;
+  HarnessRandom *random = [HarnessRandom new]; random.value = 0.5;
+  HarnessScheduler *scheduler = [HarnessScheduler new];
+  dispatch_queue_t callbacks = dispatch_queue_create("fetch.harness.network-backoff", DISPATCH_QUEUE_SERIAL);
+  HarnessCore *core = [HarnessCore new]; HarnessTransport *transport = [HarnessTransport new];
+  QONRemoteConfigV2FetchCoordinator *coordinator = Coordinator(core, transport, store, clock,
+      random, scheduler, Policy(0, nil), callbacks, nil);
+  [coordinator transitionToBinding:Binding(@"a")];
+  [coordinator fetchWithForceReason:QONRemoteConfigV2FetchForceReasonNone
+      completion:^(__unused id value) {}];
+  [transport complete:0 response:[QONRemoteConfigV2FetchResponse
+      failureWithStatusCode:nil retryAfterMilliseconds:nil]];
+  Drain(callbacks);
+  QONRemoteConfigV2FetchPolicyState *afterNilStatus = store.states[@"project/production"];
+  QON_CHECK(afterNilStatus.consecutiveRetryableFailures == 1 &&
+      afterNilStatus.nextAllowedFetchAtMilliseconds == 1500,
+      "nil-status network failure must persist full-jitter backoff");
+
+  HarnessCore *restartCore = [HarnessCore new]; HarnessTransport *restartTransport = [HarnessTransport new];
+  QONRemoteConfigV2FetchCoordinator *restart = Coordinator(restartCore, restartTransport, store, clock,
+      random, [HarnessScheduler new], Policy(0, nil), callbacks, nil);
+  [restart transitionToBinding:Binding(@"b")];
+  __block QONRemoteConfigV2FetchResult *restartResult = nil;
+  [restart fetchWithForceReason:QONRemoteConfigV2FetchForceReasonBuild
+      completion:^(id value) { restartResult = value; }];
+  Drain(callbacks);
+  QON_CHECK(restartResult.kind == QONRemoteConfigV2FetchResultKindBackoff &&
+      restartTransport.requests.count == 0,
+      "persisted nil-status backoff must survive restart and lifecycle force");
+
+  clock.now = afterNilStatus.nextAllowedFetchAtMilliseconds;
+  HarnessTransport *throwingTransport = [HarnessTransport new]; throwingTransport.throws = YES;
+  QONRemoteConfigV2FetchCoordinator *afterDeadline = Coordinator([HarnessCore new], throwingTransport,
+      store, clock, random, [HarnessScheduler new], Policy(0, nil), callbacks, nil);
+  [afterDeadline transitionToBinding:Binding(@"c")];
+  [afterDeadline fetchWithForceReason:QONRemoteConfigV2FetchForceReasonNone
+      completion:^(__unused id value) {}];
+  Drain(callbacks);
+  QONRemoteConfigV2FetchPolicyState *afterException = store.states[@"project/production"];
+  QON_CHECK(afterException.consecutiveRetryableFailures == 2 &&
+      afterException.nextAllowedFetchAtMilliseconds == 2500,
+      "transport exception must persist the next capped exponential backoff deadline");
+}
+
+static void TestPersistenceFailureIsObservableAndConservative(void) {
+  HarnessCore *core = [HarnessCore new]; HarnessTransport *transport = [HarnessTransport new];
+  HarnessStore *store = [HarnessStore new]; store.saveSucceeds = NO;
+  HarnessClock *clock = [HarnessClock new]; clock.now = 1000; HarnessRandom *random = [HarnessRandom new];
+  random.value = 0.5; HarnessScheduler *scheduler = [HarnessScheduler new];
+  dispatch_queue_t callbacks = dispatch_queue_create("fetch.harness.persistence", DISPATCH_QUEUE_SERIAL);
+  __block NSUInteger observedFailures = 0;
+  QONRemoteConfigV2FetchCoordinator *coordinator = Coordinator(core, transport, store, clock,
+      random, scheduler, Policy(0, nil), callbacks,
+      ^(__unused QONRemoteConfigV2FetchPolicyScope *scope,
+        __unused QONRemoteConfigV2FetchPolicyFailureReason reason) { observedFailures += 1; });
+  [coordinator transitionToBinding:Binding(@"a")];
+  __block QONRemoteConfigV2FetchResult *first = nil;
+  [coordinator fetchWithForceReason:QONRemoteConfigV2FetchForceReasonNone completion:^(id result) { first = result; }];
+  [transport complete:0 response:[QONRemoteConfigV2FetchResponse failureWithStatusCode:@503
+      retryAfterMilliseconds:@5000]];
+  Drain(callbacks);
+  QON_CHECK(first.kind == QONRemoteConfigV2FetchResultKindPolicyPersistenceFailed && observedFailures == 1,
+      "policy save failure must be explicit and observable");
+  __block QONRemoteConfigV2FetchResult *second = nil;
+  [coordinator fetchWithForceReason:QONRemoteConfigV2FetchForceReasonLogout completion:^(id result) { second = result; }];
+  Drain(callbacks);
+  QON_CHECK(second.kind == QONRemoteConfigV2FetchResultKindBackoff && transport.requests.count == 1,
+      "failed durable save must retain conservative backoff in-process");
+}
+
+static void TestTransitionClaimsOldWaitersOnce(void) {
+  HarnessCore *core = [HarnessCore new]; HarnessTransport *transport = [HarnessTransport new];
+  HarnessStore *store = [HarnessStore new]; HarnessClock *clock = [HarnessClock new];
+  HarnessRandom *random = [HarnessRandom new]; HarnessScheduler *scheduler = [HarnessScheduler new];
+  dispatch_queue_t callbacks = dispatch_queue_create("fetch.harness.scope", DISPATCH_QUEUE_SERIAL);
+  QONRemoteConfigV2FetchCoordinator *coordinator = Coordinator(core, transport, store, clock,
+      random, scheduler, Policy(0, nil), callbacks, nil);
+  [coordinator transitionToBinding:Binding(@"a")];
+  __block NSMutableArray *results = [NSMutableArray new];
+  [coordinator fetchWithForceReason:QONRemoteConfigV2FetchForceReasonNone completion:^(id result) { [results addObject:result]; }];
+  [coordinator transitionToBinding:Binding(@"b")]; Drain(callbacks);
+  [transport complete:0 response:[QONRemoteConfigV2FetchResponse successWithBody:[NSData data]
+      strongETag:@"late"]];
+  Drain(callbacks);
+  QONRemoteConfigV2FetchResult *result = results.firstObject;
+  QON_CHECK(results.count == 1 && result.kind == QONRemoteConfigV2FetchResultKindSuperseded,
+      "identity transition must complete old waiter once and fence late response");
+}
+
+static void TestPersistentPolicyStoreScopeAndReadback(void) {
+  HarnessLocalStorage *storage = [HarnessLocalStorage new];
+  QONRemoteConfigV2FetchPolicyStore *store = [[QONRemoteConfigV2FetchPolicyStore alloc]
+      initWithLocalStorage:storage];
+  QONRemoteConfigV2FetchPolicyScope *production = [[QONRemoteConfigV2FetchPolicyScope alloc]
+      initWithProjectKey:@"project" environment:@"production"];
+  QONRemoteConfigV2FetchPolicyScope *sandbox = [[QONRemoteConfigV2FetchPolicyScope alloc]
+      initWithProjectKey:@"project" environment:@"sandbox"];
+  QONRemoteConfigV2FetchPolicyState *state = [[QONRemoteConfigV2FetchPolicyState alloc]
+      initWithLastSuccessfulFetchAtMilliseconds:100 consecutiveRetryableFailures:3
+      nextAllowedFetchAtMilliseconds:900];
+  QON_CHECK([store saveState:state forScope:production], "policy state must persist durably");
+  QONRemoteConfigV2FetchPolicyLoadResult *loadedResult = [[[QONRemoteConfigV2FetchPolicyStore alloc]
+      initWithLocalStorage:storage] loadResultForScope:production];
+  QONRemoteConfigV2FetchPolicyState *loaded = loadedResult.state;
+  QON_CHECK(loadedResult.status == QONRemoteConfigV2FetchPolicyLoadStatusFound,
+      "valid durable policy state must be distinguished as Found");
+  QON_CHECK(loaded.consecutiveRetryableFailures == 3 && loaded.nextAllowedFetchAtMilliseconds == 900,
+      "policy state must survive restart");
+  QON_CHECK([store loadResultForScope:sandbox].status == QONRemoteConfigV2FetchPolicyLoadStatusMissing,
+      "policy state key must bind exact project and environment");
+  NSString *storageKey = storage.objects.allKeys.firstObject;
+  QON_CHECK(storageKey.length > 0 && [storageKey rangeOfString:@"project"].location == NSNotFound,
+      "durable key must be a bounded digest, not raw scope data");
+  storage.ignoreWrites = YES;
+  QONRemoteConfigV2FetchPolicyState *replacement = [[QONRemoteConfigV2FetchPolicyState alloc]
+      initWithLastSuccessfulFetchAtMilliseconds:200 consecutiveRetryableFailures:4
+      nextAllowedFetchAtMilliseconds:1000];
+  QON_CHECK(![store saveState:replacement forScope:production],
+      "silent storage write loss must fail exact read-back verification");
+  QON_CHECK([store loadResultForScope:production].state.nextAllowedFetchAtMilliseconds == 900,
+      "failed write must preserve prior durable policy state");
+}
+
+static void TestPersistentPolicyStoreDistinguishesMissingFailedAndCorrupt(void) {
+  HarnessLocalStorage *storage = [HarnessLocalStorage new];
+  QONRemoteConfigV2FetchPolicyScope *scope = [[QONRemoteConfigV2FetchPolicyScope alloc]
+      initWithProjectKey:@"project" environment:@"production"];
+  QONRemoteConfigV2FetchPolicyStore *store = [[QONRemoteConfigV2FetchPolicyStore alloc]
+      initWithLocalStorage:storage];
+  QON_CHECK([store loadResultForScope:scope].status == QONRemoteConfigV2FetchPolicyLoadStatusMissing,
+      "absent durable policy must be distinguished as Missing");
+  QONRemoteConfigV2FetchPolicyState *state = [[QONRemoteConfigV2FetchPolicyState alloc]
+      initWithLastSuccessfulFetchAtMilliseconds:100 consecutiveRetryableFailures:2
+      nextAllowedFetchAtMilliseconds:900];
+  QON_CHECK([store saveState:state forScope:scope], "valid policy must persist before corruption test");
+  NSString *key = storage.objects.allKeys.firstObject;
+  NSDictionary *valid = storage.objects[key];
+
+  NSMutableDictionary *badShape = [valid mutableCopy];
+  [badShape removeObjectForKey:@"next_allowed_fetch_at_ms"];
+  storage.objects[key] = badShape;
+  QONRemoteConfigV2FetchPolicyLoadResult *shapeResult = [[[QONRemoteConfigV2FetchPolicyStore alloc]
+      initWithLocalStorage:storage] loadResultForScope:scope];
+  QON_CHECK(shapeResult.status == QONRemoteConfigV2FetchPolicyLoadStatusCorrupt &&
+      [storage.objects[key] isEqual:badShape],
+      "shape corruption must remain quarantined and observable, not deleted as Missing");
+
+  NSMutableDictionary *badDigest = [valid mutableCopy];
+  badDigest[@"integrity_digest"] = [@"b" stringByPaddingToLength:64 withString:@"b" startingAtIndex:0];
+  storage.objects[key] = badDigest;
+  QONRemoteConfigV2FetchPolicyLoadResult *digestResult = [[[QONRemoteConfigV2FetchPolicyStore alloc]
+      initWithLocalStorage:storage] loadResultForScope:scope];
+  QON_CHECK(digestResult.status == QONRemoteConfigV2FetchPolicyLoadStatusCorrupt &&
+      [storage.objects[key] isEqual:badDigest],
+      "integrity mismatch must be Corrupt and must not be silently removed");
+
+  storage.throwsOnRead = YES;
+  QONRemoteConfigV2FetchPolicyLoadResult *failed = [[[QONRemoteConfigV2FetchPolicyStore alloc]
+      initWithLocalStorage:storage] loadResultForScope:scope];
+  QON_CHECK(failed.status == QONRemoteConfigV2FetchPolicyLoadStatusFailed,
+      "storage read exception must be distinguished as Failed");
+}
+
+static void TestPolicyLoadFailureFailsClosedBeforeNetwork(void) {
+  HarnessCore *core = [HarnessCore new]; HarnessTransport *transport = [HarnessTransport new];
+  HarnessStore *store = [HarnessStore new]; store.throwsOnLoad = YES;
+  HarnessClock *clock = [HarnessClock new]; clock.now = 1000;
+  HarnessRandom *random = [HarnessRandom new]; HarnessScheduler *scheduler = [HarnessScheduler new];
+  dispatch_queue_t callbacks = dispatch_queue_create("fetch.harness.load-failure", DISPATCH_QUEUE_SERIAL);
+  __block NSUInteger observations = 0;
+  __block QONRemoteConfigV2FetchPolicyFailureReason observedReason =
+      QONRemoteConfigV2FetchPolicyFailureReasonSave;
+  QONRemoteConfigV2FetchCoordinator *coordinator = Coordinator(core, transport, store, clock,
+      random, scheduler, Policy(0, nil), callbacks,
+      ^(__unused QONRemoteConfigV2FetchPolicyScope *scope,
+        QONRemoteConfigV2FetchPolicyFailureReason reason) {
+    observations += 1;
+    observedReason = reason;
+  });
+  [coordinator transitionToBinding:Binding(@"a")];
+  __block QONRemoteConfigV2FetchResult *first = nil;
+  [coordinator fetchWithForceReason:QONRemoteConfigV2FetchForceReasonBuild
+      completion:^(id value) { first = value; }];
+  Drain(callbacks);
+  QON_CHECK(first.kind == QONRemoteConfigV2FetchResultKindPolicyPersistenceFailed &&
+      first.policyFailureReason == QONRemoteConfigV2FetchPolicyFailureReasonLoadFailed &&
+      first.nextAllowedAtMilliseconds == 2000,
+      "load exception must emit an explicit bounded failure result before network");
+  QON_CHECK(observations == 1 && observedReason == QONRemoteConfigV2FetchPolicyFailureReasonLoadFailed &&
+      transport.requests.count == 0,
+      "load exception telemetry must be bounded and network must fail closed");
+
+  __block QONRemoteConfigV2FetchResult *second = nil;
+  [coordinator fetchWithForceReason:QONRemoteConfigV2FetchForceReasonLogout
+      completion:^(id value) { second = value; }];
+  Drain(callbacks);
+  QON_CHECK(second.kind == QONRemoteConfigV2FetchResultKindBackoff && observations == 1 &&
+      transport.requests.count == 0,
+      "subsequent callers must observe conservative in-process backoff without telemetry spam");
+
+  HarnessTransport *restartTransport = [HarnessTransport new];
+  QONRemoteConfigV2FetchCoordinator *restart = Coordinator([HarnessCore new], restartTransport, store,
+      clock, random, [HarnessScheduler new], Policy(0, nil), callbacks, nil);
+  [restart transitionToBinding:Binding(@"b")];
+  __block QONRemoteConfigV2FetchResult *restartResult = nil;
+  [restart fetchWithForceReason:QONRemoteConfigV2FetchForceReasonIdentify
+      completion:^(id value) { restartResult = value; }];
+  Drain(callbacks);
+  QON_CHECK(restartResult.kind == QONRemoteConfigV2FetchResultKindPolicyPersistenceFailed &&
+      restartTransport.requests.count == 0,
+      "read failure must fail closed again after coordinator restart");
+}
+
+static void TestCorruptPolicyFailsClosedWithoutSilentDeletion(void) {
+  HarnessLocalStorage *storage = [HarnessLocalStorage new];
+  QONRemoteConfigV2FetchPolicyStore *store = [[QONRemoteConfigV2FetchPolicyStore alloc]
+      initWithLocalStorage:storage];
+  QONRemoteConfigV2FetchPolicyScope *scope = [[QONRemoteConfigV2FetchPolicyScope alloc]
+      initWithProjectKey:@"project" environment:@"production"];
+  QONRemoteConfigV2FetchPolicyState *state = [[QONRemoteConfigV2FetchPolicyState alloc]
+      initWithLastSuccessfulFetchAtMilliseconds:100 consecutiveRetryableFailures:1
+      nextAllowedFetchAtMilliseconds:900];
+  QON_CHECK([store saveState:state forScope:scope], "valid policy must persist before fail-closed test");
+  NSString *key = storage.objects.allKeys.firstObject;
+  NSMutableDictionary *corrupt = [storage.objects[key] mutableCopy];
+  corrupt[@"integrity_digest"] = [@"c" stringByPaddingToLength:64 withString:@"c" startingAtIndex:0];
+  storage.objects[key] = corrupt;
+
+  HarnessCore *core = [HarnessCore new]; HarnessTransport *transport = [HarnessTransport new];
+  HarnessClock *clock = [HarnessClock new]; clock.now = 1000;
+  dispatch_queue_t callbacks = dispatch_queue_create("fetch.harness.corrupt", DISPATCH_QUEUE_SERIAL);
+  __block NSUInteger observations = 0;
+  QONRemoteConfigV2FetchCoordinator *coordinator = Coordinator(core, transport, store, clock,
+      [HarnessRandom new], [HarnessScheduler new], Policy(0, nil), callbacks,
+      ^(__unused QONRemoteConfigV2FetchPolicyScope *observedScope,
+        QONRemoteConfigV2FetchPolicyFailureReason reason) {
+    if (reason == QONRemoteConfigV2FetchPolicyFailureReasonLoadCorrupt) observations += 1;
+  });
+  [coordinator transitionToBinding:Binding(@"a")];
+  __block QONRemoteConfigV2FetchResult *result = nil;
+  [coordinator fetchWithForceReason:QONRemoteConfigV2FetchForceReasonBuild
+      completion:^(id value) { result = value; }];
+  Drain(callbacks);
+  QON_CHECK(result.kind == QONRemoteConfigV2FetchResultKindPolicyPersistenceFailed &&
+      result.policyFailureReason == QONRemoteConfigV2FetchPolicyFailureReasonLoadCorrupt &&
+      result.nextAllowedAtMilliseconds == 2000 && transport.requests.count == 0,
+      "corrupt durable guard state must emit explicit result and initial bounded delay before network");
+  QON_CHECK(observations == 1 && [storage.objects[key] isEqual:corrupt],
+      "corrupt policy telemetry must be bounded and the evidence must not be silently deleted");
+}
+
+static void TestOnlyExplicitNon429ClientErrorsAreNonRetryable(void) {
+  HarnessCore *core = [HarnessCore new]; HarnessTransport *transport = [HarnessTransport new];
+  HarnessStore *store = [HarnessStore new]; HarnessClock *clock = [HarnessClock new]; clock.now = 1000;
+  dispatch_queue_t callbacks = dispatch_queue_create("fetch.harness.http-4xx", DISPATCH_QUEUE_SERIAL);
+  QONRemoteConfigV2FetchCoordinator *coordinator = Coordinator(core, transport, store, clock,
+      [HarnessRandom new], [HarnessScheduler new], Policy(0, nil), callbacks, nil);
+  [coordinator transitionToBinding:Binding(@"a")];
+  [coordinator fetchWithForceReason:QONRemoteConfigV2FetchForceReasonNone
+      completion:^(__unused id value) {}];
+  [transport complete:0 response:[QONRemoteConfigV2FetchResponse
+      failureWithStatusCode:@404 retryAfterMilliseconds:nil]];
+  Drain(callbacks);
+  QON_CHECK(store.states[@"project/production"] == nil,
+      "explicit non-429 4xx must not create retry backoff");
+
+  [coordinator fetchWithForceReason:QONRemoteConfigV2FetchForceReasonNone
+      completion:^(__unused id value) {}];
+  [transport complete:1 response:[QONRemoteConfigV2FetchResponse
+      failureWithStatusCode:@429 retryAfterMilliseconds:@1000]];
+  Drain(callbacks);
+  QONRemoteConfigV2FetchPolicyState *afterRateLimit = store.states[@"project/production"];
+  QON_CHECK(afterRateLimit.nextAllowedFetchAtMilliseconds == 2000,
+      "429 must remain retryable and persist Retry-After backoff");
+}
+
+int main(void) {
+  @autoreleasepool {
+    TestCoalescingAndCallbackIsolation();
+    TestBackoffScopeAndForce();
+    TestMinimumIntervalForceOnly();
+    TestTimeoutAndZombieFence();
+    TestConditional304Retry();
+    TestMatching304IsAccepted();
+    TestCappedExponentialFullJitter();
+    TestTransportAndSchedulerExceptionsCannotHangWaiters();
+    TestNilStatusAndTransportExceptionPersistBackoffAcrossRestart();
+    TestPersistenceFailureIsObservableAndConservative();
+    TestTransitionClaimsOldWaitersOnce();
+    TestPersistentPolicyStoreScopeAndReadback();
+    TestPersistentPolicyStoreDistinguishesMissingFailedAndCorrupt();
+    TestPolicyLoadFailureFailsClosedBeforeNetwork();
+    TestCorruptPolicyFailsClosedWithoutSilentDeletion();
+    TestOnlyExplicitNon429ClientErrorsAreNonRetryable();
+  }
+  if (failures == 0) fprintf(stdout, "QONRemoteConfigV2FetchCoordinatorHarness: 16/16 passed\n");
+  return failures == 0 ? 0 : 1;
+}

--- a/QonversionTests/Managers/QONRemoteConfigV2FetchCoordinatorTests.m
+++ b/QonversionTests/Managers/QONRemoteConfigV2FetchCoordinatorTests.m
@@ -1,0 +1,348 @@
+#import <XCTest/XCTest.h>
+
+#import "QONRemoteConfigV2FetchCoordinator.h"
+
+@interface QONRemoteConfigV2FetchTestTask : NSObject <QONRemoteConfigV2FetchScheduledTask>
+@property (nonatomic, copy) dispatch_block_t action;
+@property (nonatomic, assign) BOOL cancelled;
+@end
+
+@implementation QONRemoteConfigV2FetchTestTask
+- (void)cancel { self.cancelled = YES; }
+@end
+
+@interface QONRemoteConfigV2FetchTestScheduler : NSObject <QONRemoteConfigV2FetchScheduler>
+@property (nonatomic, strong) NSMutableArray<QONRemoteConfigV2FetchTestTask *> *tasks;
+- (void)fireTaskAtIndex:(NSUInteger)index;
+@end
+
+@implementation QONRemoteConfigV2FetchTestScheduler
+- (instancetype)init { self = [super init]; if (self) _tasks = [NSMutableArray new]; return self; }
+- (id<QONRemoteConfigV2FetchScheduledTask>)scheduleAfterMilliseconds:(int64_t)delay
+                                                              action:(dispatch_block_t)action {
+  QONRemoteConfigV2FetchTestTask *task = [QONRemoteConfigV2FetchTestTask new];
+  task.action = action;
+  [self.tasks addObject:task];
+  return task;
+}
+- (void)fireTaskAtIndex:(NSUInteger)index {
+  QONRemoteConfigV2FetchTestTask *task = self.tasks[index];
+  if (!task.cancelled) task.action();
+}
+@end
+
+@interface QONRemoteConfigV2FetchTestClock : NSObject <QONRemoteConfigV2FetchClock>
+@property (nonatomic, assign) int64_t now;
+@end
+@implementation QONRemoteConfigV2FetchTestClock
+- (int64_t)nowMilliseconds { return self.now; }
+@end
+
+@interface QONRemoteConfigV2FetchTestRandom : NSObject <QONRemoteConfigV2FetchRandom>
+@property (nonatomic, assign) double value;
+@end
+@implementation QONRemoteConfigV2FetchTestRandom
+- (double)nextUnitInterval { return self.value; }
+@end
+
+@interface QONRemoteConfigV2FetchTestPolicyStore : NSObject <QONRemoteConfigV2FetchPolicyStoring>
+@property (nonatomic, strong) NSMutableDictionary<NSString *, QONRemoteConfigV2FetchPolicyState *> *states;
+@property (nonatomic, assign) BOOL saveSucceeds;
+@end
+
+@implementation QONRemoteConfigV2FetchTestPolicyStore
+- (instancetype)init { self = [super init]; if (self) { _states = [NSMutableDictionary new]; _saveSucceeds = YES; } return self; }
+- (NSString *)key:(QONRemoteConfigV2FetchPolicyScope *)scope {
+  return [NSString stringWithFormat:@"%@\n%@", scope.projectKey, scope.environment];
+}
+- (QONRemoteConfigV2FetchPolicyLoadResult *)loadResultForScope:(QONRemoteConfigV2FetchPolicyScope *)scope {
+  QONRemoteConfigV2FetchPolicyState *state = self.states[[self key:scope]];
+  return [[QONRemoteConfigV2FetchPolicyLoadResult alloc]
+      initWithStatus:state ? QONRemoteConfigV2FetchPolicyLoadStatusFound
+                         : QONRemoteConfigV2FetchPolicyLoadStatusMissing
+               state:state];
+}
+- (BOOL)saveState:(QONRemoteConfigV2FetchPolicyState *)state
+          forScope:(QONRemoteConfigV2FetchPolicyScope *)scope {
+  if (!self.saveSucceeds) return NO;
+  self.states[[self key:scope]] = state;
+  return YES;
+}
+@end
+
+@interface QONRemoteConfigV2FetchTestTransport : NSObject <QONRemoteConfigV2FetchTransport>
+@property (nonatomic, strong) NSMutableArray<QONRemoteConfigV2FetchRequest *> *requests;
+@property (nonatomic, strong) NSMutableArray<QONRemoteConfigV2FetchTransportCompletion> *completions;
+@end
+
+@implementation QONRemoteConfigV2FetchTestTransport
+- (instancetype)init { self = [super init]; if (self) { _requests = [NSMutableArray new]; _completions = [NSMutableArray new]; } return self; }
+- (void)fetchRequest:(QONRemoteConfigV2FetchRequest *)request
+          completion:(QONRemoteConfigV2FetchTransportCompletion)completion {
+  [self.requests addObject:request];
+  [self.completions addObject:[completion copy]];
+}
+@end
+
+@interface QONRemoteConfigV2FetchTestCore : NSObject <QONRemoteConfigV2FetchCore>
+@property (nonatomic, strong) QONRemoteConfigV2Scope *currentScope;
+@property (nonatomic, strong) QONRemoteConfigV2ConditionalRequestValidator *validator;
+@property (nonatomic, strong) QONRemoteConfigSnapshot *snapshot;
+@property (nonatomic, assign) NSUInteger admissions;
+@property (nonatomic, assign) NSUInteger admittedBodies;
+@property (nonatomic, assign) QONRemoteConfigV2TransitionStatus transitionStatus;
+@end
+
+@implementation QONRemoteConfigV2FetchTestCore
+- (void)setScope:(QONRemoteConfigV2Scope *)scope { self.currentScope = scope; }
+- (QONRemoteConfigSnapshot *)currentSnapshot { return self.snapshot; }
+- (QONRemoteConfigV2AdmissionToken *)beginAdmissionForScope:(QONRemoteConfigV2Scope *)scope
+                                                expectation:(QONRemoteConfigV2EnvelopeExpectation *)expectation {
+  self.admissions += 1;
+  return (id)[NSObject new];
+}
+- (QONRemoteConfigV2TransitionStatus)admitBody:(NSData *)body
+                                   strongETag:(NSString *)strongETag
+                               admissionToken:(QONRemoteConfigV2AdmissionToken *)admissionToken {
+  self.admittedBodies += 1;
+  return self.transitionStatus;
+}
+- (QONRemoteConfigV2ConditionalRequestValidator *)conditionalRequestValidator { return self.validator; }
+- (BOOL)isConditionalRequestValidatorCurrent:(QONRemoteConfigV2ConditionalRequestValidator *)validator {
+  return [self.validator isEqual:validator];
+}
+@end
+
+@interface QONRemoteConfigV2FetchCoordinatorTests : XCTestCase
+@end
+
+@implementation QONRemoteConfigV2FetchCoordinatorTests
+
+- (QONRemoteConfigV2FetchBinding *)bindingForUser:(NSString *)user {
+  QONRemoteConfigV2Scope *scope = [[QONRemoteConfigV2Scope alloc]
+      initWithProjectKey:@"project" environment:@"production" canonicalUserID:user];
+  QONRemoteConfigV2EnvelopeExpectation *expectation = [[QONRemoteConfigV2EnvelopeExpectation alloc]
+      initWithProjectID:42 environmentUID:@"production"
+      contextFingerprint:[@"a" stringByPaddingToLength:64 withString:@"a" startingAtIndex:0]];
+  return [[QONRemoteConfigV2FetchBinding alloc] initWithScope:scope expectation:expectation];
+}
+
+- (QONRemoteConfigV2FetchCoordinator *)coordinatorWithCore:(QONRemoteConfigV2FetchTestCore *)core
+                                                 transport:(QONRemoteConfigV2FetchTestTransport *)transport
+                                                     store:(QONRemoteConfigV2FetchTestPolicyStore *)store
+                                                     clock:(QONRemoteConfigV2FetchTestClock *)clock
+                                                    policy:(QONRemoteConfigV2FetchPolicy *)policy {
+  dispatch_queue_t callbacks = dispatch_queue_create("io.qonversion.fetch-policy-tests", DISPATCH_QUEUE_SERIAL);
+  return [[QONRemoteConfigV2FetchCoordinator alloc] initWithCore:core transport:transport
+      policyStore:store clock:clock random:[QONRemoteConfigV2FetchTestRandom new]
+      scheduler:[QONRemoteConfigV2FetchTestScheduler new] policy:policy
+      callbackExecutor:callbacks policyPersistenceFailureObserver:nil];
+}
+
+- (void)testConcurrentFetchesCoalesceIntoOneTransportRequest {
+  QONRemoteConfigV2FetchTestCore *core = [QONRemoteConfigV2FetchTestCore new];
+  core.transitionStatus = QONRemoteConfigV2TransitionStatusAccepted;
+  QONRemoteConfigV2FetchTestTransport *transport = [QONRemoteConfigV2FetchTestTransport new];
+  QONRemoteConfigV2FetchTestPolicyStore *store = [QONRemoteConfigV2FetchTestPolicyStore new];
+  QONRemoteConfigV2FetchTestClock *clock = [QONRemoteConfigV2FetchTestClock new];
+  QONRemoteConfigV2FetchPolicy *policy = [[QONRemoteConfigV2FetchPolicy alloc]
+      initWithMinimumFetchIntervalMilliseconds:0 timeoutMilliseconds:nil
+      initialBackoffMilliseconds:1000 maximumBackoffMilliseconds:60000];
+  QONRemoteConfigV2FetchCoordinator *coordinator = [self coordinatorWithCore:core
+      transport:transport store:store clock:clock policy:policy];
+  [coordinator transitionToBinding:[self bindingForUser:@"user"]];
+  XCTestExpectation *both = [self expectationWithDescription:@"both waiters"];
+  both.expectedFulfillmentCount = 2;
+
+  [coordinator fetchWithForceReason:QONRemoteConfigV2FetchForceReasonNone
+                         completion:^(__unused QONRemoteConfigV2FetchResult *result) { [both fulfill]; }];
+  [coordinator fetchWithForceReason:QONRemoteConfigV2FetchForceReasonBuild
+                         completion:^(__unused QONRemoteConfigV2FetchResult *result) { [both fulfill]; }];
+  XCTAssertEqual(transport.requests.count, 1u);
+  transport.completions.firstObject([QONRemoteConfigV2FetchResponse
+      successWithBody:[@"{}" dataUsingEncoding:NSUTF8StringEncoding] strongETag:@"etag"]);
+  [self waitForExpectations:@[both] timeout:2];
+  XCTAssertEqual(core.admissions, 1u);
+}
+
+- (void)testRetryAfterBackoffPersistsAcrossIdentityAndLifecycleForceCannotBypassIt {
+  QONRemoteConfigV2FetchTestCore *core = [QONRemoteConfigV2FetchTestCore new];
+  QONRemoteConfigV2FetchTestTransport *transport = [QONRemoteConfigV2FetchTestTransport new];
+  QONRemoteConfigV2FetchTestPolicyStore *store = [QONRemoteConfigV2FetchTestPolicyStore new];
+  QONRemoteConfigV2FetchTestClock *clock = [QONRemoteConfigV2FetchTestClock new];
+  clock.now = 1000;
+  QONRemoteConfigV2FetchPolicy *policy = [[QONRemoteConfigV2FetchPolicy alloc]
+      initWithMinimumFetchIntervalMilliseconds:0 timeoutMilliseconds:nil
+      initialBackoffMilliseconds:1000 maximumBackoffMilliseconds:60000];
+  QONRemoteConfigV2FetchCoordinator *coordinator = [self coordinatorWithCore:core
+      transport:transport store:store clock:clock policy:policy];
+  [coordinator transitionToBinding:[self bindingForUser:@"user-a"]];
+  XCTestExpectation *failed = [self expectationWithDescription:@"failure"];
+  [coordinator fetchWithForceReason:QONRemoteConfigV2FetchForceReasonNone
+      completion:^(__unused QONRemoteConfigV2FetchResult *result) { [failed fulfill]; }];
+  transport.completions[0]([QONRemoteConfigV2FetchResponse failureWithStatusCode:@503
+      retryAfterMilliseconds:@5000]);
+  [self waitForExpectations:@[failed] timeout:2];
+  QONRemoteConfigV2FetchPolicyState *saved = store.states[@"project\nproduction"];
+  XCTAssertEqual(saved.nextAllowedFetchAtMilliseconds, 6000);
+
+  [coordinator transitionToBinding:[self bindingForUser:@"user-b"]];
+  for (NSNumber *force in @[@(QONRemoteConfigV2FetchForceReasonBuild),
+                            @(QONRemoteConfigV2FetchForceReasonIdentify),
+                            @(QONRemoteConfigV2FetchForceReasonLogout)]) {
+    XCTestExpectation *gated = [self expectationWithDescription:@"gated"];
+    [coordinator fetchWithForceReason:force.integerValue completion:^(QONRemoteConfigV2FetchResult *result) {
+      XCTAssertEqual(result.kind, QONRemoteConfigV2FetchResultKindBackoff);
+      [gated fulfill];
+    }];
+    [self waitForExpectations:@[gated] timeout:2];
+  }
+  XCTAssertEqual(transport.requests.count, 1u);
+}
+
+- (void)testTimeoutReturnsSnapshotWithoutCancellingHTTPAndLateResponsePersistsCandidate {
+  QONRemoteConfigV2FetchTestCore *core = [QONRemoteConfigV2FetchTestCore new];
+  core.transitionStatus = QONRemoteConfigV2TransitionStatusAccepted;
+  core.snapshot = (id)[NSObject new];
+  QONRemoteConfigV2FetchTestTransport *transport = [QONRemoteConfigV2FetchTestTransport new];
+  QONRemoteConfigV2FetchTestPolicyStore *store = [QONRemoteConfigV2FetchTestPolicyStore new];
+  QONRemoteConfigV2FetchTestClock *clock = [QONRemoteConfigV2FetchTestClock new];
+  QONRemoteConfigV2FetchTestRandom *random = [QONRemoteConfigV2FetchTestRandom new];
+  QONRemoteConfigV2FetchTestScheduler *scheduler = [QONRemoteConfigV2FetchTestScheduler new];
+  dispatch_queue_t callbacks = dispatch_queue_create("io.qonversion.fetch-timeout-tests", DISPATCH_QUEUE_SERIAL);
+  QONRemoteConfigV2FetchPolicy *policy = [[QONRemoteConfigV2FetchPolicy alloc]
+      initWithMinimumFetchIntervalMilliseconds:0 timeoutMilliseconds:@100
+      initialBackoffMilliseconds:1000 maximumBackoffMilliseconds:60000];
+  QONRemoteConfigV2FetchCoordinator *coordinator = [[QONRemoteConfigV2FetchCoordinator alloc]
+      initWithCore:core transport:transport policyStore:store clock:clock random:random
+      scheduler:scheduler policy:policy callbackExecutor:callbacks
+      policyPersistenceFailureObserver:nil];
+  [coordinator transitionToBinding:[self bindingForUser:@"user"]];
+  XCTestExpectation *timedOut = [self expectationWithDescription:@"timed out"];
+  [coordinator fetchWithForceReason:QONRemoteConfigV2FetchForceReasonNone
+      completion:^(QONRemoteConfigV2FetchResult *result) {
+    XCTAssertEqual(result.kind, QONRemoteConfigV2FetchResultKindTimedOut);
+    XCTAssertEqual(result.snapshot, core.snapshot);
+    [timedOut fulfill];
+  }];
+  [scheduler fireTaskAtIndex:0];
+  [self waitForExpectations:@[timedOut] timeout:2];
+  transport.completions[0]([QONRemoteConfigV2FetchResponse successWithBody:[NSData data]
+      strongETag:@"etag"]);
+  dispatch_sync(callbacks, ^{});
+  XCTAssertEqual(core.admittedBodies, 1u);
+  XCTAssertNotNil(store.states[@"project\nproduction"]);
+}
+
+- (void)testNewFetchAfterAllWaitersTimeoutSupersedesZombieWithoutCancellingOldHTTP {
+  QONRemoteConfigV2FetchTestCore *core = [QONRemoteConfigV2FetchTestCore new];
+  core.transitionStatus = QONRemoteConfigV2TransitionStatusAccepted;
+  QONRemoteConfigV2FetchTestTransport *transport = [QONRemoteConfigV2FetchTestTransport new];
+  QONRemoteConfigV2FetchTestPolicyStore *store = [QONRemoteConfigV2FetchTestPolicyStore new];
+  QONRemoteConfigV2FetchTestClock *clock = [QONRemoteConfigV2FetchTestClock new];
+  QONRemoteConfigV2FetchTestScheduler *scheduler = [QONRemoteConfigV2FetchTestScheduler new];
+  dispatch_queue_t callbacks = dispatch_queue_create("io.qonversion.fetch-zombie-tests", DISPATCH_QUEUE_SERIAL);
+  QONRemoteConfigV2FetchPolicy *policy = [[QONRemoteConfigV2FetchPolicy alloc]
+      initWithMinimumFetchIntervalMilliseconds:0 timeoutMilliseconds:@100
+      initialBackoffMilliseconds:1000 maximumBackoffMilliseconds:60000];
+  QONRemoteConfigV2FetchCoordinator *coordinator = [[QONRemoteConfigV2FetchCoordinator alloc]
+      initWithCore:core transport:transport policyStore:store clock:clock
+      random:[QONRemoteConfigV2FetchTestRandom new] scheduler:scheduler policy:policy
+      callbackExecutor:callbacks policyPersistenceFailureObserver:nil];
+  [coordinator transitionToBinding:[self bindingForUser:@"user"]];
+
+  XCTestExpectation *timedOut = [self expectationWithDescription:@"old waiter times out"];
+  [coordinator fetchWithForceReason:QONRemoteConfigV2FetchForceReasonNone
+      completion:^(QONRemoteConfigV2FetchResult *result) {
+    XCTAssertEqual(result.kind, QONRemoteConfigV2FetchResultKindTimedOut);
+    [timedOut fulfill];
+  }];
+  [scheduler fireTaskAtIndex:0];
+  [self waitForExpectations:@[timedOut] timeout:2];
+
+  XCTestExpectation *fresh = [self expectationWithDescription:@"fresh operation completes"];
+  [coordinator fetchWithForceReason:QONRemoteConfigV2FetchForceReasonNone
+      completion:^(QONRemoteConfigV2FetchResult *result) {
+    XCTAssertEqual(result.kind, QONRemoteConfigV2FetchResultKindFetched);
+    [fresh fulfill];
+  }];
+  XCTAssertEqual(transport.requests.count, 2u);
+  XCTAssertEqual(core.admissions, 2u);
+  transport.completions[0]([QONRemoteConfigV2FetchResponse successWithBody:[NSData data]
+      strongETag:@"old"]);
+  transport.completions[1]([QONRemoteConfigV2FetchResponse successWithBody:[NSData data]
+      strongETag:@"fresh"]);
+  [self waitForExpectations:@[fresh] timeout:2];
+  XCTAssertEqual(core.admittedBodies, 1u);
+}
+
+- (void)testInvalid304RetriesExactlyOnceWithoutETag {
+  QONRemoteConfigV2FetchTestCore *core = [QONRemoteConfigV2FetchTestCore new];
+  core.validator = [[QONRemoteConfigV2ConditionalRequestValidator alloc]
+      initWithStrongETag:@"\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\""
+      bodyDigest:[@"a" stringByPaddingToLength:64 withString:@"a" startingAtIndex:0]
+      headAdmissionOrdinal:1];
+  QONRemoteConfigV2FetchTestTransport *transport = [QONRemoteConfigV2FetchTestTransport new];
+  QONRemoteConfigV2FetchTestPolicyStore *store = [QONRemoteConfigV2FetchTestPolicyStore new];
+  QONRemoteConfigV2FetchTestClock *clock = [QONRemoteConfigV2FetchTestClock new];
+  QONRemoteConfigV2FetchPolicy *policy = [[QONRemoteConfigV2FetchPolicy alloc]
+      initWithMinimumFetchIntervalMilliseconds:0 timeoutMilliseconds:nil
+      initialBackoffMilliseconds:1000 maximumBackoffMilliseconds:60000];
+  QONRemoteConfigV2FetchCoordinator *coordinator = [self coordinatorWithCore:core
+      transport:transport store:store clock:clock policy:policy];
+  [coordinator transitionToBinding:[self bindingForUser:@"user"]];
+  XCTestExpectation *done = [self expectationWithDescription:@"invalid 304"];
+  [coordinator fetchWithForceReason:QONRemoteConfigV2FetchForceReasonNone
+      completion:^(QONRemoteConfigV2FetchResult *result) {
+    XCTAssertEqual(result.kind, QONRemoteConfigV2FetchResultKindInvalidNotModified);
+    [done fulfill];
+  }];
+  XCTAssertNotNil(transport.requests[0].ifNoneMatch);
+  core.validator = nil;
+  transport.completions[0]([QONRemoteConfigV2FetchResponse notModifiedWithStrongETag:nil]);
+  XCTAssertEqual(transport.requests.count, 2u);
+  XCTAssertNil(transport.requests[1].ifNoneMatch);
+  transport.completions[1]([QONRemoteConfigV2FetchResponse notModifiedWithStrongETag:nil]);
+  [self waitForExpectations:@[done] timeout:2];
+  XCTAssertEqual(transport.requests.count, 2u);
+}
+
+- (void)testPolicySaveFailureIsExplicitObservableAndConservativeInProcess {
+  QONRemoteConfigV2FetchTestCore *core = [QONRemoteConfigV2FetchTestCore new];
+  QONRemoteConfigV2FetchTestTransport *transport = [QONRemoteConfigV2FetchTestTransport new];
+  QONRemoteConfigV2FetchTestPolicyStore *store = [QONRemoteConfigV2FetchTestPolicyStore new];
+  store.saveSucceeds = NO;
+  QONRemoteConfigV2FetchTestClock *clock = [QONRemoteConfigV2FetchTestClock new];
+  clock.now = 1000;
+  dispatch_queue_t callbacks = dispatch_queue_create("io.qonversion.fetch-save-tests", DISPATCH_QUEUE_SERIAL);
+  __block NSUInteger observations = 0;
+  QONRemoteConfigV2FetchCoordinator *coordinator = [[QONRemoteConfigV2FetchCoordinator alloc]
+      initWithCore:core transport:transport policyStore:store clock:clock
+      random:[QONRemoteConfigV2FetchTestRandom new]
+      scheduler:[QONRemoteConfigV2FetchTestScheduler new]
+      policy:[[QONRemoteConfigV2FetchPolicy alloc] initWithMinimumFetchIntervalMilliseconds:0
+          timeoutMilliseconds:nil initialBackoffMilliseconds:1000 maximumBackoffMilliseconds:60000]
+      callbackExecutor:callbacks policyPersistenceFailureObserver:^(__unused id scope,
+          __unused QONRemoteConfigV2FetchPolicyFailureReason reason) { observations += 1; }];
+  [coordinator transitionToBinding:[self bindingForUser:@"user"]];
+  XCTestExpectation *failed = [self expectationWithDescription:@"save failed"];
+  [coordinator fetchWithForceReason:QONRemoteConfigV2FetchForceReasonNone
+      completion:^(QONRemoteConfigV2FetchResult *result) {
+    XCTAssertEqual(result.kind, QONRemoteConfigV2FetchResultKindPolicyPersistenceFailed);
+    [failed fulfill];
+  }];
+  transport.completions[0]([QONRemoteConfigV2FetchResponse failureWithStatusCode:@503
+      retryAfterMilliseconds:@5000]);
+  [self waitForExpectations:@[failed] timeout:2];
+  XCTAssertEqual(observations, 1u);
+  XCTestExpectation *gated = [self expectationWithDescription:@"in-process backoff"];
+  [coordinator fetchWithForceReason:QONRemoteConfigV2FetchForceReasonLogout
+      completion:^(QONRemoteConfigV2FetchResult *result) {
+    XCTAssertEqual(result.kind, QONRemoteConfigV2FetchResultKindBackoff);
+    [gated fulfill];
+  }];
+  [self waitForExpectations:@[gated] timeout:2];
+  XCTAssertEqual(transport.requests.count, 1u);
+}
+
+@end

--- a/QonversionTests/Managers/QONRemoteConfigV2ManagerTests.m
+++ b/QonversionTests/Managers/QONRemoteConfigV2ManagerTests.m
@@ -10,6 +10,7 @@
 #import "QNInMemoryStorage.h"
 #import "QNLocalStorage.h"
 #import "QONRemoteConfigSnapshot.h"
+#import "QONRemoteConfigV2FetchCoordinator.h"
 #import "QONRemoteConfigV2Manager.h"
 #import "QONRemoteConfigV2Models.h"
 #import "QONRemoteConfigV2Store.h"
@@ -457,6 +458,44 @@
 
   XCTAssertEqualObjects(observed, (@[@"blocking", @"release"]));
   XCTAssertEqualObjects(manager.currentSnapshot.releaseUID, @"release");
+}
+
+- (void)testConditionalValidatorIsBoundToExactCurrentCanonicalHeadAdmission {
+  QONRemoteConfigV2Manager *manager = [self managerWithStorage:[QNInMemoryStorage new]
+      decoder:[QONRemoteConfigV2EnvelopeParser new]];
+  QONRemoteConfigV2Scope *scope = [self wireScope:@"user"];
+  [manager setScope:scope];
+  NSString *firstString = [self wireBodyWithValues:[NSString stringWithFormat:@"\"only\":%@",
+      [self wireItemWithRaw:@"1" metadata:@"null" variationUID:@"variation-1"
+      policy:@"on_next_activate"]]];
+  NSData *firstBody = [self utf8Data:firstString];
+  QONRemoteConfigV2AdmissionToken *firstToken = [manager beginAdmissionForScope:scope
+      expectation:[self wireExpectation]];
+  XCTAssertEqual([manager admitBody:firstBody strongETag:[self strongETagForBody:firstBody]
+      admissionToken:firstToken], QONRemoteConfigV2TransitionStatusAccepted);
+  QONRemoteConfigV2ConditionalRequestValidator *first = manager.conditionalRequestValidator;
+  XCTAssertNotNil(first);
+  XCTAssertTrue([manager isConditionalRequestValidatorCurrent:first]);
+
+  NSString *secondString = [[self wireBodyWithValues:[NSString stringWithFormat:@"\"only\":%@",
+      [self wireItemWithRaw:@"2" metadata:@"null" variationUID:@"variation-2"
+      policy:@"on_next_activate"]]] stringByReplacingOccurrencesOfString:
+      @"\"release_number\":7" withString:@"\"release_number\":8"];
+  NSData *secondBody = [self utf8Data:secondString];
+  QONRemoteConfigV2AdmissionToken *secondToken = [manager beginAdmissionForScope:scope
+      expectation:[self wireExpectation]];
+  XCTAssertEqual([manager admitBody:secondBody strongETag:[self strongETagForBody:secondBody]
+      admissionToken:secondToken], QONRemoteConfigV2TransitionStatusAccepted);
+  QONRemoteConfigV2ConditionalRequestValidator *second = manager.conditionalRequestValidator;
+  XCTAssertNotEqualObjects(first, second);
+  XCTAssertFalse([manager isConditionalRequestValidatorCurrent:first]);
+  XCTAssertTrue([manager isConditionalRequestValidatorCurrent:second]);
+
+  XCTAssertTrue([manager activate]);
+  [manager acceptFetchedRelease:[self release:@"local-candidate" number:9
+      values:@{@"only": @"3"} immediate:NO] forScope:scope];
+  XCTAssertNil(manager.conditionalRequestValidator,
+      @"A non-canonical Candidate must suppress the older Active ETag instead of falling back to it");
 }
 
 - (NSData *)utf8Data:(NSString *)string {

--- a/Sources/Qonversion/Qonversion/Core/QONRemoteConfigV2Store/QONRemoteConfigV2FetchPolicyStore.h
+++ b/Sources/Qonversion/Qonversion/Core/QONRemoteConfigV2Store/QONRemoteConfigV2FetchPolicyStore.h
@@ -1,0 +1,16 @@
+#import <Foundation/Foundation.h>
+#import "QONRemoteConfigV2FetchCoordinator.h"
+
+@protocol QNLocalStorage;
+
+NS_ASSUME_NONNULL_BEGIN
+
+FOUNDATION_EXPORT NSUInteger const QONRemoteConfigV2FetchPolicyMaximumArchiveBytes;
+
+/** Small, identity-independent durable guard state keyed by project and environment. */
+@interface QONRemoteConfigV2FetchPolicyStore : NSObject <QONRemoteConfigV2FetchPolicyStoring>
+- (instancetype)init NS_UNAVAILABLE;
+- (nullable instancetype)initWithLocalStorage:(id<QNLocalStorage>)localStorage NS_DESIGNATED_INITIALIZER;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Qonversion/Qonversion/Core/QONRemoteConfigV2Store/QONRemoteConfigV2FetchPolicyStore.m
+++ b/Sources/Qonversion/Qonversion/Core/QONRemoteConfigV2Store/QONRemoteConfigV2FetchPolicyStore.m
@@ -1,0 +1,203 @@
+#import "QONRemoteConfigV2FetchPolicyStore.h"
+#import "QNLocalStorage.h"
+#import <CommonCrypto/CommonDigest.h>
+#import <CoreFoundation/CoreFoundation.h>
+#import <string.h>
+
+NSUInteger const QONRemoteConfigV2FetchPolicyMaximumArchiveBytes = 2048;
+static NSInteger const QONRemoteConfigV2FetchPolicySchema = 1;
+static NSString *const QONRemoteConfigV2FetchPolicyPrefix =
+    @"com.qonversion.keys.remote-config-v2-fetch-policy.";
+
+static BOOL QONRemoteConfigV2FetchPolicyExactInt64(id object, int64_t *value) {
+  if (![object isKindOfClass:NSNumber.class] ||
+      CFGetTypeID((__bridge CFTypeRef)object) == CFBooleanGetTypeID()) return NO;
+  const char type = [object objCType][0];
+  if (strchr("csiql", type)) {
+    if (value) *value = [object longLongValue];
+    return YES;
+  }
+  if (strchr("CSILQ", type)) {
+    unsigned long long candidate = [object unsignedLongLongValue];
+    if (candidate > INT64_MAX) return NO;
+    if (value) *value = (int64_t)candidate;
+    return YES;
+  }
+  return NO;
+}
+
+static void QONRemoteConfigV2FetchPolicyAppendFramed(NSMutableData *data, NSData *value) {
+  uint32_t length = CFSwapInt32HostToBig((uint32_t)value.length);
+  [data appendBytes:&length length:sizeof(length)];
+  [data appendData:value];
+}
+
+static void QONRemoteConfigV2FetchPolicyAppendInt64(NSMutableData *data, int64_t value) {
+  uint64_t encoded = CFSwapInt64HostToBig((uint64_t)value);
+  [data appendBytes:&encoded length:sizeof(encoded)];
+}
+
+static NSString *QONRemoteConfigV2FetchPolicySHA256(NSData *data) {
+  uint8_t digest[CC_SHA256_DIGEST_LENGTH];
+  CC_SHA256(data.bytes, (CC_LONG)data.length, digest);
+  NSMutableString *hex = [NSMutableString stringWithCapacity:CC_SHA256_DIGEST_LENGTH * 2];
+  for (NSUInteger index = 0; index < CC_SHA256_DIGEST_LENGTH; index++) {
+    [hex appendFormat:@"%02x", digest[index]];
+  }
+  return hex;
+}
+
+static NSString *QONRemoteConfigV2FetchPolicyStorageKey(QONRemoteConfigV2FetchPolicyScope *scope) {
+  NSMutableData *framing = [NSMutableData new];
+  QONRemoteConfigV2FetchPolicyAppendFramed(framing,
+      [@"remote-config-fetch-policy-v1" dataUsingEncoding:NSUTF8StringEncoding]);
+  QONRemoteConfigV2FetchPolicyAppendFramed(framing,
+      [scope.projectKey dataUsingEncoding:NSUTF8StringEncoding]);
+  QONRemoteConfigV2FetchPolicyAppendFramed(framing,
+      [scope.environment dataUsingEncoding:NSUTF8StringEncoding]);
+  return [QONRemoteConfigV2FetchPolicyPrefix
+      stringByAppendingString:QONRemoteConfigV2FetchPolicySHA256(framing)];
+}
+
+static NSString *QONRemoteConfigV2FetchPolicyIntegrityDigest(
+    QONRemoteConfigV2FetchPolicyScope *scope, QONRemoteConfigV2FetchPolicyState *state) {
+  NSMutableData *framing = [NSMutableData new];
+  QONRemoteConfigV2FetchPolicyAppendFramed(framing,
+      [@"remote-config-fetch-policy-state-v1" dataUsingEncoding:NSUTF8StringEncoding]);
+  QONRemoteConfigV2FetchPolicyAppendFramed(framing,
+      [scope.projectKey dataUsingEncoding:NSUTF8StringEncoding]);
+  QONRemoteConfigV2FetchPolicyAppendFramed(framing,
+      [scope.environment dataUsingEncoding:NSUTF8StringEncoding]);
+  QONRemoteConfigV2FetchPolicyAppendInt64(framing, QONRemoteConfigV2FetchPolicySchema);
+  QONRemoteConfigV2FetchPolicyAppendInt64(framing, state.lastSuccessfulFetchAtMilliseconds);
+  QONRemoteConfigV2FetchPolicyAppendInt64(framing, state.consecutiveRetryableFailures);
+  QONRemoteConfigV2FetchPolicyAppendInt64(framing, state.nextAllowedFetchAtMilliseconds);
+  return QONRemoteConfigV2FetchPolicySHA256(framing);
+}
+
+@interface QONRemoteConfigV2FetchPolicyStore ()
+@property (nonatomic, strong) id<QNLocalStorage> localStorage;
+@end
+
+@implementation QONRemoteConfigV2FetchPolicyStore
+
+- (instancetype)initWithLocalStorage:(id<QNLocalStorage>)localStorage {
+  if (!localStorage) return nil;
+  self = [super init];
+  if (self) _localStorage = localStorage;
+  return self;
+}
+
+- (NSDictionary *)dictionaryForState:(QONRemoteConfigV2FetchPolicyState *)state
+                                scope:(QONRemoteConfigV2FetchPolicyScope *)scope {
+  return @{
+    @"schema_version": @(QONRemoteConfigV2FetchPolicySchema),
+    @"project": scope.projectKey,
+    @"environment": scope.environment,
+    @"last_successful_fetch_at_ms": @(state.lastSuccessfulFetchAtMilliseconds),
+    @"consecutive_retryable_failures": @(state.consecutiveRetryableFailures),
+    @"next_allowed_fetch_at_ms": @(state.nextAllowedFetchAtMilliseconds),
+    @"integrity_digest": QONRemoteConfigV2FetchPolicyIntegrityDigest(scope, state),
+  };
+}
+
+- (BOOL)objectFitsArchiveBudget:(id)object {
+  @try {
+    NSError *error = nil;
+    NSData *data = [NSPropertyListSerialization dataWithPropertyList:object
+        format:NSPropertyListBinaryFormat_v1_0 options:0 error:&error];
+    return data.length > 0 && data.length <= QONRemoteConfigV2FetchPolicyMaximumArchiveBytes && !error;
+  } @catch (__unused NSException *exception) {
+    return NO;
+  }
+}
+
+- (QONRemoteConfigV2FetchPolicyLoadResult *)loadResultForScope:(QONRemoteConfigV2FetchPolicyScope *)scope {
+  if (!scope) {
+    return [[QONRemoteConfigV2FetchPolicyLoadResult alloc]
+        initWithStatus:QONRemoteConfigV2FetchPolicyLoadStatusFailed state:nil];
+  }
+  @synchronized (self) {
+    NSString *key = QONRemoteConfigV2FetchPolicyStorageKey(scope);
+    id object = nil;
+    @try { object = [self.localStorage loadObjectForKey:key]; }
+    @catch (__unused NSException *exception) {
+      return [[QONRemoteConfigV2FetchPolicyLoadResult alloc]
+          initWithStatus:QONRemoteConfigV2FetchPolicyLoadStatusFailed state:nil];
+    }
+    if (!object) {
+      return [[QONRemoteConfigV2FetchPolicyLoadResult alloc]
+          initWithStatus:QONRemoteConfigV2FetchPolicyLoadStatusMissing state:nil];
+    }
+    if (![object isKindOfClass:NSDictionary.class] || ![self objectFitsArchiveBudget:object]) {
+      return [[QONRemoteConfigV2FetchPolicyLoadResult alloc]
+          initWithStatus:QONRemoteConfigV2FetchPolicyLoadStatusCorrupt state:nil];
+    }
+    @try {
+      NSDictionary *dictionary = object;
+      if (dictionary.count != 7 || ![dictionary[@"project"] isKindOfClass:NSString.class] ||
+          ![dictionary[@"environment"] isKindOfClass:NSString.class] ||
+          ![dictionary[@"integrity_digest"] isKindOfClass:NSString.class] ||
+          ![dictionary[@"project"] isEqualToString:scope.projectKey] ||
+          ![dictionary[@"environment"] isEqualToString:scope.environment]) {
+        return [[QONRemoteConfigV2FetchPolicyLoadResult alloc]
+            initWithStatus:QONRemoteConfigV2FetchPolicyLoadStatusCorrupt state:nil];
+      }
+      int64_t schema = 0, lastSuccessful = 0, failures = 0, nextAllowed = 0;
+      if (!QONRemoteConfigV2FetchPolicyExactInt64(dictionary[@"schema_version"], &schema) ||
+          !QONRemoteConfigV2FetchPolicyExactInt64(dictionary[@"last_successful_fetch_at_ms"],
+                                                  &lastSuccessful) ||
+          !QONRemoteConfigV2FetchPolicyExactInt64(dictionary[@"consecutive_retryable_failures"],
+                                                  &failures) ||
+          !QONRemoteConfigV2FetchPolicyExactInt64(dictionary[@"next_allowed_fetch_at_ms"],
+                                                  &nextAllowed) ||
+          schema != QONRemoteConfigV2FetchPolicySchema || lastSuccessful < 0 ||
+          failures < 0 || failures > 63 || nextAllowed < 0) {
+        return [[QONRemoteConfigV2FetchPolicyLoadResult alloc]
+            initWithStatus:QONRemoteConfigV2FetchPolicyLoadStatusCorrupt state:nil];
+      }
+      QONRemoteConfigV2FetchPolicyState *state = [[QONRemoteConfigV2FetchPolicyState alloc]
+          initWithLastSuccessfulFetchAtMilliseconds:lastSuccessful
+          consecutiveRetryableFailures:(NSInteger)failures
+          nextAllowedFetchAtMilliseconds:nextAllowed];
+      if (!state || ![dictionary[@"integrity_digest"] isEqualToString:
+          QONRemoteConfigV2FetchPolicyIntegrityDigest(scope, state)]) {
+        return [[QONRemoteConfigV2FetchPolicyLoadResult alloc]
+            initWithStatus:QONRemoteConfigV2FetchPolicyLoadStatusCorrupt state:nil];
+      }
+      return [[QONRemoteConfigV2FetchPolicyLoadResult alloc]
+          initWithStatus:QONRemoteConfigV2FetchPolicyLoadStatusFound state:state];
+    } @catch (__unused NSException *exception) {
+      return [[QONRemoteConfigV2FetchPolicyLoadResult alloc]
+          initWithStatus:QONRemoteConfigV2FetchPolicyLoadStatusCorrupt state:nil];
+    }
+  }
+}
+
+- (BOOL)saveState:(QONRemoteConfigV2FetchPolicyState *)state
+          forScope:(QONRemoteConfigV2FetchPolicyScope *)scope {
+  if (!state || !scope) return NO;
+  NSDictionary *dictionary = [self dictionaryForState:state scope:scope];
+  if (![self objectFitsArchiveBudget:dictionary]) return NO;
+  @synchronized (self) {
+    NSString *key = QONRemoteConfigV2FetchPolicyStorageKey(scope);
+    id previous = nil;
+    BOOL attempted = NO;
+    @try {
+      previous = [self.localStorage loadObjectForKey:key];
+      attempted = YES;
+      [self.localStorage storeObject:dictionary forKey:key];
+      id readBack = [self.localStorage loadObjectForKey:key];
+      if ([readBack isEqual:dictionary]) return YES;
+    } @catch (__unused NSException *exception) {}
+    if (attempted) {
+      @try {
+        if (previous) [self.localStorage storeObject:previous forKey:key];
+        else [self.localStorage removeObjectForKey:key];
+      } @catch (__unused NSException *exception) {}
+    }
+    return NO;
+  }
+}
+
+@end

--- a/Sources/Qonversion/Qonversion/Main/QONRemoteConfigV2Manager/QONRemoteConfigV2FetchCoordinator.h
+++ b/Sources/Qonversion/Qonversion/Main/QONRemoteConfigV2Manager/QONRemoteConfigV2FetchCoordinator.h
@@ -1,0 +1,199 @@
+#import <Foundation/Foundation.h>
+#import "QONRemoteConfigV2Manager.h"
+#import "QONRemoteConfigV2Models.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface QONRemoteConfigV2ConditionalRequestValidator : NSObject <NSCopying>
+@property (nonatomic, copy, readonly) NSString *strongETag;
+@property (nonatomic, copy, readonly) NSString *bodyDigest;
+@property (nonatomic, assign, readonly) int64_t headAdmissionOrdinal;
+- (nullable instancetype)initWithStrongETag:(NSString *)strongETag
+                                  bodyDigest:(NSString *)bodyDigest
+                    headAdmissionOrdinal:(int64_t)headAdmissionOrdinal;
+@end
+
+@protocol QONRemoteConfigV2FetchCore <NSObject>
+- (void)setScope:(nullable QONRemoteConfigV2Scope *)scope;
+- (QONRemoteConfigSnapshot *)currentSnapshot;
+- (nullable QONRemoteConfigV2AdmissionToken *)beginAdmissionForScope:(QONRemoteConfigV2Scope *)scope
+                                                        expectation:(QONRemoteConfigV2EnvelopeExpectation *)expectation;
+- (QONRemoteConfigV2TransitionStatus)admitBody:(NSData *)body
+                                   strongETag:(NSString *)strongETag
+                               admissionToken:(QONRemoteConfigV2AdmissionToken *)admissionToken;
+- (nullable QONRemoteConfigV2ConditionalRequestValidator *)conditionalRequestValidator;
+- (BOOL)isConditionalRequestValidatorCurrent:(QONRemoteConfigV2ConditionalRequestValidator *)validator;
+@end
+
+@interface QONRemoteConfigV2Manager (QONRemoteConfigV2FetchCore) <QONRemoteConfigV2FetchCore>
+@end
+
+@interface QONRemoteConfigV2FetchBinding : NSObject <NSCopying>
+@property (nonatomic, strong, readonly) QONRemoteConfigV2Scope *scope;
+@property (nonatomic, strong, readonly) QONRemoteConfigV2EnvelopeExpectation *expectation;
+- (nullable instancetype)initWithScope:(QONRemoteConfigV2Scope *)scope
+                            expectation:(QONRemoteConfigV2EnvelopeExpectation *)expectation;
+@end
+
+typedef NS_ENUM(NSInteger, QONRemoteConfigV2FetchForceReason) {
+  QONRemoteConfigV2FetchForceReasonNone,
+  QONRemoteConfigV2FetchForceReasonBuild,
+  QONRemoteConfigV2FetchForceReasonIdentify,
+  QONRemoteConfigV2FetchForceReasonLogout,
+};
+
+@interface QONRemoteConfigV2FetchPolicy : NSObject <NSCopying>
+@property (nonatomic, assign, readonly) int64_t minimumFetchIntervalMilliseconds;
+@property (nonatomic, strong, nullable, readonly) NSNumber *timeoutMilliseconds;
+@property (nonatomic, assign, readonly) int64_t initialBackoffMilliseconds;
+@property (nonatomic, assign, readonly) int64_t maximumBackoffMilliseconds;
+- (nullable instancetype)initWithMinimumFetchIntervalMilliseconds:(int64_t)minimumFetchIntervalMilliseconds
+                                               timeoutMilliseconds:(nullable NSNumber *)timeoutMilliseconds
+                                        initialBackoffMilliseconds:(int64_t)initialBackoffMilliseconds
+                                        maximumBackoffMilliseconds:(int64_t)maximumBackoffMilliseconds;
+@end
+
+@interface QONRemoteConfigV2FetchPolicyState : NSObject <NSCopying>
+@property (nonatomic, assign, readonly) int64_t lastSuccessfulFetchAtMilliseconds;
+@property (nonatomic, assign, readonly) NSInteger consecutiveRetryableFailures;
+@property (nonatomic, assign, readonly) int64_t nextAllowedFetchAtMilliseconds;
+- (nullable instancetype)initWithLastSuccessfulFetchAtMilliseconds:(int64_t)lastSuccessfulFetchAtMilliseconds
+                                      consecutiveRetryableFailures:(NSInteger)consecutiveRetryableFailures
+                                    nextAllowedFetchAtMilliseconds:(int64_t)nextAllowedFetchAtMilliseconds;
+@end
+
+typedef NS_ENUM(NSInteger, QONRemoteConfigV2FetchPolicyLoadStatus) {
+  QONRemoteConfigV2FetchPolicyLoadStatusFound,
+  QONRemoteConfigV2FetchPolicyLoadStatusMissing,
+  QONRemoteConfigV2FetchPolicyLoadStatusFailed,
+  QONRemoteConfigV2FetchPolicyLoadStatusCorrupt,
+};
+
+/** Explicit load outcome so unavailable or corrupt guard state can never fail open as Missing. */
+@interface QONRemoteConfigV2FetchPolicyLoadResult : NSObject
+@property (nonatomic, assign, readonly) QONRemoteConfigV2FetchPolicyLoadStatus status;
+@property (nonatomic, strong, nullable, readonly) QONRemoteConfigV2FetchPolicyState *state;
+- (nullable instancetype)initWithStatus:(QONRemoteConfigV2FetchPolicyLoadStatus)status
+                                  state:(nullable QONRemoteConfigV2FetchPolicyState *)state;
+@end
+
+@interface QONRemoteConfigV2FetchPolicyScope : NSObject <NSCopying>
+@property (nonatomic, copy, readonly) NSString *projectKey;
+@property (nonatomic, copy, readonly) NSString *environment;
+- (nullable instancetype)initWithProjectKey:(NSString *)projectKey environment:(NSString *)environment;
++ (instancetype)scopeFromRemoteConfigScope:(QONRemoteConfigV2Scope *)scope;
+@end
+
+@protocol QONRemoteConfigV2FetchPolicyStoring <NSObject>
+- (QONRemoteConfigV2FetchPolicyLoadResult *)loadResultForScope:(QONRemoteConfigV2FetchPolicyScope *)scope;
+- (BOOL)saveState:(QONRemoteConfigV2FetchPolicyState *)state
+          forScope:(QONRemoteConfigV2FetchPolicyScope *)scope;
+@end
+
+@protocol QONRemoteConfigV2FetchClock <NSObject>
+- (int64_t)nowMilliseconds;
+@end
+
+@protocol QONRemoteConfigV2FetchRandom <NSObject>
+- (double)nextUnitInterval;
+@end
+
+@protocol QONRemoteConfigV2FetchScheduledTask <NSObject>
+- (void)cancel;
+@end
+
+@protocol QONRemoteConfigV2FetchScheduler <NSObject>
+- (id<QONRemoteConfigV2FetchScheduledTask>)scheduleAfterMilliseconds:(int64_t)delay
+                                                              action:(dispatch_block_t)action;
+@end
+
+@interface QONRemoteConfigV2FetchRequest : NSObject
+@property (nonatomic, copy, nullable, readonly) NSString *ifNoneMatch;
+- (instancetype)initWithIfNoneMatch:(nullable NSString *)ifNoneMatch;
+@end
+
+typedef NS_ENUM(NSInteger, QONRemoteConfigV2FetchResponseKind) {
+  QONRemoteConfigV2FetchResponseKindSuccess,
+  QONRemoteConfigV2FetchResponseKindNotModified,
+  QONRemoteConfigV2FetchResponseKindFailure,
+};
+
+@interface QONRemoteConfigV2FetchResponse : NSObject
+@property (nonatomic, assign, readonly) QONRemoteConfigV2FetchResponseKind kind;
+@property (nonatomic, copy, nullable, readonly) NSData *body;
+@property (nonatomic, copy, nullable, readonly) NSString *strongETag;
+@property (nonatomic, strong, nullable, readonly) NSNumber *statusCode;
+/** Transport-normalized Retry-After delay. The coordinator gives it precedence over jitter. */
+@property (nonatomic, strong, nullable, readonly) NSNumber *retryAfterMilliseconds;
++ (instancetype)successWithBody:(NSData *)body strongETag:(NSString *)strongETag;
++ (instancetype)notModifiedWithStrongETag:(nullable NSString *)strongETag;
++ (instancetype)failureWithStatusCode:(nullable NSNumber *)statusCode
+                retryAfterMilliseconds:(nullable NSNumber *)retryAfterMilliseconds;
+@end
+
+typedef void (^QONRemoteConfigV2FetchTransportCompletion)(QONRemoteConfigV2FetchResponse *response);
+
+@protocol QONRemoteConfigV2FetchTransport <NSObject>
+- (void)fetchRequest:(QONRemoteConfigV2FetchRequest *)request
+          completion:(QONRemoteConfigV2FetchTransportCompletion)completion;
+@end
+
+typedef NS_ENUM(NSInteger, QONRemoteConfigV2FetchResultKind) {
+  QONRemoteConfigV2FetchResultKindFetched,
+  QONRemoteConfigV2FetchResultKindNotModified,
+  QONRemoteConfigV2FetchResultKindFailed,
+  QONRemoteConfigV2FetchResultKindMinimumInterval,
+  QONRemoteConfigV2FetchResultKindBackoff,
+  QONRemoteConfigV2FetchResultKindTimedOut,
+  QONRemoteConfigV2FetchResultKindPolicyPersistenceFailed,
+  QONRemoteConfigV2FetchResultKindInvalidNotModified,
+  QONRemoteConfigV2FetchResultKindSuperseded,
+};
+
+typedef NS_ENUM(NSInteger, QONRemoteConfigV2FetchPolicyFailureReason) {
+  QONRemoteConfigV2FetchPolicyFailureReasonSave,
+  QONRemoteConfigV2FetchPolicyFailureReasonLoadFailed,
+  QONRemoteConfigV2FetchPolicyFailureReasonLoadCorrupt,
+};
+
+@interface QONRemoteConfigV2FetchResult : NSObject
+@property (nonatomic, assign, readonly) QONRemoteConfigV2FetchResultKind kind;
+@property (nonatomic, assign, readonly) QONRemoteConfigV2TransitionStatus transitionStatus;
+@property (nonatomic, strong, nullable, readonly) NSNumber *statusCode;
+@property (nonatomic, assign, readonly) int64_t nextAllowedAtMilliseconds;
+@property (nonatomic, strong, nullable, readonly) QONRemoteConfigSnapshot *snapshot;
+@property (nonatomic, strong, nullable, readonly) QONRemoteConfigV2FetchResult *underlyingResult;
+@property (nonatomic, assign, readonly) QONRemoteConfigV2FetchPolicyFailureReason policyFailureReason;
+@end
+
+typedef void (^QONRemoteConfigV2FetchCompletion)(QONRemoteConfigV2FetchResult *result);
+typedef void (^QONRemoteConfigV2FetchPolicyPersistenceFailureObserver)(
+    QONRemoteConfigV2FetchPolicyScope *scope,
+    QONRemoteConfigV2FetchPolicyFailureReason reason);
+
+@interface QONRemoteConfigV2FetchCoordinator : NSObject
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithCore:(id<QONRemoteConfigV2FetchCore>)core
+                    transport:(id<QONRemoteConfigV2FetchTransport>)transport
+                  policyStore:(id<QONRemoteConfigV2FetchPolicyStoring>)policyStore
+                        clock:(id<QONRemoteConfigV2FetchClock>)clock
+                       random:(id<QONRemoteConfigV2FetchRandom>)random
+                    scheduler:(id<QONRemoteConfigV2FetchScheduler>)scheduler
+                       policy:(QONRemoteConfigV2FetchPolicy *)policy;
+/** Internal deterministic-test seam. callbackExecutor must be serial. */
+- (instancetype)initWithCore:(id<QONRemoteConfigV2FetchCore>)core
+                    transport:(id<QONRemoteConfigV2FetchTransport>)transport
+                  policyStore:(id<QONRemoteConfigV2FetchPolicyStoring>)policyStore
+                        clock:(id<QONRemoteConfigV2FetchClock>)clock
+                       random:(id<QONRemoteConfigV2FetchRandom>)random
+                    scheduler:(id<QONRemoteConfigV2FetchScheduler>)scheduler
+                       policy:(QONRemoteConfigV2FetchPolicy *)policy
+             callbackExecutor:(dispatch_queue_t)callbackExecutor
+ policyPersistenceFailureObserver:(nullable QONRemoteConfigV2FetchPolicyPersistenceFailureObserver)observer
+    NS_DESIGNATED_INITIALIZER;
+- (void)transitionToBinding:(nullable QONRemoteConfigV2FetchBinding *)binding;
+- (void)fetchWithForceReason:(QONRemoteConfigV2FetchForceReason)forceReason
+                   completion:(QONRemoteConfigV2FetchCompletion)completion;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Qonversion/Qonversion/Main/QONRemoteConfigV2Manager/QONRemoteConfigV2FetchCoordinator.m
+++ b/Sources/Qonversion/Qonversion/Main/QONRemoteConfigV2Manager/QONRemoteConfigV2FetchCoordinator.m
@@ -1,0 +1,821 @@
+#import "QONRemoteConfigV2FetchCoordinator.h"
+#import <math.h>
+
+static NSInteger const QONRemoteConfigV2FetchMaximumFailureCount = 63;
+static double const QONRemoteConfigV2FetchFallbackJitter = 0.5;
+
+static int64_t QONRemoteConfigV2FetchSaturatingAdd(int64_t left, int64_t right) {
+  if (right > 0 && left > INT64_MAX - right) return INT64_MAX;
+  return left + right;
+}
+
+@implementation QONRemoteConfigV2ConditionalRequestValidator
+
+- (instancetype)initWithStrongETag:(NSString *)strongETag
+                          bodyDigest:(NSString *)bodyDigest
+            headAdmissionOrdinal:(int64_t)headAdmissionOrdinal {
+  if (strongETag.length == 0 || bodyDigest.length != 64 || headAdmissionOrdinal <= 0) return nil;
+  self = [super init];
+  if (self) {
+    _strongETag = [strongETag copy];
+    _bodyDigest = [bodyDigest copy];
+    _headAdmissionOrdinal = headAdmissionOrdinal;
+  }
+  return self;
+}
+
+- (id)copyWithZone:(NSZone *)zone { return self; }
+- (NSUInteger)hash {
+  return self.strongETag.hash ^ self.bodyDigest.hash ^ (NSUInteger)self.headAdmissionOrdinal;
+}
+- (BOOL)isEqual:(id)object {
+  if (self == object) return YES;
+  if (![object isKindOfClass:QONRemoteConfigV2ConditionalRequestValidator.class]) return NO;
+  QONRemoteConfigV2ConditionalRequestValidator *other = object;
+  return self.headAdmissionOrdinal == other.headAdmissionOrdinal &&
+      [self.strongETag isEqualToString:other.strongETag] &&
+      [self.bodyDigest isEqualToString:other.bodyDigest];
+}
+
+@end
+
+@implementation QONRemoteConfigV2FetchBinding
+
+- (instancetype)initWithScope:(QONRemoteConfigV2Scope *)scope
+                    expectation:(QONRemoteConfigV2EnvelopeExpectation *)expectation {
+  if (!scope || !expectation || ![scope.environment isEqualToString:expectation.environmentUID]) return nil;
+  self = [super init];
+  if (self) {
+    _scope = [scope copy];
+    _expectation = [expectation copy];
+  }
+  return self;
+}
+- (id)copyWithZone:(NSZone *)zone { return self; }
+
+@end
+
+@implementation QONRemoteConfigV2FetchPolicy
+
+- (instancetype)initWithMinimumFetchIntervalMilliseconds:(int64_t)minimumFetchIntervalMilliseconds
+                                       timeoutMilliseconds:(NSNumber *)timeoutMilliseconds
+                                initialBackoffMilliseconds:(int64_t)initialBackoffMilliseconds
+                                maximumBackoffMilliseconds:(int64_t)maximumBackoffMilliseconds {
+  if (minimumFetchIntervalMilliseconds < 0 ||
+      (timeoutMilliseconds && timeoutMilliseconds.longLongValue <= 0) ||
+      initialBackoffMilliseconds <= 0 || maximumBackoffMilliseconds < initialBackoffMilliseconds) return nil;
+  self = [super init];
+  if (self) {
+    _minimumFetchIntervalMilliseconds = minimumFetchIntervalMilliseconds;
+    _timeoutMilliseconds = [timeoutMilliseconds copy];
+    _initialBackoffMilliseconds = initialBackoffMilliseconds;
+    _maximumBackoffMilliseconds = maximumBackoffMilliseconds;
+  }
+  return self;
+}
+- (id)copyWithZone:(NSZone *)zone { return self; }
+
+@end
+
+@implementation QONRemoteConfigV2FetchPolicyState
+
+- (instancetype)initWithLastSuccessfulFetchAtMilliseconds:(int64_t)lastSuccessfulFetchAtMilliseconds
+                              consecutiveRetryableFailures:(NSInteger)consecutiveRetryableFailures
+                            nextAllowedFetchAtMilliseconds:(int64_t)nextAllowedFetchAtMilliseconds {
+  if (lastSuccessfulFetchAtMilliseconds < 0 || consecutiveRetryableFailures < 0 ||
+      consecutiveRetryableFailures > QONRemoteConfigV2FetchMaximumFailureCount ||
+      nextAllowedFetchAtMilliseconds < 0) return nil;
+  self = [super init];
+  if (self) {
+    _lastSuccessfulFetchAtMilliseconds = lastSuccessfulFetchAtMilliseconds;
+    _consecutiveRetryableFailures = consecutiveRetryableFailures;
+    _nextAllowedFetchAtMilliseconds = nextAllowedFetchAtMilliseconds;
+  }
+  return self;
+}
+- (id)copyWithZone:(NSZone *)zone { return self; }
+
+@end
+
+@implementation QONRemoteConfigV2FetchPolicyLoadResult
+
+- (instancetype)initWithStatus:(QONRemoteConfigV2FetchPolicyLoadStatus)status
+                          state:(QONRemoteConfigV2FetchPolicyState *)state {
+  if (status < QONRemoteConfigV2FetchPolicyLoadStatusFound ||
+      status > QONRemoteConfigV2FetchPolicyLoadStatusCorrupt) return nil;
+  if ((status == QONRemoteConfigV2FetchPolicyLoadStatusFound) != (state != nil)) return nil;
+  self = [super init];
+  if (self) {
+    _status = status;
+    _state = state;
+  }
+  return self;
+}
+
+@end
+
+@implementation QONRemoteConfigV2FetchPolicyScope
+
+- (instancetype)initWithProjectKey:(NSString *)projectKey environment:(NSString *)environment {
+  if (projectKey.length == 0 || environment.length == 0) return nil;
+  self = [super init];
+  if (self) {
+    _projectKey = [projectKey copy];
+    _environment = [environment copy];
+  }
+  return self;
+}
++ (instancetype)scopeFromRemoteConfigScope:(QONRemoteConfigV2Scope *)scope {
+  return [[self alloc] initWithProjectKey:scope.projectKey environment:scope.environment];
+}
+- (id)copyWithZone:(NSZone *)zone { return self; }
+- (NSUInteger)hash { return self.projectKey.hash ^ self.environment.hash; }
+- (BOOL)isEqual:(id)object {
+  if (self == object) return YES;
+  if (![object isKindOfClass:QONRemoteConfigV2FetchPolicyScope.class]) return NO;
+  QONRemoteConfigV2FetchPolicyScope *other = object;
+  return [self.projectKey isEqualToString:other.projectKey] &&
+      [self.environment isEqualToString:other.environment];
+}
+
+@end
+
+@implementation QONRemoteConfigV2FetchRequest
+- (instancetype)initWithIfNoneMatch:(NSString *)ifNoneMatch {
+  self = [super init];
+  if (self) _ifNoneMatch = [ifNoneMatch copy];
+  return self;
+}
+@end
+
+@interface QONRemoteConfigV2FetchResponse ()
+@property (nonatomic, assign, readwrite) QONRemoteConfigV2FetchResponseKind kind;
+@property (nonatomic, copy, nullable, readwrite) NSData *body;
+@property (nonatomic, copy, nullable, readwrite) NSString *strongETag;
+@property (nonatomic, strong, nullable, readwrite) NSNumber *statusCode;
+@property (nonatomic, strong, nullable, readwrite) NSNumber *retryAfterMilliseconds;
+@end
+
+@implementation QONRemoteConfigV2FetchResponse
+
++ (instancetype)successWithBody:(NSData *)body strongETag:(NSString *)strongETag {
+  QONRemoteConfigV2FetchResponse *response = [self new];
+  response.kind = QONRemoteConfigV2FetchResponseKindSuccess;
+  response.body = [body copy];
+  response.strongETag = [strongETag copy];
+  return response;
+}
++ (instancetype)notModifiedWithStrongETag:(NSString *)strongETag {
+  QONRemoteConfigV2FetchResponse *response = [self new];
+  response.kind = QONRemoteConfigV2FetchResponseKindNotModified;
+  response.strongETag = [strongETag copy];
+  return response;
+}
++ (instancetype)failureWithStatusCode:(NSNumber *)statusCode
+                retryAfterMilliseconds:(NSNumber *)retryAfterMilliseconds {
+  QONRemoteConfigV2FetchResponse *response = [self new];
+  response.kind = QONRemoteConfigV2FetchResponseKindFailure;
+  response.statusCode = [statusCode copy];
+  response.retryAfterMilliseconds = [retryAfterMilliseconds copy];
+  return response;
+}
+
+@end
+
+@interface QONRemoteConfigV2FetchResult ()
+@property (nonatomic, assign, readwrite) QONRemoteConfigV2FetchResultKind kind;
+@property (nonatomic, assign, readwrite) QONRemoteConfigV2TransitionStatus transitionStatus;
+@property (nonatomic, strong, nullable, readwrite) NSNumber *statusCode;
+@property (nonatomic, assign, readwrite) int64_t nextAllowedAtMilliseconds;
+@property (nonatomic, strong, nullable, readwrite) QONRemoteConfigSnapshot *snapshot;
+@property (nonatomic, strong, nullable, readwrite) QONRemoteConfigV2FetchResult *underlyingResult;
+@property (nonatomic, assign, readwrite) QONRemoteConfigV2FetchPolicyFailureReason policyFailureReason;
+@end
+
+@implementation QONRemoteConfigV2FetchResult
+@end
+
+@interface QONRemoteConfigV2FetchWaiter : NSObject
+@property (nonatomic, copy) QONRemoteConfigV2FetchCompletion callback;
+@property (nonatomic, strong, nullable) id<QONRemoteConfigV2FetchScheduledTask> timeoutTask;
+@property (nonatomic, assign) BOOL terminalClaimed;
+@end
+@implementation QONRemoteConfigV2FetchWaiter
+@end
+
+@interface QONRemoteConfigV2FetchOperation : NSObject
+@property (nonatomic, assign) NSUInteger generation;
+@property (nonatomic, strong) QONRemoteConfigV2FetchBinding *binding;
+@property (nonatomic, strong) QONRemoteConfigV2AdmissionToken *admission;
+@property (nonatomic, strong) NSMutableArray<QONRemoteConfigV2FetchWaiter *> *waiters;
+@property (nonatomic, strong, nullable) QONRemoteConfigV2ConditionalRequestValidator *validator;
+@property (nonatomic, assign) NSUInteger attemptOrdinal;
+@property (nonatomic, assign) BOOL didRetryWithoutETag;
+@property (nonatomic, strong) QONRemoteConfigV2FetchPolicyScope *policyScope;
+@end
+@implementation QONRemoteConfigV2FetchOperation
+@end
+
+@interface QONRemoteConfigV2FetchDelivery : NSObject
+@property (nonatomic, assign) NSUInteger generation;
+@property (nonatomic, strong) QONRemoteConfigV2FetchWaiter *waiter;
+@property (nonatomic, strong) QONRemoteConfigV2FetchResult *result;
+@end
+@implementation QONRemoteConfigV2FetchDelivery
+@end
+
+@interface QONRemoteConfigV2FetchDecision : NSObject
+@property (nonatomic, assign) NSUInteger generation;
+@property (nonatomic, strong, nullable) QONRemoteConfigV2FetchResult *immediateResult;
+@property (nonatomic, strong, nullable) QONRemoteConfigV2FetchOperation *operation;
+@property (nonatomic, strong, nullable) QONRemoteConfigV2FetchWaiter *waiter;
+@property (nonatomic, assign) BOOL shouldStart;
+@end
+@implementation QONRemoteConfigV2FetchDecision
+@end
+
+@interface QONRemoteConfigV2FetchOutcome : NSObject
+@property (nonatomic, strong) QONRemoteConfigV2FetchResult *result;
+@property (nonatomic, strong, nullable) QONRemoteConfigV2FetchPolicyState *nextPolicyState;
+@end
+@implementation QONRemoteConfigV2FetchOutcome
+@end
+
+typedef NS_ENUM(NSInteger, QONRemoteConfigV2NotModifiedDisposition) {
+  QONRemoteConfigV2NotModifiedDispositionNotApplicable,
+  QONRemoteConfigV2NotModifiedDispositionAccept,
+  QONRemoteConfigV2NotModifiedDispositionRetry,
+  QONRemoteConfigV2NotModifiedDispositionReject,
+  QONRemoteConfigV2NotModifiedDispositionIgnore,
+};
+
+@interface QONRemoteConfigV2FetchCoordinator ()
+@property (nonatomic, strong) id<QONRemoteConfigV2FetchCore> core;
+@property (nonatomic, strong) id<QONRemoteConfigV2FetchTransport> transport;
+@property (nonatomic, strong) id<QONRemoteConfigV2FetchPolicyStoring> policyStore;
+@property (nonatomic, strong) id<QONRemoteConfigV2FetchClock> clock;
+@property (nonatomic, strong) id<QONRemoteConfigV2FetchRandom> random;
+@property (nonatomic, strong) id<QONRemoteConfigV2FetchScheduler> scheduler;
+@property (nonatomic, strong) QONRemoteConfigV2FetchPolicy *policy;
+@property (nonatomic, strong) dispatch_queue_t stateQueue;
+@property (nonatomic, strong) dispatch_queue_t callbackExecutor;
+@property (nonatomic, strong) NSObject *callbackExecutorToken;
+@property (nonatomic, assign) BOOL callbackExecutorIsMain;
+@property (nonatomic, strong, nullable) QONRemoteConfigV2FetchPolicyPersistenceFailureObserver failureObserver;
+@property (nonatomic, strong, nullable) QONRemoteConfigV2FetchBinding *binding;
+@property (nonatomic, assign) NSUInteger operationGeneration;
+@property (nonatomic, strong, nullable) QONRemoteConfigV2FetchOperation *inFlight;
+@property (nonatomic, strong) QONRemoteConfigV2FetchPolicyState *policyState;
+@property (nonatomic, strong, nullable) NSNumber *pendingPolicyFailureReason;
+@property (nonatomic, strong) NSMutableArray<QONRemoteConfigV2FetchDelivery *> *pendingDeliveries;
+@property (nonatomic, assign) BOOL isDrainingDeliveries;
+@end
+
+@implementation QONRemoteConfigV2FetchCoordinator
+
+- (instancetype)initWithCore:(id<QONRemoteConfigV2FetchCore>)core
+                    transport:(id<QONRemoteConfigV2FetchTransport>)transport
+                  policyStore:(id<QONRemoteConfigV2FetchPolicyStoring>)policyStore
+                        clock:(id<QONRemoteConfigV2FetchClock>)clock
+                       random:(id<QONRemoteConfigV2FetchRandom>)random
+                    scheduler:(id<QONRemoteConfigV2FetchScheduler>)scheduler
+                       policy:(QONRemoteConfigV2FetchPolicy *)policy {
+  return [self initWithCore:core transport:transport policyStore:policyStore clock:clock
+      random:random scheduler:scheduler policy:policy callbackExecutor:dispatch_get_main_queue()
+      policyPersistenceFailureObserver:nil];
+}
+
+- (instancetype)initWithCore:(id<QONRemoteConfigV2FetchCore>)core
+                    transport:(id<QONRemoteConfigV2FetchTransport>)transport
+                  policyStore:(id<QONRemoteConfigV2FetchPolicyStoring>)policyStore
+                        clock:(id<QONRemoteConfigV2FetchClock>)clock
+                       random:(id<QONRemoteConfigV2FetchRandom>)random
+                    scheduler:(id<QONRemoteConfigV2FetchScheduler>)scheduler
+                       policy:(QONRemoteConfigV2FetchPolicy *)policy
+             callbackExecutor:(dispatch_queue_t)callbackExecutor
+ policyPersistenceFailureObserver:(QONRemoteConfigV2FetchPolicyPersistenceFailureObserver)observer {
+  if (!core || !transport || !policyStore || !clock || !random || !scheduler || !policy || !callbackExecutor) {
+    return nil;
+  }
+  self = [super init];
+  if (self) {
+    _core = core;
+    _transport = transport;
+    _policyStore = policyStore;
+    _clock = clock;
+    _random = random;
+    _scheduler = scheduler;
+    _policy = [policy copy];
+    _stateQueue = dispatch_queue_create("io.qonversion.remote-config-v2-fetch-state", DISPATCH_QUEUE_SERIAL);
+    _callbackExecutor = callbackExecutor;
+    _callbackExecutorToken = [NSObject new];
+    _callbackExecutorIsMain = callbackExecutor == dispatch_get_main_queue();
+    const void *key = (__bridge const void *)_callbackExecutorToken;
+    dispatch_queue_set_specific(callbackExecutor, key, (void *)key, NULL);
+    _failureObserver = [observer copy];
+    _policyState = [[QONRemoteConfigV2FetchPolicyState alloc]
+        initWithLastSuccessfulFetchAtMilliseconds:0 consecutiveRetryableFailures:0
+        nextAllowedFetchAtMilliseconds:0];
+    _pendingDeliveries = [NSMutableArray new];
+  }
+  return self;
+}
+
+- (QONRemoteConfigV2FetchResult *)resultWithKind:(QONRemoteConfigV2FetchResultKind)kind {
+  QONRemoteConfigV2FetchResult *result = [QONRemoteConfigV2FetchResult new];
+  result.kind = kind;
+  result.transitionStatus = QONRemoteConfigV2TransitionStatusRejected;
+  return result;
+}
+
+- (QONRemoteConfigV2FetchResult *)supersededResult {
+  return [self resultWithKind:QONRemoteConfigV2FetchResultKindSuperseded];
+}
+
+- (int64_t)nowMilliseconds {
+  @try { return MAX((int64_t)0, [self.clock nowMilliseconds]); }
+  @catch (__unused NSException *exception) { return 0; }
+}
+
+- (BOOL)savePolicyState:(QONRemoteConfigV2FetchPolicyState *)state
+                   scope:(QONRemoteConfigV2FetchPolicyScope *)scope {
+  @try { return [self.policyStore saveState:state forScope:scope]; }
+  @catch (__unused NSException *exception) { return NO; }
+}
+
+- (QONRemoteConfigV2FetchPolicyState *)conservativePolicyState {
+  int64_t now = [self nowMilliseconds];
+  return [[QONRemoteConfigV2FetchPolicyState alloc]
+      initWithLastSuccessfulFetchAtMilliseconds:0 consecutiveRetryableFailures:1
+      nextAllowedFetchAtMilliseconds:QONRemoteConfigV2FetchSaturatingAdd(
+          now, self.policy.initialBackoffMilliseconds)];
+}
+
+- (QONRemoteConfigV2FetchPolicyState *)loadPolicyState:(QONRemoteConfigV2FetchPolicyScope *)scope
+                                         failureReason:(NSNumber **)failureReason {
+  QONRemoteConfigV2FetchPolicyLoadResult *loadResult = nil;
+  @try { loadResult = [self.policyStore loadResultForScope:scope]; }
+  @catch (__unused NSException *exception) {
+    loadResult = [[QONRemoteConfigV2FetchPolicyLoadResult alloc]
+        initWithStatus:QONRemoteConfigV2FetchPolicyLoadStatusFailed state:nil];
+  }
+  if (!loadResult || loadResult.status == QONRemoteConfigV2FetchPolicyLoadStatusFailed) {
+    if (failureReason) *failureReason = @(QONRemoteConfigV2FetchPolicyFailureReasonLoadFailed);
+    return [self conservativePolicyState];
+  }
+  if (loadResult.status == QONRemoteConfigV2FetchPolicyLoadStatusCorrupt) {
+    if (failureReason) *failureReason = @(QONRemoteConfigV2FetchPolicyFailureReasonLoadCorrupt);
+    return [self conservativePolicyState];
+  }
+  if (loadResult.status == QONRemoteConfigV2FetchPolicyLoadStatusMissing) {
+    return [[QONRemoteConfigV2FetchPolicyState alloc]
+        initWithLastSuccessfulFetchAtMilliseconds:0 consecutiveRetryableFailures:0
+        nextAllowedFetchAtMilliseconds:0];
+  }
+  QONRemoteConfigV2FetchPolicyState *loaded = loadResult.state;
+  if (!loaded) {
+    if (failureReason) *failureReason = @(QONRemoteConfigV2FetchPolicyFailureReasonLoadCorrupt);
+    return [self conservativePolicyState];
+  }
+  int64_t latest = QONRemoteConfigV2FetchSaturatingAdd([self nowMilliseconds],
+      self.policy.maximumBackoffMilliseconds);
+  if (loaded.nextAllowedFetchAtMilliseconds <= latest) return loaded;
+  QONRemoteConfigV2FetchPolicyState *sanitized = [[QONRemoteConfigV2FetchPolicyState alloc]
+      initWithLastSuccessfulFetchAtMilliseconds:loaded.lastSuccessfulFetchAtMilliseconds
+      consecutiveRetryableFailures:loaded.consecutiveRetryableFailures
+      nextAllowedFetchAtMilliseconds:latest];
+  if (![self savePolicyState:sanitized scope:scope] && failureReason) {
+    *failureReason = @(QONRemoteConfigV2FetchPolicyFailureReasonSave);
+  }
+  return sanitized;
+}
+
+- (void)observePersistenceFailureForScope:(QONRemoteConfigV2FetchPolicyScope *)scope
+                                    reason:(QONRemoteConfigV2FetchPolicyFailureReason)reason {
+  QONRemoteConfigV2FetchPolicyPersistenceFailureObserver observer = self.failureObserver;
+  if (!observer) return;
+  @try { observer(scope, reason); }
+  @catch (__unused NSException *exception) {}
+}
+
+- (void)transitionToBinding:(QONRemoteConfigV2FetchBinding *)binding {
+  __block QONRemoteConfigV2FetchPolicyScope *failedScope = nil;
+  __block NSNumber *failureReason = nil;
+  QONRemoteConfigV2FetchBinding *bindingCopy = [binding copy];
+  dispatch_sync(self.stateQueue, ^{
+    self.operationGeneration = self.operationGeneration == NSUIntegerMax ? 0 : self.operationGeneration + 1;
+    self.binding = bindingCopy;
+    [self.core setScope:bindingCopy.scope];
+    if (bindingCopy) {
+      QONRemoteConfigV2FetchPolicyScope *scope = [QONRemoteConfigV2FetchPolicyScope
+          scopeFromRemoteConfigScope:bindingCopy.scope];
+      self.policyState = [self loadPolicyState:scope failureReason:&failureReason];
+      self.pendingPolicyFailureReason = failureReason;
+      if (failureReason) failedScope = scope;
+    } else {
+      self.policyState = [[QONRemoteConfigV2FetchPolicyState alloc]
+          initWithLastSuccessfulFetchAtMilliseconds:0 consecutiveRetryableFailures:0
+          nextAllowedFetchAtMilliseconds:0];
+      self.pendingPolicyFailureReason = nil;
+    }
+    QONRemoteConfigV2FetchOperation *operation = self.inFlight;
+    if (operation) {
+      for (QONRemoteConfigV2FetchWaiter *waiter in operation.waiters) {
+        if (waiter.terminalClaimed) continue;
+        waiter.terminalClaimed = YES;
+        QONRemoteConfigV2FetchDelivery *delivery = [QONRemoteConfigV2FetchDelivery new];
+        delivery.generation = operation.generation;
+        delivery.waiter = waiter;
+        delivery.result = [self supersededResult];
+        [self.pendingDeliveries addObject:delivery];
+      }
+      [operation.waiters removeAllObjects];
+    }
+    self.inFlight = nil;
+  });
+  if (failedScope) [self observePersistenceFailureForScope:failedScope
+      reason:failureReason.integerValue];
+  [self drainDeliveries];
+}
+
+- (QONRemoteConfigV2FetchResult *)gateResultForForceReason:(QONRemoteConfigV2FetchForceReason)forceReason
+                                                       now:(int64_t)now {
+  if (now < self.policyState.nextAllowedFetchAtMilliseconds) {
+    QONRemoteConfigV2FetchResult *result = [self resultWithKind:QONRemoteConfigV2FetchResultKindBackoff];
+    result.nextAllowedAtMilliseconds = self.policyState.nextAllowedFetchAtMilliseconds;
+    return result;
+  }
+  if (forceReason == QONRemoteConfigV2FetchForceReasonNone &&
+      self.policyState.lastSuccessfulFetchAtMilliseconds > 0 &&
+      now >= self.policyState.lastSuccessfulFetchAtMilliseconds) {
+    int64_t next = QONRemoteConfigV2FetchSaturatingAdd(
+        self.policyState.lastSuccessfulFetchAtMilliseconds,
+        self.policy.minimumFetchIntervalMilliseconds);
+    if (now < next) {
+      QONRemoteConfigV2FetchResult *result = [self resultWithKind:
+          QONRemoteConfigV2FetchResultKindMinimumInterval];
+      result.nextAllowedAtMilliseconds = next;
+      return result;
+    }
+  }
+  return nil;
+}
+
+- (QONRemoteConfigV2FetchWaiter *)waiterWithCallback:(QONRemoteConfigV2FetchCompletion)callback {
+  QONRemoteConfigV2FetchWaiter *waiter = [QONRemoteConfigV2FetchWaiter new];
+  waiter.callback = [callback copy];
+  return waiter;
+}
+
+- (QONRemoteConfigV2FetchDecision *)decisionForForceReason:(QONRemoteConfigV2FetchForceReason)forceReason
+                                                   callback:(QONRemoteConfigV2FetchCompletion)callback {
+  QONRemoteConfigV2FetchDecision *decision = [QONRemoteConfigV2FetchDecision new];
+  decision.generation = self.operationGeneration;
+  if (self.inFlight) {
+    BOOL hasLiveWaiter = NO;
+    for (QONRemoteConfigV2FetchWaiter *waiter in self.inFlight.waiters) {
+      if (!waiter.terminalClaimed) { hasLiveWaiter = YES; break; }
+    }
+    if (hasLiveWaiter) {
+      decision.operation = self.inFlight;
+      decision.waiter = [self waiterWithCallback:callback];
+      [self.inFlight.waiters addObject:decision.waiter];
+      return decision;
+    }
+    // The old HTTP continues, but the next caller owns a fresh admission token.
+    self.inFlight = nil;
+  }
+  if (!self.binding) {
+    decision.immediateResult = [self supersededResult];
+    return decision;
+  }
+  if (self.pendingPolicyFailureReason) {
+    QONRemoteConfigV2FetchResult *failure = [self resultWithKind:
+        QONRemoteConfigV2FetchResultKindPolicyPersistenceFailed];
+    failure.policyFailureReason = self.pendingPolicyFailureReason.integerValue;
+    failure.nextAllowedAtMilliseconds = self.policyState.nextAllowedFetchAtMilliseconds;
+    QONRemoteConfigV2FetchResult *backoff = [self resultWithKind:QONRemoteConfigV2FetchResultKindBackoff];
+    backoff.nextAllowedAtMilliseconds = self.policyState.nextAllowedFetchAtMilliseconds;
+    failure.underlyingResult = backoff;
+    self.pendingPolicyFailureReason = nil;
+    decision.immediateResult = failure;
+    return decision;
+  }
+  QONRemoteConfigV2FetchResult *gate = [self gateResultForForceReason:forceReason
+      now:[self nowMilliseconds]];
+  if (gate) {
+    decision.immediateResult = gate;
+    return decision;
+  }
+  QONRemoteConfigV2AdmissionToken *admission = [self.core beginAdmissionForScope:self.binding.scope
+      expectation:self.binding.expectation];
+  if (!admission) {
+    QONRemoteConfigV2FetchResult *failed = [self resultWithKind:QONRemoteConfigV2FetchResultKindFailed];
+    decision.immediateResult = failed;
+    return decision;
+  }
+  QONRemoteConfigV2FetchOperation *operation = [QONRemoteConfigV2FetchOperation new];
+  operation.generation = self.operationGeneration;
+  operation.binding = self.binding;
+  operation.admission = admission;
+  operation.waiters = [NSMutableArray new];
+  operation.validator = [self.core conditionalRequestValidator];
+  operation.policyScope = [QONRemoteConfigV2FetchPolicyScope
+      scopeFromRemoteConfigScope:self.binding.scope];
+  decision.operation = operation;
+  decision.waiter = [self waiterWithCallback:callback];
+  [operation.waiters addObject:decision.waiter];
+  decision.shouldStart = YES;
+  self.inFlight = operation;
+  return decision;
+}
+
+- (void)fetchWithForceReason:(QONRemoteConfigV2FetchForceReason)forceReason
+                   completion:(QONRemoteConfigV2FetchCompletion)completion {
+  if (!completion) return;
+  __block QONRemoteConfigV2FetchDecision *decision = nil;
+  dispatch_sync(self.stateQueue, ^{
+    decision = [self decisionForForceReason:forceReason callback:completion];
+  });
+  if (decision.immediateResult) {
+    dispatch_sync(self.stateQueue, ^{
+      QONRemoteConfigV2FetchWaiter *waiter = [self waiterWithCallback:completion];
+      waiter.terminalClaimed = YES;
+      QONRemoteConfigV2FetchDelivery *delivery = [QONRemoteConfigV2FetchDelivery new];
+      delivery.generation = decision.generation;
+      delivery.waiter = waiter;
+      delivery.result = decision.generation == self.operationGeneration
+          ? decision.immediateResult : [self supersededResult];
+      [self.pendingDeliveries addObject:delivery];
+    });
+    [self drainDeliveries];
+    return;
+  }
+  [self scheduleTimeoutForOperation:decision.operation waiter:decision.waiter];
+  if (decision.shouldStart) [self startAttempt:decision.operation];
+}
+
+- (void)scheduleTimeoutForOperation:(QONRemoteConfigV2FetchOperation *)operation
+                              waiter:(QONRemoteConfigV2FetchWaiter *)waiter {
+  NSNumber *timeout = self.policy.timeoutMilliseconds;
+  if (!timeout) return;
+  id<QONRemoteConfigV2FetchScheduledTask> task = nil;
+  @try {
+    __weak typeof(self) weakSelf = self;
+    task = [self.scheduler scheduleAfterMilliseconds:timeout.longLongValue action:^{
+      [weakSelf timeoutOperation:operation waiter:waiter];
+    }];
+  } @catch (__unused NSException *exception) { return; }
+  __block BOOL retained = NO;
+  dispatch_sync(self.stateQueue, ^{
+    if (self.inFlight == operation && operation.generation == self.operationGeneration &&
+        !waiter.terminalClaimed && [operation.waiters containsObject:waiter]) {
+      waiter.timeoutTask = task;
+      retained = YES;
+    }
+  });
+  if (!retained) [self cancelTaskSafely:task];
+}
+
+- (void)timeoutOperation:(QONRemoteConfigV2FetchOperation *)operation
+                   waiter:(QONRemoteConfigV2FetchWaiter *)waiter {
+  dispatch_sync(self.stateQueue, ^{
+    if (self.inFlight != operation || operation.generation != self.operationGeneration ||
+        waiter.terminalClaimed || ![operation.waiters containsObject:waiter]) return;
+    [operation.waiters removeObject:waiter];
+    waiter.terminalClaimed = YES;
+    QONRemoteConfigV2FetchResult *result = [self resultWithKind:QONRemoteConfigV2FetchResultKindTimedOut];
+    result.snapshot = [self.core currentSnapshot];
+    QONRemoteConfigV2FetchDelivery *delivery = [QONRemoteConfigV2FetchDelivery new];
+    delivery.generation = operation.generation;
+    delivery.waiter = waiter;
+    delivery.result = result;
+    [self.pendingDeliveries addObject:delivery];
+  });
+  [self drainDeliveries];
+}
+
+- (void)startAttempt:(QONRemoteConfigV2FetchOperation *)operation {
+  __block QONRemoteConfigV2FetchRequest *request = nil;
+  __block NSUInteger attempt = 0;
+  dispatch_sync(self.stateQueue, ^{
+    if (self.inFlight != operation || operation.generation != self.operationGeneration) return;
+    operation.attemptOrdinal += 1;
+    attempt = operation.attemptOrdinal;
+    request = [[QONRemoteConfigV2FetchRequest alloc]
+        initWithIfNoneMatch:operation.validator.strongETag];
+  });
+  if (!request) return;
+  @try {
+    __weak typeof(self) weakSelf = self;
+    [self.transport fetchRequest:request completion:^(QONRemoteConfigV2FetchResponse *response) {
+      QONRemoteConfigV2FetchResponse *safeResponse = response ?: [QONRemoteConfigV2FetchResponse
+          failureWithStatusCode:nil retryAfterMilliseconds:nil];
+      [weakSelf completeOperation:operation attempt:attempt response:safeResponse];
+    }];
+  } @catch (__unused NSException *exception) {
+    [self completeOperation:operation attempt:attempt response:[QONRemoteConfigV2FetchResponse
+        failureWithStatusCode:nil retryAfterMilliseconds:nil]];
+  }
+}
+
+- (BOOL)operationIsCurrent:(QONRemoteConfigV2FetchOperation *)operation attempt:(NSUInteger)attempt {
+  return self.inFlight == operation && operation.generation == self.operationGeneration &&
+      operation.attemptOrdinal == attempt;
+}
+
+- (QONRemoteConfigV2NotModifiedDisposition)notModifiedDispositionForOperation:
+    (QONRemoteConfigV2FetchOperation *)operation attempt:(NSUInteger)attempt
+    response:(QONRemoteConfigV2FetchResponse *)response {
+  if (![self operationIsCurrent:operation attempt:attempt]) {
+    return QONRemoteConfigV2NotModifiedDispositionIgnore;
+  }
+  QONRemoteConfigV2ConditionalRequestValidator *validator = operation.validator;
+  BOOL responseMatches = response.strongETag == nil ||
+      [response.strongETag isEqualToString:validator.strongETag];
+  if (validator && responseMatches && [self.core isConditionalRequestValidatorCurrent:validator]) {
+    return QONRemoteConfigV2NotModifiedDispositionAccept;
+  }
+  if (operation.didRetryWithoutETag) return QONRemoteConfigV2NotModifiedDispositionReject;
+  QONRemoteConfigV2AdmissionToken *admission = [self.core beginAdmissionForScope:operation.binding.scope
+      expectation:operation.binding.expectation];
+  if (!admission) return QONRemoteConfigV2NotModifiedDispositionReject;
+  operation.didRetryWithoutETag = YES;
+  operation.validator = nil;
+  operation.admission = admission;
+  return QONRemoteConfigV2NotModifiedDispositionRetry;
+}
+
+- (QONRemoteConfigV2FetchPolicyState *)retryableFailureStateFrom:
+    (QONRemoteConfigV2FetchPolicyState *)current response:(QONRemoteConfigV2FetchResponse *)response {
+  int64_t now = [self nowMilliseconds];
+  NSInteger failures = MIN(QONRemoteConfigV2FetchMaximumFailureCount,
+                           current.consecutiveRetryableFailures + 1);
+  int64_t cap = self.policy.initialBackoffMilliseconds;
+  for (NSInteger index = 1; index < failures; index++) {
+    if (cap >= self.policy.maximumBackoffMilliseconds / 2) {
+      cap = self.policy.maximumBackoffMilliseconds;
+      break;
+    }
+    cap = MIN(self.policy.maximumBackoffMilliseconds, cap * 2);
+  }
+  double random = QONRemoteConfigV2FetchFallbackJitter;
+  @try { random = [self.random nextUnitInterval]; }
+  @catch (__unused NSException *exception) {}
+  if (!isfinite(random) || random < 0 || random >= 1) random = QONRemoteConfigV2FetchFallbackJitter;
+  int64_t delay = MAX((int64_t)1, (int64_t)((double)cap * random));
+  if (response.retryAfterMilliseconds && response.retryAfterMilliseconds.longLongValue >= 0) {
+    delay = MIN(self.policy.maximumBackoffMilliseconds,
+                response.retryAfterMilliseconds.longLongValue);
+  }
+  return [[QONRemoteConfigV2FetchPolicyState alloc]
+      initWithLastSuccessfulFetchAtMilliseconds:current.lastSuccessfulFetchAtMilliseconds
+      consecutiveRetryableFailures:failures
+      nextAllowedFetchAtMilliseconds:QONRemoteConfigV2FetchSaturatingAdd(now, delay)];
+}
+
+- (BOOL)responseIsRetryable:(QONRemoteConfigV2FetchResponse *)response {
+  if (!response.statusCode) return YES;
+  NSInteger code = response.statusCode.integerValue;
+  return code == 429 || code < 400 || code > 499;
+}
+
+- (QONRemoteConfigV2FetchOutcome *)outcomeForOperation:(QONRemoteConfigV2FetchOperation *)operation
+                                              response:(QONRemoteConfigV2FetchResponse *)response
+                           notModifiedDisposition:(QONRemoteConfigV2NotModifiedDisposition)disposition
+                                          policyState:(QONRemoteConfigV2FetchPolicyState *)policyState {
+  QONRemoteConfigV2FetchOutcome *outcome = [QONRemoteConfigV2FetchOutcome new];
+  if (response.kind == QONRemoteConfigV2FetchResponseKindSuccess) {
+    QONRemoteConfigV2TransitionStatus status = response.body && response.strongETag
+        ? [self.core admitBody:response.body strongETag:response.strongETag
+            admissionToken:operation.admission]
+        : QONRemoteConfigV2TransitionStatusRejected;
+    QONRemoteConfigV2FetchResult *result = [self resultWithKind:QONRemoteConfigV2FetchResultKindFetched];
+    result.transitionStatus = status;
+    outcome.result = result;
+    if (status == QONRemoteConfigV2TransitionStatusAccepted ||
+        status == QONRemoteConfigV2TransitionStatusActivated) {
+      outcome.nextPolicyState = [[QONRemoteConfigV2FetchPolicyState alloc]
+          initWithLastSuccessfulFetchAtMilliseconds:[self nowMilliseconds]
+          consecutiveRetryableFailures:0 nextAllowedFetchAtMilliseconds:0];
+    }
+  } else if (response.kind == QONRemoteConfigV2FetchResponseKindNotModified) {
+    if (disposition == QONRemoteConfigV2NotModifiedDispositionAccept) {
+      outcome.result = [self resultWithKind:QONRemoteConfigV2FetchResultKindNotModified];
+      outcome.nextPolicyState = [[QONRemoteConfigV2FetchPolicyState alloc]
+          initWithLastSuccessfulFetchAtMilliseconds:[self nowMilliseconds]
+          consecutiveRetryableFailures:0 nextAllowedFetchAtMilliseconds:0];
+    } else {
+      outcome.result = [self resultWithKind:QONRemoteConfigV2FetchResultKindInvalidNotModified];
+    }
+  } else {
+    QONRemoteConfigV2FetchResult *result = [self resultWithKind:QONRemoteConfigV2FetchResultKindFailed];
+    result.statusCode = response.statusCode;
+    outcome.result = result;
+    if ([self responseIsRetryable:response]) {
+      outcome.nextPolicyState = [self retryableFailureStateFrom:policyState response:response];
+    }
+  }
+  return outcome;
+}
+
+- (void)completeOperation:(QONRemoteConfigV2FetchOperation *)operation
+                  attempt:(NSUInteger)attempt
+                 response:(QONRemoteConfigV2FetchResponse *)response {
+  __block QONRemoteConfigV2NotModifiedDisposition disposition =
+      QONRemoteConfigV2NotModifiedDispositionNotApplicable;
+  if (response.kind == QONRemoteConfigV2FetchResponseKindNotModified) {
+    dispatch_sync(self.stateQueue, ^{
+      disposition = [self notModifiedDispositionForOperation:operation attempt:attempt response:response];
+    });
+    if (disposition == QONRemoteConfigV2NotModifiedDispositionIgnore) return;
+    if (disposition == QONRemoteConfigV2NotModifiedDispositionRetry) {
+      [self startAttempt:operation];
+      return;
+    }
+  }
+  __block BOOL current = NO;
+  __block QONRemoteConfigV2FetchPolicyState *basePolicyState = nil;
+  dispatch_sync(self.stateQueue, ^{
+    current = [self operationIsCurrent:operation attempt:attempt];
+    basePolicyState = self.policyState;
+  });
+  if (!current) return;
+  QONRemoteConfigV2FetchOutcome *outcome = [self outcomeForOperation:operation response:response
+      notModifiedDisposition:disposition policyState:basePolicyState];
+  __block QONRemoteConfigV2FetchPolicyScope *persistenceFailedScope = nil;
+  dispatch_sync(self.stateQueue, ^{
+    if (![self operationIsCurrent:operation attempt:attempt]) return;
+    QONRemoteConfigV2FetchResult *terminal = outcome.result;
+    if (outcome.nextPolicyState) {
+      self.policyState = outcome.nextPolicyState;
+      if (![self savePolicyState:outcome.nextPolicyState scope:operation.policyScope]) {
+        persistenceFailedScope = operation.policyScope;
+        QONRemoteConfigV2FetchResult *wrapped = [self resultWithKind:
+            QONRemoteConfigV2FetchResultKindPolicyPersistenceFailed];
+        wrapped.policyFailureReason = QONRemoteConfigV2FetchPolicyFailureReasonSave;
+        wrapped.underlyingResult = outcome.result;
+        terminal = wrapped;
+      }
+    }
+    self.inFlight = nil;
+    for (QONRemoteConfigV2FetchWaiter *waiter in operation.waiters) {
+      if (waiter.terminalClaimed) continue;
+      waiter.terminalClaimed = YES;
+      QONRemoteConfigV2FetchDelivery *delivery = [QONRemoteConfigV2FetchDelivery new];
+      delivery.generation = operation.generation;
+      delivery.waiter = waiter;
+      delivery.result = terminal;
+      [self.pendingDeliveries addObject:delivery];
+    }
+    [operation.waiters removeAllObjects];
+  });
+  if (persistenceFailedScope) [self observePersistenceFailureForScope:persistenceFailedScope
+      reason:QONRemoteConfigV2FetchPolicyFailureReasonSave];
+  [self drainDeliveries];
+}
+
+- (BOOL)isOnCallbackExecutor {
+  if (self.callbackExecutorIsMain && NSThread.isMainThread) return YES;
+  const void *key = (__bridge const void *)self.callbackExecutorToken;
+  return dispatch_get_specific(key) == key;
+}
+
+- (void)cancelTaskSafely:(id<QONRemoteConfigV2FetchScheduledTask>)task {
+  if (!task) return;
+  @try { [task cancel]; }
+  @catch (__unused NSException *exception) {}
+}
+
+- (void)drainDeliveriesOnCallbackExecutor {
+  NSAssert([self isOnCallbackExecutor], @"Remote Config fetch callback executor must be serial");
+  if (self.isDrainingDeliveries) return;
+  self.isDrainingDeliveries = YES;
+  @try {
+    while (YES) {
+      __block QONRemoteConfigV2FetchDelivery *delivery = nil;
+      dispatch_sync(self.stateQueue, ^{
+        if (self.pendingDeliveries.count == 0) return;
+        delivery = self.pendingDeliveries.firstObject;
+        [self.pendingDeliveries removeObjectAtIndex:0];
+        if (delivery.generation != self.operationGeneration) delivery.result = [self supersededResult];
+      });
+      if (!delivery) return;
+      [self cancelTaskSafely:delivery.waiter.timeoutTask];
+      @try { delivery.waiter.callback(delivery.result); }
+      @catch (__unused NSException *exception) {}
+    }
+  } @finally {
+    self.isDrainingDeliveries = NO;
+  }
+}
+
+- (void)drainDeliveries {
+  if ([self isOnCallbackExecutor]) {
+    [self drainDeliveriesOnCallbackExecutor];
+  } else {
+    dispatch_async(self.callbackExecutor, ^{ [self drainDeliveriesOnCallbackExecutor]; });
+  }
+}
+
+@end

--- a/Sources/Qonversion/Qonversion/Main/QONRemoteConfigV2Manager/QONRemoteConfigV2Manager.m
+++ b/Sources/Qonversion/Qonversion/Main/QONRemoteConfigV2Manager/QONRemoteConfigV2Manager.m
@@ -1,5 +1,6 @@
 #import "QONRemoteConfigV2Manager.h"
 #import "QONRemoteConfigSnapshot+Protected.h"
+#import "QONRemoteConfigV2FetchCoordinator.h"
 #import "QONRemoteConfigV2Models.h"
 #import "QONRemoteConfigV2Store.h"
 
@@ -144,6 +145,30 @@
     }
   });
   return snapshot;
+}
+
+- (QONRemoteConfigV2ConditionalRequestValidator *)conditionalRequestValidatorForHeadLocked {
+  QONRemoteConfigV2Release *head = self.state.candidate ?: self.state.active;
+  if (!head.canonicalBody || head.strongETag.length != 66 || head.admissionOrdinal <= 0) return nil;
+  NSString *bodyDigest = [head.strongETag substringWithRange:NSMakeRange(1, 64)];
+  return [[QONRemoteConfigV2ConditionalRequestValidator alloc]
+      initWithStrongETag:head.strongETag bodyDigest:bodyDigest
+      headAdmissionOrdinal:head.admissionOrdinal];
+}
+
+- (QONRemoteConfigV2ConditionalRequestValidator *)conditionalRequestValidator {
+  __block QONRemoteConfigV2ConditionalRequestValidator *validator = nil;
+  dispatch_sync(self.stateQueue, ^{ validator = [self conditionalRequestValidatorForHeadLocked]; });
+  return validator;
+}
+
+- (BOOL)isConditionalRequestValidatorCurrent:(QONRemoteConfigV2ConditionalRequestValidator *)validator {
+  if (!validator) return NO;
+  __block BOOL current = NO;
+  dispatch_sync(self.stateQueue, ^{
+    current = [[self conditionalRequestValidatorForHeadLocked] isEqual:validator];
+  });
+  return current;
 }
 
 - (void)applyScopeLocked:(QONRemoteConfigV2Scope *)scope {


### PR DESCRIPTION
## Summary

Adds the internal/dark iOS Remote Config fetch coordinator on top of #756. It does not add a public URL, caller-supplied user ID, session token, or public SDK method.

- concurrent coalescing and configurable minimum interval
- timeout returns best Active/bundle while the transport continues and may persist Candidate
- orphan/zombie replacement without cancelling the old HTTP operation
- project+environment persisted capped exponential full-jitter backoff across identity changes
- exact current-canonical-head ETag and one unconditional retry for stale/missing local bytes
- scope/generation/admission fences and injected transport/clock/random/scheduler

## Fail-closed storage and incidents

Policy load distinguishes `Found`, `Missing`, `Failed` and `Corrupt`; the canonical payload has a scope-bound SHA-256 digest. Read failure/corruption is quarantined, never silently deleted or treated as missing, emits one bounded signal, and installs a conservative pre-network delay. Network/transport failures without HTTP status are retryable; only explicit non-429 4xx are non-retryable. Lifecycle force does not bypass incident backoff.

## Review fixes

Independent review found and this PR fixes nil-status failures skipping backoff and corrupt/load-failed policy state failing open after restart. Final re-review is CLEAN.

## Verification

- standalone Foundation harness: 16/16
- production Objective-C strict syntax: `-Wall -Wextra -Werror`
- hosted coordinator and manager test syntax green
- PBX `plutil -lint`
- git diff --check

Full XCTest runs in hosted Xcode CI.

## Deliberate remainder

Raw HTTP `Retry-After` parsing/normalization and real lifecycle/network wiring remain in the future transport/public adapter. Public serving remains closed until the identity-session and gateway boundaries are complete.