### PR TITLE
feat: guard remote config reads before activation

### DIFF
--- a/QonversionTests/Managers/QONRemoteConfigV2ManagerTests.m
+++ b/QonversionTests/Managers/QONRemoteConfigV2ManagerTests.m
@@ -20,12 +20,24 @@
 @property (nonatomic, assign) BOOL failWrites;
 @property (nonatomic, assign) BOOL throwOnWrite;
 @property (nonatomic, assign) NSUInteger readsToFail;
+@property (nonatomic, assign) NSUInteger readCount;
+@property (nonatomic, assign) NSUInteger writeCount;
 @property (nonatomic, copy, nullable) void (^writeObserver)(id object);
+@property (nonatomic, assign) BOOL blockNextWrite;
+@property (nonatomic, strong, nullable) dispatch_semaphore_t writeStarted;
+@property (nonatomic, strong, nullable) dispatch_semaphore_t releaseWrite;
 @end
 
 @implementation QONRemoteConfigFailingStorage
 - (instancetype)init { self = [super init]; if (self) _objects = [NSMutableDictionary new]; return self; }
 - (void)storeObject:(id)object forKey:(NSString *)key {
+  if (self.blockNextWrite) {
+    self.blockNextWrite = NO;
+    dispatch_semaphore_signal(self.writeStarted);
+    dispatch_semaphore_wait(self.releaseWrite,
+                            dispatch_time(DISPATCH_TIME_NOW, 3 * NSEC_PER_SEC));
+  }
+  self.writeCount += 1;
   if (self.throwOnWrite) @throw [NSException exceptionWithName:@"WriteFailure" reason:nil userInfo:nil];
   if (!self.failWrites) {
     self.objects[key] = object;
@@ -33,6 +45,7 @@
   }
 }
 - (id)loadObjectForKey:(NSString *)key {
+  self.readCount += 1;
   if (self.readsToFail > 0) {
     self.readsToFail -= 1;
     @throw [NSException exceptionWithName:@"ReadFailure" reason:nil userInfo:nil];
@@ -43,6 +56,40 @@
   completion([self loadObjectForKey:key]);
 }
 - (void)removeObjectForKey:(NSString *)key { [self.objects removeObjectForKey:key]; }
+@end
+
+@interface QONRemoteConfigV2TestScopePreloader : NSObject <QONRemoteConfigV2ScopePreloading>
+@property (nonatomic, strong) QONRemoteConfigV2ReadGuardPreloadResult *result;
+@property (nonatomic, strong) NSDictionary<NSString *, QONRemoteConfigV2ReadGuardPreloadResult *> *resultsByUserID;
+@property (nonatomic, weak) QONRemoteConfigV2Manager *manager;
+@property (nonatomic, copy) NSString *blockedUserID;
+@property (nonatomic, strong) dispatch_semaphore_t blockedCallStarted;
+@property (nonatomic, strong) dispatch_semaphore_t releaseBlockedCall;
+@property (nonatomic, assign) BOOL waitForSupersedingToken;
+@property (nonatomic, assign) BOOL observedMainThread;
+@end
+
+@implementation QONRemoteConfigV2TestScopePreloader
+- (QONRemoteConfigV2ReadGuardPreloadResult *)preloadResultForScope:
+    (QONRemoteConfigV2Scope *)scope {
+  self.observedMainThread = NSThread.isMainThread;
+  if ([scope.canonicalUserID isEqualToString:self.blockedUserID]) {
+    NSUUID *initialToken = [self.manager valueForKey:@"latestReadGuardPreloadToken"];
+    dispatch_semaphore_signal(self.blockedCallStarted);
+    if (self.waitForSupersedingToken) {
+      NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:2];
+      while (deadline.timeIntervalSinceNow > 0) {
+        NSUUID *token = [self.manager valueForKey:@"latestReadGuardPreloadToken"];
+        if (![token isEqual:initialToken]) break;
+        [NSThread sleepForTimeInterval:0.001];
+      }
+    } else {
+      dispatch_semaphore_wait(self.releaseBlockedCall,
+                              dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC));
+    }
+  }
+  return self.resultsByUserID[scope.canonicalUserID] ?: self.result;
+}
 @end
 
 @interface QONRemoteConfigBlockingEnvelopeDecoder : NSObject <QONRemoteConfigV2EnvelopeDecoding>
@@ -318,6 +365,37 @@
       initWithStore:[[QONRemoteConfigV2Store alloc] initWithLocalStorage:storage]
       fallbackRelease:nil fallbackProjectKey:nil fallbackEnvironment:nil
       envelopeDecoder:decoder callbackExecutor:callbackExecutor];
+}
+
+- (QONRemoteConfigV2Manager *)readGuardManagerWithStorage:(id<QNLocalStorage>)storage
+                                                preloader:(QONRemoteConfigV2TestScopePreloader *)preloader
+                                                     mode:(QONRemoteConfigV2ReadGuardBuildMode)mode
+                                        callbackExecutor:(dispatch_queue_t)callbackExecutor
+                                         assertionHandler:(QONRemoteConfigV2ReadGuardAssertionHandler)assertionHandler
+                                         telemetryHandler:(QONRemoteConfigV2ReadGuardTelemetryHandler)telemetryHandler {
+  return [[QONRemoteConfigV2Manager alloc]
+      initWithStore:[[QONRemoteConfigV2Store alloc] initWithLocalStorage:storage]
+      fallbackRelease:[self release:@"bundle" number:1 values:@{@"key": @"0"} immediate:NO]
+      fallbackProjectKey:@"project" fallbackEnvironment:@"production"
+      envelopeDecoder:[QONRemoteConfigV2EnvelopeParser new]
+      callbackExecutor:callbackExecutor readGuardBuildMode:mode
+      assertionHandler:assertionHandler telemetryHandler:telemetryHandler
+      scopePreloader:preloader];
+}
+
+- (QONRemoteConfigV2ReadGuardPreloadStatus)preloadReadGuardManager:
+    (QONRemoteConfigV2Manager *)manager scope:(QONRemoteConfigV2Scope *)scope {
+  __block QONRemoteConfigV2ReadGuardPreloadStatus status =
+      QONRemoteConfigV2ReadGuardPreloadStatusFailed;
+  dispatch_semaphore_t finished = dispatch_semaphore_create(0);
+  dispatch_async(dispatch_queue_create("io.qonversion.remote-config-v2-tests-preload",
+                                       DISPATCH_QUEUE_SERIAL), ^{
+    status = [manager preloadScopeForReadGuard:scope];
+    dispatch_semaphore_signal(finished);
+  });
+  XCTAssertEqual(dispatch_semaphore_wait(finished,
+      dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC)), 0L);
+  return status;
 }
 
 - (void)testAdmissionTokenIsManagerScopeExpectationAndLatestRequestBound {
@@ -1078,6 +1156,512 @@
   XCTAssertEqual(firstObserverInvocations, 1u);
   XCTAssertEqual(remainingObserverInvocations, 0u);
   XCTAssertEqualObjects(manager.currentSnapshot.releaseUID, @"");
+}
+
+- (void)testReadGuardReleaseFirstReadAtomicallyUsesPreparedCandidateWithoutGetterIO {
+  QONRemoteConfigFailingStorage *storage = [QONRemoteConfigFailingStorage new];
+  QONRemoteConfigV2TestScopePreloader *preloader = [QONRemoteConfigV2TestScopePreloader new];
+  QONRemoteConfigV2Release *candidate = [[self release:@"candidate" number:2
+      values:@{@"key": @"1"} immediate:NO] releaseBySettingAdmissionOrdinal:2];
+  QONRemoteConfigV2State *candidateState = [[QONRemoteConfigV2State alloc]
+      initWithCandidate:candidate active:nil previous:nil didActivate:NO
+      latestAdmissionOrdinal:2];
+  preloader.result = [[QONRemoteConfigV2ReadGuardPreloadResult alloc]
+      initWithStatus:QONRemoteConfigV2ReadGuardPreloadStatusFound state:candidateState];
+  dispatch_queue_t callbacks = dispatch_queue_create(
+      "io.qonversion.remote-config-v2-tests-read-guard", DISPATCH_QUEUE_SERIAL);
+  __block NSUInteger misuseEvents = 0, implicitEvents = 0;
+  QONRemoteConfigV2Manager *manager = [self readGuardManagerWithStorage:storage
+      preloader:preloader mode:QONRemoteConfigV2ReadGuardBuildModeRelease
+      callbackExecutor:callbacks assertionHandler:nil
+  telemetryHandler:^(QONRemoteConfigV2ReadGuardTelemetryEvent event) {
+    if (event == QONRemoteConfigV2ReadGuardTelemetryEventReadBeforeActivate) misuseEvents += 1;
+    if (event == QONRemoteConfigV2ReadGuardTelemetryEventImplicitActivation) implicitEvents += 1;
+  }];
+  QONRemoteConfigV2Scope *scope = [self scope:@"user"];
+
+  XCTAssertEqual([self preloadReadGuardManager:manager scope:scope],
+                 QONRemoteConfigV2ReadGuardPreloadStatusFound);
+  XCTAssertFalse(preloader.observedMainThread);
+  [manager setScope:scope];
+  NSUInteger readsBefore = storage.readCount;
+  NSUInteger writesBefore = storage.writeCount;
+  __block NSUInteger wrongSnapshots = 0;
+  dispatch_apply(64, dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0),
+      ^(__unused size_t index) {
+    if (![manager.currentSnapshot.releaseUID isEqualToString:@"candidate"]) {
+      @synchronized (manager) { wrongSnapshots += 1; }
+    }
+  });
+  dispatch_sync(callbacks, ^{});
+
+  XCTAssertEqual(wrongSnapshots, 0u);
+  XCTAssertEqual(misuseEvents, 1u);
+  XCTAssertEqual(implicitEvents, 1u);
+  XCTAssertEqual(storage.readCount, readsBefore);
+  XCTAssertEqual(storage.writeCount, writesBefore);
+
+  [manager acceptFetchedRelease:[self release:@"later" number:3
+      values:@{@"key": @"2"} immediate:NO] forScope:scope];
+  XCTAssertEqualObjects(manager.currentSnapshot.releaseUID, @"candidate");
+  XCTAssertEqualObjects(manager.lastFetchedSnapshot.releaseUID, @"later");
+  XCTAssertTrue([manager activate]);
+  XCTAssertEqualObjects(manager.currentSnapshot.releaseUID, @"later");
+}
+
+- (void)testReadGuardFetchAfterPreloadIsDurablyPreparedForFirstRead {
+  QONRemoteConfigFailingStorage *storage = [QONRemoteConfigFailingStorage new];
+  QONRemoteConfigV2Release *active = [[self release:@"active" number:1
+      values:@{@"key": @"1"} immediate:NO] releaseBySettingAdmissionOrdinal:1];
+  QONRemoteConfigV2State *activeState = [[QONRemoteConfigV2State alloc]
+      initWithCandidate:active active:active previous:nil didActivate:YES
+      latestAdmissionOrdinal:1];
+  QONRemoteConfigV2TestScopePreloader *preloader = [QONRemoteConfigV2TestScopePreloader new];
+  preloader.result = [[QONRemoteConfigV2ReadGuardPreloadResult alloc]
+      initWithStatus:QONRemoteConfigV2ReadGuardPreloadStatusFound state:activeState];
+  dispatch_queue_t callbacks = dispatch_queue_create(
+      "io.qonversion.remote-config-v2-tests-read-guard-post-preload-fetch",
+      DISPATCH_QUEUE_SERIAL);
+  __block NSUInteger implicitEvents = 0;
+  QONRemoteConfigV2Manager *manager = [self readGuardManagerWithStorage:storage
+      preloader:preloader mode:QONRemoteConfigV2ReadGuardBuildModeRelease
+      callbackExecutor:callbacks assertionHandler:nil
+      telemetryHandler:^(QONRemoteConfigV2ReadGuardTelemetryEvent event) {
+    if (event == QONRemoteConfigV2ReadGuardTelemetryEventImplicitActivation) {
+      implicitEvents += 1;
+    }
+  }];
+  QONRemoteConfigV2Scope *scope = [self scope:@"user"];
+  XCTAssertEqual([self preloadReadGuardManager:manager scope:scope],
+                 QONRemoteConfigV2ReadGuardPreloadStatusFound);
+  [manager setScope:scope];
+
+  [manager acceptFetchedRelease:[self release:@"fetched" number:2
+      values:@{@"key": @"2"} immediate:NO] forScope:scope];
+  QONRemoteConfigV2State *durable = nil;
+  QONRemoteConfigV2Store *store = [[QONRemoteConfigV2Store alloc] initWithLocalStorage:storage];
+  XCTAssertEqual([store loadStateForScope:scope state:&durable],
+                 QONRemoteConfigV2StoreLoadStatusFound);
+  XCTAssertEqualObjects(durable.active.releaseUID, @"fetched");
+  NSUInteger readsBefore = storage.readCount, writesBefore = storage.writeCount;
+
+  XCTAssertEqualObjects(manager.currentSnapshot.releaseUID, @"fetched");
+  XCTAssertEqual(storage.readCount, readsBefore);
+  XCTAssertEqual(storage.writeCount, writesBefore);
+  dispatch_sync(callbacks, ^{});
+  XCTAssertEqual(implicitEvents, 1u);
+  XCTAssertEqualObjects(manager.currentSnapshot.releaseUID, @"fetched");
+}
+
+- (void)testReadGuardRecoveredPersistenceRearmsButImmediateFetchDoesNotReportImplicitActivation {
+  QONRemoteConfigFailingStorage *storage = [QONRemoteConfigFailingStorage new];
+  storage.failWrites = YES;
+  QONRemoteConfigV2Release *active = [[self release:@"active" number:1
+      values:@{@"key": @"1"} immediate:NO] releaseBySettingAdmissionOrdinal:1];
+  QONRemoteConfigV2Release *pending = [[self release:@"pending" number:2
+      values:@{@"key": @"2"} immediate:NO] releaseBySettingAdmissionOrdinal:2];
+  QONRemoteConfigV2TestScopePreloader *preloader = [QONRemoteConfigV2TestScopePreloader new];
+  preloader.result = [[QONRemoteConfigV2ReadGuardPreloadResult alloc]
+      initWithStatus:QONRemoteConfigV2ReadGuardPreloadStatusFound
+      state:[[QONRemoteConfigV2State alloc] initWithCandidate:pending active:active
+          previous:nil didActivate:YES latestAdmissionOrdinal:2]];
+  dispatch_queue_t callbacks = dispatch_queue_create(
+      "io.qonversion.remote-config-v2-tests-read-guard-recovery", DISPATCH_QUEUE_SERIAL);
+  __block NSUInteger implicitEvents = 0;
+  QONRemoteConfigV2Manager *manager = [self readGuardManagerWithStorage:storage
+      preloader:preloader mode:QONRemoteConfigV2ReadGuardBuildModeRelease
+      callbackExecutor:callbacks assertionHandler:nil
+      telemetryHandler:^(QONRemoteConfigV2ReadGuardTelemetryEvent event) {
+    if (event == QONRemoteConfigV2ReadGuardTelemetryEventImplicitActivation) {
+      implicitEvents += 1;
+    }
+  }];
+  QONRemoteConfigV2Scope *scope = [self scope:@"user"];
+  XCTAssertEqual([self preloadReadGuardManager:manager scope:scope],
+                 QONRemoteConfigV2ReadGuardPreloadStatusPersistenceFailed);
+  [manager setScope:scope];
+  storage.failWrites = NO;
+  [manager acceptFetchedRelease:[self release:@"recovered" number:3
+      values:@{@"key": @"3"} immediate:NO] forScope:scope];
+
+  XCTAssertEqualObjects(manager.currentSnapshot.releaseUID, @"recovered");
+  dispatch_sync(callbacks, ^{});
+  XCTAssertEqual(implicitEvents, 1u);
+
+  QONRemoteConfigV2TestScopePreloader *missing = [QONRemoteConfigV2TestScopePreloader new];
+  missing.result = [[QONRemoteConfigV2ReadGuardPreloadResult alloc]
+      initWithStatus:QONRemoteConfigV2ReadGuardPreloadStatusMissing state:nil];
+  __block NSUInteger immediateImplicitEvents = 0;
+  QONRemoteConfigV2Manager *immediateManager = [self readGuardManagerWithStorage:
+      [QONRemoteConfigFailingStorage new] preloader:missing
+      mode:QONRemoteConfigV2ReadGuardBuildModeRelease callbackExecutor:callbacks
+      assertionHandler:nil telemetryHandler:^(QONRemoteConfigV2ReadGuardTelemetryEvent event) {
+    if (event == QONRemoteConfigV2ReadGuardTelemetryEventImplicitActivation) {
+      immediateImplicitEvents += 1;
+    }
+  }];
+  QONRemoteConfigV2Scope *immediateScope = [self scope:@"immediate-user"];
+  XCTAssertEqual([self preloadReadGuardManager:immediateManager scope:immediateScope],
+                 QONRemoteConfigV2ReadGuardPreloadStatusMissing);
+  [immediateManager setScope:immediateScope];
+  [immediateManager acceptFetchedRelease:[self release:@"immediate" number:2
+      values:@{@"key": @"4"} immediate:YES] forScope:immediateScope];
+  XCTAssertEqualObjects(immediateManager.currentSnapshot.releaseUID, @"immediate");
+  dispatch_sync(callbacks, ^{});
+  XCTAssertEqual(immediateImplicitEvents, 0u);
+}
+
+- (void)testReadGuardDebugAssertionIsExactAndExplicitActivationRemainsRequired {
+  QONRemoteConfigFailingStorage *storage = [QONRemoteConfigFailingStorage new];
+  QONRemoteConfigV2TestScopePreloader *preloader = [QONRemoteConfigV2TestScopePreloader new];
+  QONRemoteConfigV2Release *candidate = [[self release:@"candidate" number:2
+      values:@{@"key": @"1"} immediate:NO] releaseBySettingAdmissionOrdinal:2];
+  preloader.result = [[QONRemoteConfigV2ReadGuardPreloadResult alloc]
+      initWithStatus:QONRemoteConfigV2ReadGuardPreloadStatusFound
+      state:[[QONRemoteConfigV2State alloc] initWithCandidate:candidate active:nil
+          previous:nil didActivate:NO latestAdmissionOrdinal:2]];
+  __block NSMutableArray<NSString *> *assertions = [NSMutableArray new];
+  QONRemoteConfigV2Manager *manager = [self readGuardManagerWithStorage:storage
+      preloader:preloader mode:QONRemoteConfigV2ReadGuardBuildModeDebug
+      callbackExecutor:dispatch_get_main_queue()
+      assertionHandler:^(NSString *message) { [assertions addObject:message]; }
+      telemetryHandler:nil];
+  QONRemoteConfigV2Scope *scope = [self scope:@"user"];
+  XCTAssertEqual([self preloadReadGuardManager:manager scope:scope],
+                 QONRemoteConfigV2ReadGuardPreloadStatusFound);
+  [manager setScope:scope];
+
+  XCTAssertEqualObjects(manager.currentSnapshot.releaseUID, @"bundle");
+  XCTAssertEqualObjects(manager.currentSnapshot.releaseUID, @"bundle");
+  XCTAssertEqualObjects(assertions, (@[QONRemoteConfigV2ReadBeforeActivateAssertionMessage]));
+  XCTAssertEqualObjects(assertions.firstObject,
+      @"Remote Config read before activate(). Call activate() during SDK startup before reading currentSnapshot.");
+  XCTAssertTrue([manager activate]);
+  XCTAssertEqualObjects(manager.currentSnapshot.releaseUID, @"candidate");
+}
+
+- (void)testReadGuardCorruptScopeIsolationAndPreparationFailureFailSafe {
+  dispatch_queue_t callbacks = dispatch_queue_create(
+      "io.qonversion.remote-config-v2-tests-read-guard-fail-safe", DISPATCH_QUEUE_SERIAL);
+  QONRemoteConfigV2TestScopePreloader *corrupt = [QONRemoteConfigV2TestScopePreloader new];
+  corrupt.result = [[QONRemoteConfigV2ReadGuardPreloadResult alloc]
+      initWithStatus:QONRemoteConfigV2ReadGuardPreloadStatusCorrupt state:nil];
+  __block NSUInteger corruptEvents = 0, corruptMisuse = 0, corruptImplicit = 0;
+  QONRemoteConfigV2Manager *corruptManager = [self readGuardManagerWithStorage:
+      [QONRemoteConfigFailingStorage new] preloader:corrupt
+      mode:QONRemoteConfigV2ReadGuardBuildModeRelease callbackExecutor:callbacks
+      assertionHandler:nil telemetryHandler:^(QONRemoteConfigV2ReadGuardTelemetryEvent event) {
+    if (event == QONRemoteConfigV2ReadGuardTelemetryEventPreloadCorrupt) corruptEvents += 1;
+    if (event == QONRemoteConfigV2ReadGuardTelemetryEventReadBeforeActivate) corruptMisuse += 1;
+    if (event == QONRemoteConfigV2ReadGuardTelemetryEventImplicitActivation) corruptImplicit += 1;
+  }];
+  QONRemoteConfigV2Scope *scope = [self scope:@"user-a"];
+  XCTAssertEqual([self preloadReadGuardManager:corruptManager scope:scope],
+                 QONRemoteConfigV2ReadGuardPreloadStatusCorrupt);
+  [corruptManager setScope:scope];
+  XCTAssertEqualObjects(corruptManager.currentSnapshot.releaseUID, @"bundle");
+  QONRemoteConfigV2EnvelopeExpectation *sameEnvironmentExpectation =
+      [[QONRemoteConfigV2EnvelopeExpectation alloc] initWithProjectID:42
+          environmentUID:@"production"
+          contextFingerprint:[@"a" stringByPaddingToLength:64 withString:@"a"
+              startingAtIndex:0]];
+  XCTAssertNil([corruptManager beginAdmissionForScope:scope
+      expectation:sameEnvironmentExpectation]);
+  dispatch_sync(callbacks, ^{});
+  XCTAssertEqual(corruptEvents, 1u);
+  XCTAssertEqual(corruptMisuse, 1u);
+  XCTAssertEqual(corruptImplicit, 0u);
+
+  QONRemoteConfigFailingStorage *storage = [QONRemoteConfigFailingStorage new];
+  storage.failWrites = YES;
+  QONRemoteConfigV2Release *active = [[self release:@"active" number:1
+      values:@{@"key": @"1"} immediate:NO] releaseBySettingAdmissionOrdinal:1];
+  QONRemoteConfigV2Release *candidate = [[self release:@"candidate" number:2
+      values:@{@"key": @"2"} immediate:NO] releaseBySettingAdmissionOrdinal:2];
+  QONRemoteConfigV2TestScopePreloader *pending = [QONRemoteConfigV2TestScopePreloader new];
+  pending.result = [[QONRemoteConfigV2ReadGuardPreloadResult alloc]
+      initWithStatus:QONRemoteConfigV2ReadGuardPreloadStatusFound
+      state:[[QONRemoteConfigV2State alloc] initWithCandidate:candidate active:active
+          previous:nil didActivate:YES latestAdmissionOrdinal:2]];
+  __block NSUInteger persistenceEvents = 0, diskMisuse = 0, diskImplicit = 0;
+  QONRemoteConfigV2Manager *diskFullManager = [self readGuardManagerWithStorage:storage
+      preloader:pending mode:QONRemoteConfigV2ReadGuardBuildModeRelease
+      callbackExecutor:callbacks assertionHandler:nil
+      telemetryHandler:^(QONRemoteConfigV2ReadGuardTelemetryEvent event) {
+    if (event == QONRemoteConfigV2ReadGuardTelemetryEventPreparedActivationPersistenceFailed) {
+      persistenceEvents += 1;
+    }
+    if (event == QONRemoteConfigV2ReadGuardTelemetryEventReadBeforeActivate) diskMisuse += 1;
+    if (event == QONRemoteConfigV2ReadGuardTelemetryEventImplicitActivation) diskImplicit += 1;
+  }];
+  XCTAssertEqual([self preloadReadGuardManager:diskFullManager scope:scope],
+                 QONRemoteConfigV2ReadGuardPreloadStatusPersistenceFailed);
+  [diskFullManager setScope:scope];
+  XCTAssertEqualObjects(diskFullManager.currentSnapshot.releaseUID, @"active");
+  dispatch_sync(callbacks, ^{});
+  XCTAssertEqual(persistenceEvents, 1u);
+  XCTAssertEqual(diskMisuse, 1u);
+  XCTAssertEqual(diskImplicit, 0u);
+}
+
+- (void)testReadGuardNewestIssuedPreloadWinsAndScopeSelectionCancelsLateCompletion {
+  QONRemoteConfigV2Release *releaseA = [[self release:@"candidate-a" number:2
+      values:@{@"key": @"1"} immediate:NO] releaseBySettingAdmissionOrdinal:2];
+  QONRemoteConfigV2Release *releaseB = [[self release:@"candidate-b" number:3
+      values:@{@"key": @"2"} immediate:NO] releaseBySettingAdmissionOrdinal:3];
+  QONRemoteConfigV2TestScopePreloader *preloader = [QONRemoteConfigV2TestScopePreloader new];
+  preloader.blockedUserID = @"user-a";
+  preloader.blockedCallStarted = dispatch_semaphore_create(0);
+  preloader.releaseBlockedCall = dispatch_semaphore_create(0);
+  preloader.waitForSupersedingToken = YES;
+  preloader.resultsByUserID = @{
+    @"user-a": [[QONRemoteConfigV2ReadGuardPreloadResult alloc]
+        initWithStatus:QONRemoteConfigV2ReadGuardPreloadStatusFound
+        state:[[QONRemoteConfigV2State alloc] initWithCandidate:releaseA active:nil
+            previous:nil didActivate:NO latestAdmissionOrdinal:2]],
+    @"user-b": [[QONRemoteConfigV2ReadGuardPreloadResult alloc]
+        initWithStatus:QONRemoteConfigV2ReadGuardPreloadStatusFound
+        state:[[QONRemoteConfigV2State alloc] initWithCandidate:releaseB active:nil
+            previous:nil didActivate:NO latestAdmissionOrdinal:3]],
+  };
+  dispatch_queue_t callbacks = dispatch_queue_create(
+      "io.qonversion.remote-config-v2-tests-read-guard-race", DISPATCH_QUEUE_SERIAL);
+  QONRemoteConfigV2Manager *manager = [self readGuardManagerWithStorage:
+      [QONRemoteConfigFailingStorage new] preloader:preloader
+      mode:QONRemoteConfigV2ReadGuardBuildModeRelease callbackExecutor:callbacks
+      assertionHandler:nil telemetryHandler:nil];
+  preloader.manager = manager;
+  QONRemoteConfigV2Scope *userA = [self scope:@"user-a"];
+  QONRemoteConfigV2Scope *userB = [self scope:@"user-b"];
+  dispatch_semaphore_t aFinished = dispatch_semaphore_create(0);
+  dispatch_semaphore_t bFinished = dispatch_semaphore_create(0);
+  __block QONRemoteConfigV2ReadGuardPreloadStatus aStatus =
+      QONRemoteConfigV2ReadGuardPreloadStatusFound;
+  __block QONRemoteConfigV2ReadGuardPreloadStatus bStatus =
+      QONRemoteConfigV2ReadGuardPreloadStatusFailed;
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    aStatus = [manager preloadScopeForReadGuard:userA];
+    dispatch_semaphore_signal(aFinished);
+  });
+  XCTAssertEqual(dispatch_semaphore_wait(preloader.blockedCallStarted,
+      dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC)), 0L);
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    bStatus = [manager preloadScopeForReadGuard:userB];
+    dispatch_semaphore_signal(bFinished);
+  });
+  XCTAssertEqual(dispatch_semaphore_wait(aFinished,
+      dispatch_time(DISPATCH_TIME_NOW, 3 * NSEC_PER_SEC)), 0L);
+  XCTAssertEqual(dispatch_semaphore_wait(bFinished,
+      dispatch_time(DISPATCH_TIME_NOW, 3 * NSEC_PER_SEC)), 0L);
+  XCTAssertEqual(aStatus, QONRemoteConfigV2ReadGuardPreloadStatusFailed);
+  XCTAssertEqual(bStatus, QONRemoteConfigV2ReadGuardPreloadStatusFound);
+  [manager setScope:userB];
+  XCTAssertEqualObjects(manager.currentSnapshot.releaseUID, @"candidate-b");
+  [manager setScope:userA];
+  XCTAssertEqualObjects(manager.currentSnapshot.releaseUID, @"bundle");
+
+  QONRemoteConfigV2TestScopePreloader *late = [QONRemoteConfigV2TestScopePreloader new];
+  late.blockedUserID = @"user-a";
+  late.blockedCallStarted = dispatch_semaphore_create(0);
+  late.releaseBlockedCall = dispatch_semaphore_create(0);
+  late.result = preloader.resultsByUserID[@"user-a"];
+  QONRemoteConfigV2Manager *lateManager = [self readGuardManagerWithStorage:
+      [QONRemoteConfigFailingStorage new] preloader:late
+      mode:QONRemoteConfigV2ReadGuardBuildModeRelease callbackExecutor:callbacks
+      assertionHandler:nil telemetryHandler:nil];
+  late.manager = lateManager;
+  dispatch_semaphore_t lateFinished = dispatch_semaphore_create(0);
+  __block QONRemoteConfigV2ReadGuardPreloadStatus lateStatus =
+      QONRemoteConfigV2ReadGuardPreloadStatusFound;
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    lateStatus = [lateManager preloadScopeForReadGuard:userA];
+    dispatch_semaphore_signal(lateFinished);
+  });
+  XCTAssertEqual(dispatch_semaphore_wait(late.blockedCallStarted,
+      dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC)), 0L);
+  [lateManager setScope:userB];
+  dispatch_semaphore_signal(late.releaseBlockedCall);
+  XCTAssertEqual(dispatch_semaphore_wait(lateFinished,
+      dispatch_time(DISPATCH_TIME_NOW, 3 * NSEC_PER_SEC)), 0L);
+  XCTAssertEqual(lateStatus, QONRemoteConfigV2ReadGuardPreloadStatusFailed);
+  [lateManager setScope:userA];
+  XCTAssertEqualObjects(lateManager.currentSnapshot.releaseUID, @"bundle");
+}
+
+- (void)testReadGuardScopeSelectionWaitsForAdmittedSaveAndFencesLateWrites {
+  QONRemoteConfigFailingStorage *storage = [QONRemoteConfigFailingStorage new];
+  storage.blockNextWrite = YES;
+  storage.writeStarted = dispatch_semaphore_create(0);
+  storage.releaseWrite = dispatch_semaphore_create(0);
+  QONRemoteConfigV2Release *candidate = [[self release:@"candidate-a" number:2
+      values:@{@"key": @"1"} immediate:NO] releaseBySettingAdmissionOrdinal:2];
+  QONRemoteConfigV2TestScopePreloader *preloader = [QONRemoteConfigV2TestScopePreloader new];
+  preloader.result = [[QONRemoteConfigV2ReadGuardPreloadResult alloc]
+      initWithStatus:QONRemoteConfigV2ReadGuardPreloadStatusFound
+      state:[[QONRemoteConfigV2State alloc] initWithCandidate:candidate active:nil
+          previous:nil didActivate:NO latestAdmissionOrdinal:2]];
+  QONRemoteConfigV2Manager *manager = [self readGuardManagerWithStorage:storage
+      preloader:preloader mode:QONRemoteConfigV2ReadGuardBuildModeRelease
+      callbackExecutor:dispatch_queue_create(
+          "io.qonversion.remote-config-v2-tests-atomic-save", DISPATCH_QUEUE_SERIAL)
+      assertionHandler:nil telemetryHandler:nil];
+  QONRemoteConfigV2Scope *userA = [self scope:@"user-a"];
+  QONRemoteConfigV2Scope *userB = [self scope:@"user-b"];
+  dispatch_semaphore_t preloadFinished = dispatch_semaphore_create(0);
+  dispatch_semaphore_t scopeReturned = dispatch_semaphore_create(0);
+  __block QONRemoteConfigV2ReadGuardPreloadStatus status =
+      QONRemoteConfigV2ReadGuardPreloadStatusFailed;
+  __block NSUInteger writesAtScopeReturn = NSNotFound;
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    status = [manager preloadScopeForReadGuard:userA];
+    dispatch_semaphore_signal(preloadFinished);
+  });
+  XCTAssertEqual(dispatch_semaphore_wait(storage.writeStarted,
+      dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC)), 0L);
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    [manager setScope:userB];
+    writesAtScopeReturn = storage.writeCount;
+    dispatch_semaphore_signal(scopeReturned);
+  });
+
+  XCTAssertNotEqual(dispatch_semaphore_wait(scopeReturned,
+      dispatch_time(DISPATCH_TIME_NOW, 100 * NSEC_PER_MSEC)), 0L);
+  dispatch_semaphore_signal(storage.releaseWrite);
+  XCTAssertEqual(dispatch_semaphore_wait(preloadFinished,
+      dispatch_time(DISPATCH_TIME_NOW, 3 * NSEC_PER_SEC)), 0L);
+  XCTAssertEqual(dispatch_semaphore_wait(scopeReturned,
+      dispatch_time(DISPATCH_TIME_NOW, 3 * NSEC_PER_SEC)), 0L);
+  XCTAssertEqual(status, QONRemoteConfigV2ReadGuardPreloadStatusFound);
+  XCTAssertEqual(storage.writeCount, writesAtScopeReturn);
+  XCTAssertEqualObjects(manager.currentSnapshot.releaseUID, @"bundle");
+}
+
+- (void)testReadGuardImplicitActivationOpportunityIsOncePerSDKLifetime {
+  QONRemoteConfigFailingStorage *storage = [QONRemoteConfigFailingStorage new];
+  QONRemoteConfigV2TestScopePreloader *preloader = [QONRemoteConfigV2TestScopePreloader new];
+  dispatch_queue_t callbacks = dispatch_queue_create(
+      "io.qonversion.remote-config-v2-tests-lifetime", DISPATCH_QUEUE_SERIAL);
+  __block NSUInteger implicitEvents = 0;
+  QONRemoteConfigV2Manager *manager = [self readGuardManagerWithStorage:storage
+      preloader:preloader mode:QONRemoteConfigV2ReadGuardBuildModeRelease
+      callbackExecutor:callbacks assertionHandler:nil
+      telemetryHandler:^(QONRemoteConfigV2ReadGuardTelemetryEvent event) {
+    if (event == QONRemoteConfigV2ReadGuardTelemetryEventImplicitActivation) {
+      implicitEvents += 1;
+    }
+  }];
+  QONRemoteConfigV2Release *candidateA = [[self release:@"candidate-a" number:2
+      values:@{@"key": @"1"} immediate:NO] releaseBySettingAdmissionOrdinal:2];
+  preloader.result = [[QONRemoteConfigV2ReadGuardPreloadResult alloc]
+      initWithStatus:QONRemoteConfigV2ReadGuardPreloadStatusFound
+      state:[[QONRemoteConfigV2State alloc] initWithCandidate:candidateA active:nil
+          previous:nil didActivate:NO latestAdmissionOrdinal:2]];
+  QONRemoteConfigV2Scope *userA = [self scope:@"user-a"];
+  XCTAssertEqual([self preloadReadGuardManager:manager scope:userA],
+                 QONRemoteConfigV2ReadGuardPreloadStatusFound);
+  [manager setScope:userA];
+  XCTAssertEqualObjects(manager.currentSnapshot.releaseUID, @"candidate-a");
+  NSUInteger writesAfterFirstActivation = storage.writeCount;
+
+  QONRemoteConfigV2Release *candidateB = [[self release:@"candidate-b" number:3
+      values:@{@"key": @"2"} immediate:NO] releaseBySettingAdmissionOrdinal:3];
+  preloader.result = [[QONRemoteConfigV2ReadGuardPreloadResult alloc]
+      initWithStatus:QONRemoteConfigV2ReadGuardPreloadStatusFound
+      state:[[QONRemoteConfigV2State alloc] initWithCandidate:candidateB active:nil
+          previous:nil didActivate:NO latestAdmissionOrdinal:3]];
+  QONRemoteConfigV2Scope *userB = [self scope:@"user-b"];
+  XCTAssertEqual([self preloadReadGuardManager:manager scope:userB],
+                 QONRemoteConfigV2ReadGuardPreloadStatusFound);
+  XCTAssertEqual(storage.writeCount, writesAfterFirstActivation);
+  [manager setScope:userB];
+  XCTAssertEqualObjects(manager.currentSnapshot.releaseUID, @"bundle");
+  dispatch_sync(callbacks, ^{});
+  XCTAssertEqual(implicitEvents, 1u);
+
+  QONRemoteConfigFailingStorage *explicitStorage = [QONRemoteConfigFailingStorage new];
+  QONRemoteConfigV2TestScopePreloader *explicitPreloader =
+      [QONRemoteConfigV2TestScopePreloader new];
+  __block NSUInteger explicitImplicitEvents = 0;
+  QONRemoteConfigV2Manager *explicitManager = [self
+      readGuardManagerWithStorage:explicitStorage preloader:explicitPreloader
+      mode:QONRemoteConfigV2ReadGuardBuildModeRelease callbackExecutor:callbacks
+      assertionHandler:nil telemetryHandler:^(QONRemoteConfigV2ReadGuardTelemetryEvent event) {
+    if (event == QONRemoteConfigV2ReadGuardTelemetryEventImplicitActivation) {
+      explicitImplicitEvents += 1;
+    }
+  }];
+  explicitPreloader.result = [[QONRemoteConfigV2ReadGuardPreloadResult alloc]
+      initWithStatus:QONRemoteConfigV2ReadGuardPreloadStatusFound
+      state:[[QONRemoteConfigV2State alloc] initWithCandidate:candidateA active:nil
+          previous:nil didActivate:NO latestAdmissionOrdinal:2]];
+  XCTAssertEqual([self preloadReadGuardManager:explicitManager scope:userA],
+                 QONRemoteConfigV2ReadGuardPreloadStatusFound);
+  [explicitManager setScope:userA];
+  XCTAssertTrue([explicitManager activate]);
+  NSUInteger writesAfterExplicit = explicitStorage.writeCount;
+  explicitPreloader.result = preloader.result;
+  XCTAssertEqual([self preloadReadGuardManager:explicitManager scope:userB],
+                 QONRemoteConfigV2ReadGuardPreloadStatusFound);
+  XCTAssertEqual(explicitStorage.writeCount, writesAfterExplicit);
+  [explicitManager setScope:userB];
+  XCTAssertEqualObjects(explicitManager.currentSnapshot.releaseUID, @"bundle");
+  dispatch_sync(callbacks, ^{});
+  XCTAssertEqual(explicitImplicitEvents, 0u);
+}
+
+- (void)testReadGuardStaleReadDuringPreloadBindWindowCannotConsumeTargetOpportunity {
+  QONRemoteConfigFailingStorage *storage = [QONRemoteConfigFailingStorage new];
+  QONRemoteConfigV2Release *candidate = [[self release:@"candidate-a" number:2
+      values:@{@"key": @"1"} immediate:NO] releaseBySettingAdmissionOrdinal:2];
+  QONRemoteConfigV2TestScopePreloader *preloader = [QONRemoteConfigV2TestScopePreloader new];
+  preloader.blockedUserID = @"user-a";
+  preloader.blockedCallStarted = dispatch_semaphore_create(0);
+  preloader.releaseBlockedCall = dispatch_semaphore_create(0);
+  preloader.resultsByUserID = @{
+    @"user-a": [[QONRemoteConfigV2ReadGuardPreloadResult alloc]
+        initWithStatus:QONRemoteConfigV2ReadGuardPreloadStatusFound
+        state:[[QONRemoteConfigV2State alloc] initWithCandidate:candidate active:nil
+            previous:nil didActivate:NO latestAdmissionOrdinal:2]],
+    @"user-b": [[QONRemoteConfigV2ReadGuardPreloadResult alloc]
+        initWithStatus:QONRemoteConfigV2ReadGuardPreloadStatusMissing state:nil],
+  };
+  dispatch_queue_t callbacks = dispatch_queue_create(
+      "io.qonversion.remote-config-v2-tests-bind-window", DISPATCH_QUEUE_SERIAL);
+  __block NSUInteger implicitEvents = 0;
+  QONRemoteConfigV2Manager *manager = [self readGuardManagerWithStorage:storage
+      preloader:preloader mode:QONRemoteConfigV2ReadGuardBuildModeRelease
+      callbackExecutor:callbacks assertionHandler:nil
+      telemetryHandler:^(QONRemoteConfigV2ReadGuardTelemetryEvent event) {
+    if (event == QONRemoteConfigV2ReadGuardTelemetryEventImplicitActivation) {
+      implicitEvents += 1;
+    }
+  }];
+  preloader.manager = manager;
+  QONRemoteConfigV2Scope *userA = [self scope:@"user-a"];
+  QONRemoteConfigV2Scope *userB = [self scope:@"user-b"];
+  XCTAssertEqual([self preloadReadGuardManager:manager scope:userB],
+                 QONRemoteConfigV2ReadGuardPreloadStatusMissing);
+  [manager setScope:userB];
+
+  dispatch_semaphore_t preloadFinished = dispatch_semaphore_create(0);
+  __block QONRemoteConfigV2ReadGuardPreloadStatus status =
+      QONRemoteConfigV2ReadGuardPreloadStatusFailed;
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    status = [manager preloadScopeForReadGuard:userA];
+    dispatch_semaphore_signal(preloadFinished);
+  });
+  XCTAssertEqual(dispatch_semaphore_wait(preloader.blockedCallStarted,
+      dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC)), 0L);
+  XCTAssertEqualObjects(manager.currentSnapshot.releaseUID, @"bundle");
+  dispatch_semaphore_signal(preloader.releaseBlockedCall);
+  XCTAssertEqual(dispatch_semaphore_wait(preloadFinished,
+      dispatch_time(DISPATCH_TIME_NOW, 3 * NSEC_PER_SEC)), 0L);
+  XCTAssertEqual(status, QONRemoteConfigV2ReadGuardPreloadStatusFound);
+
+  [manager setScope:userA];
+  XCTAssertEqualObjects(manager.currentSnapshot.releaseUID, @"candidate-a");
+  dispatch_sync(callbacks, ^{});
+  XCTAssertEqual(implicitEvents, 1u);
 }
 
 @end

--- a/QonversionTests/Managers/QONRemoteConfigV2ReadGuardHarness.m
+++ b/QonversionTests/Managers/QONRemoteConfigV2ReadGuardHarness.m
@@ -1,0 +1,781 @@
+#import <Foundation/Foundation.h>
+#import "QNLocalStorage.h"
+#import "QONRemoteConfigV2Manager.h"
+#import "QONRemoteConfigV2Models.h"
+#import "QONRemoteConfigV2Store.h"
+
+id QONRemoteConfigPortableJSONObject(NSData *data, NSUInteger maximumBytes) {
+  if (!data || data.length == 0 || data.length > maximumBytes) return nil;
+  return [NSJSONSerialization JSONObjectWithData:data
+      options:NSJSONReadingFragmentsAllowed error:nil];
+}
+
+static NSUInteger failures = 0;
+#define QON_CHECK(condition, message) do { if (!(condition)) { \
+  failures += 1; fprintf(stderr, "FAIL: %s\n", message); } } while (0)
+
+@interface GuardStorage : NSObject <QNLocalStorage>
+@property(nonatomic, strong) NSMutableDictionary *objects;
+@property(nonatomic) NSUInteger reads;
+@property(nonatomic) NSUInteger writes;
+@property(nonatomic) BOOL failWrites;
+@end
+
+@implementation GuardStorage
+- (instancetype)init {
+  self = [super init];
+  if (self) _objects = [NSMutableDictionary new];
+  return self;
+}
+- (void)storeObject:(id)object forKey:(NSString *)key {
+  self.writes += 1;
+  if (!self.failWrites) self.objects[key] = object;
+}
+- (id)loadObjectForKey:(NSString *)key {
+  self.reads += 1;
+  return self.objects[key];
+}
+- (void)loadObjectForKey:(NSString *)key withCompletion:(void (^)(id))completion {
+  completion([self loadObjectForKey:key]);
+}
+- (void)removeObjectForKey:(NSString *)key { [self.objects removeObjectForKey:key]; }
+@end
+
+@interface GuardBlockingStorage : GuardStorage
+@property(nonatomic) BOOL blockNextWrite;
+@property(nonatomic, strong) dispatch_semaphore_t writeStarted;
+@property(nonatomic, strong) dispatch_semaphore_t releaseWrite;
+@end
+
+@implementation GuardBlockingStorage
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    _writeStarted = dispatch_semaphore_create(0);
+    _releaseWrite = dispatch_semaphore_create(0);
+  }
+  return self;
+}
+- (void)storeObject:(id)object forKey:(NSString *)key {
+  if (self.blockNextWrite) {
+    self.blockNextWrite = NO;
+    dispatch_semaphore_signal(self.writeStarted);
+    dispatch_semaphore_wait(self.releaseWrite,
+                            dispatch_time(DISPATCH_TIME_NOW, 3 * NSEC_PER_SEC));
+  }
+  [super storeObject:object forKey:key];
+}
+@end
+
+@interface GuardPreloader : NSObject <QONRemoteConfigV2ScopePreloading>
+@property(nonatomic, strong) QONRemoteConfigV2ReadGuardPreloadResult *result;
+@property(nonatomic) NSUInteger calls;
+@property(nonatomic) BOOL observedMainThread;
+@end
+
+@implementation GuardPreloader
+- (QONRemoteConfigV2ReadGuardPreloadResult *)preloadResultForScope:
+    (__unused QONRemoteConfigV2Scope *)scope {
+  self.calls += 1;
+  self.observedMainThread = NSThread.isMainThread;
+  return self.result;
+}
+@end
+
+@interface GuardAdversarialPreloader : NSObject <QONRemoteConfigV2ScopePreloading>
+@property(nonatomic, weak) QONRemoteConfigV2Manager *manager;
+@property(nonatomic, strong) QONRemoteConfigV2ReadGuardPreloadResult *resultA;
+@property(nonatomic, strong) QONRemoteConfigV2ReadGuardPreloadResult *resultB;
+@property(nonatomic, strong) dispatch_semaphore_t firstStarted;
+@property(nonatomic, strong) dispatch_semaphore_t releaseFirst;
+@property(nonatomic) BOOL waitForSupersedingToken;
+@end
+
+@implementation GuardAdversarialPreloader
+- (QONRemoteConfigV2ReadGuardPreloadResult *)preloadResultForScope:
+    (QONRemoteConfigV2Scope *)scope {
+  if (![scope.canonicalUserID isEqualToString:@"user-a"]) return self.resultB;
+  NSUUID *initialToken = [self.manager valueForKey:@"latestReadGuardPreloadToken"];
+  dispatch_semaphore_signal(self.firstStarted);
+  if (self.waitForSupersedingToken) {
+    NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:2];
+    while (deadline.timeIntervalSinceNow > 0) {
+      NSUUID *token = [self.manager valueForKey:@"latestReadGuardPreloadToken"];
+      if (![token isEqual:initialToken]) break;
+      [NSThread sleepForTimeInterval:0.001];
+    }
+  } else {
+    dispatch_semaphore_wait(self.releaseFirst,
+                            dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC));
+  }
+  return self.resultA;
+}
+@end
+
+static QONRemoteConfigV2Scope *Scope(NSString *user) {
+  return [[QONRemoteConfigV2Scope alloc] initWithProjectKey:@"project"
+      environment:@"production" canonicalUserID:user];
+}
+
+static QONRemoteConfigV2Release *Release(NSString *uid, NSInteger number, NSString *raw) {
+  NSData *data = [raw dataUsingEncoding:NSUTF8StringEncoding];
+  QONRemoteConfigV2Entry *entry = [[QONRemoteConfigV2Entry alloc]
+      initWithKey:@"key" rawData:data variationUID:[uid stringByAppendingString:@"-key"]
+      applyPolicy:QONRemoteConfigApplyPolicyOnNextActivate metadata:@{}];
+  return [[QONRemoteConfigV2Release alloc] initWithReleaseUID:uid releaseNumber:number
+      manifestContentHash:[[NSString stringWithFormat:@"%lx", (long)(number % 16)]
+          stringByPaddingToLength:64 withString:@"a" startingAtIndex:0]
+      entries:@{@"key": entry}];
+}
+
+static QONRemoteConfigV2Release *ImmediateRelease(
+    NSString *uid, NSInteger number, NSString *raw) {
+  NSData *data = [raw dataUsingEncoding:NSUTF8StringEncoding];
+  QONRemoteConfigV2Entry *entry = [[QONRemoteConfigV2Entry alloc]
+      initWithKey:@"key" rawData:data variationUID:[uid stringByAppendingString:@"-key"]
+      applyPolicy:QONRemoteConfigApplyPolicyImmediate metadata:@{}];
+  return [[QONRemoteConfigV2Release alloc] initWithReleaseUID:uid releaseNumber:number
+      manifestContentHash:[[NSString stringWithFormat:@"%lx", (long)(number % 16)]
+          stringByPaddingToLength:64 withString:@"a" startingAtIndex:0]
+      entries:@{@"key": entry}];
+}
+
+static QONRemoteConfigV2State *CandidateState(NSString *uid, NSInteger number) {
+  QONRemoteConfigV2Release *candidate = [Release(uid, number, @"1")
+      releaseBySettingAdmissionOrdinal:number];
+  return [[QONRemoteConfigV2State alloc] initWithCandidate:candidate
+      active:nil previous:nil didActivate:NO latestAdmissionOrdinal:number];
+}
+
+static QONRemoteConfigV2State *PendingState(void) {
+  QONRemoteConfigV2Release *active = [Release(@"active", 1, @"1")
+      releaseBySettingAdmissionOrdinal:1];
+  QONRemoteConfigV2Release *candidate = [Release(@"candidate", 2, @"2")
+      releaseBySettingAdmissionOrdinal:2];
+  return [[QONRemoteConfigV2State alloc] initWithCandidate:candidate active:active
+      previous:nil didActivate:YES latestAdmissionOrdinal:2];
+}
+
+static QONRemoteConfigV2ReadGuardPreloadResult *PreloadResult(
+    QONRemoteConfigV2ReadGuardPreloadStatus status, QONRemoteConfigV2State *state) {
+  return [[QONRemoteConfigV2ReadGuardPreloadResult alloc] initWithStatus:status state:state];
+}
+
+static QONRemoteConfigV2Manager *Manager(GuardStorage *storage,
+    id<QONRemoteConfigV2ScopePreloading> preloader,
+    QONRemoteConfigV2ReadGuardBuildMode mode, dispatch_queue_t callbacks,
+    QONRemoteConfigV2ReadGuardAssertionHandler assertion,
+    QONRemoteConfigV2ReadGuardTelemetryHandler telemetry) {
+  return [[QONRemoteConfigV2Manager alloc]
+      initWithStore:[[QONRemoteConfigV2Store alloc] initWithLocalStorage:storage]
+      fallbackRelease:Release(@"bundle", 1, @"0")
+      fallbackProjectKey:@"project" fallbackEnvironment:@"production"
+      envelopeDecoder:[QONRemoteConfigV2EnvelopeParser new]
+      callbackExecutor:callbacks readGuardBuildMode:mode
+      assertionHandler:assertion telemetryHandler:telemetry scopePreloader:preloader];
+}
+
+static QONRemoteConfigV2ReadGuardPreloadStatus PreloadOffMain(
+    QONRemoteConfigV2Manager *manager, QONRemoteConfigV2Scope *scope) {
+  __block QONRemoteConfigV2ReadGuardPreloadStatus status =
+      QONRemoteConfigV2ReadGuardPreloadStatusFailed;
+  dispatch_semaphore_t finished = dispatch_semaphore_create(0);
+  dispatch_async(dispatch_queue_create("read.guard.preload", DISPATCH_QUEUE_SERIAL), ^{
+    status = [manager preloadScopeForReadGuard:scope];
+    dispatch_semaphore_signal(finished);
+  });
+  dispatch_semaphore_wait(finished, DISPATCH_TIME_FOREVER);
+  return status;
+}
+
+static void Drain(dispatch_queue_t callbacks) { dispatch_sync(callbacks, ^{}); }
+
+static void TestReleaseFirstReadUsesDurablyPreparedCandidateOnlyOnce(void) {
+  GuardStorage *storage = [GuardStorage new];
+  GuardPreloader *preloader = [GuardPreloader new];
+  preloader.result = PreloadResult(QONRemoteConfigV2ReadGuardPreloadStatusFound,
+                                   CandidateState(@"candidate", 2));
+  dispatch_queue_t callbacks = dispatch_queue_create("read.guard.release", DISPATCH_QUEUE_SERIAL);
+  __block NSUInteger misuse = 0, implicitActivations = 0;
+  QONRemoteConfigV2Manager *manager = Manager(storage, preloader,
+      QONRemoteConfigV2ReadGuardBuildModeRelease, callbacks, nil,
+      ^(QONRemoteConfigV2ReadGuardTelemetryEvent event) {
+    if (event == QONRemoteConfigV2ReadGuardTelemetryEventReadBeforeActivate) misuse += 1;
+    if (event == QONRemoteConfigV2ReadGuardTelemetryEventImplicitActivation) {
+      implicitActivations += 1;
+    }
+  });
+  QONRemoteConfigV2Scope *scope = Scope(@"user");
+
+  QON_CHECK(PreloadOffMain(manager, scope) == QONRemoteConfigV2ReadGuardPreloadStatusFound,
+      "valid candidate preload must prepare successfully");
+  QON_CHECK(!preloader.observedMainThread, "preloader must run off main before readiness");
+  [manager setScope:scope];
+  NSUInteger readsBefore = storage.reads, writesBefore = storage.writes;
+  QONRemoteConfigSnapshot *first = manager.currentSnapshot;
+  QONRemoteConfigSnapshot *second = manager.currentSnapshot;
+  Drain(callbacks);
+
+  QON_CHECK([first.releaseUID isEqualToString:@"candidate"] &&
+      [second.releaseUID isEqualToString:@"candidate"],
+      "release first read must expose the durably prepared candidate");
+  QON_CHECK(storage.reads == readsBefore && storage.writes == writesBefore,
+      "currentSnapshot getter must perform no storage I/O");
+  QON_CHECK(misuse == 1 && implicitActivations == 1,
+      "release misuse and confirmed implicit activation must each be emitted once");
+
+  [manager acceptFetchedRelease:Release(@"later", 3, @"2") forScope:scope];
+  QON_CHECK([manager.currentSnapshot.releaseUID isEqualToString:@"candidate"],
+      "later reads must never implicitly activate a later candidate");
+  QON_CHECK([manager.lastFetchedSnapshot.releaseUID isEqualToString:@"later"],
+      "later candidate must remain fetched until explicit activation");
+}
+
+static void TestFetchAfterPreloadRefreshesDurableFirstReadPreparation(void) {
+  GuardStorage *storage = [GuardStorage new];
+  GuardPreloader *preloader = [GuardPreloader new];
+  preloader.result = PreloadResult(QONRemoteConfigV2ReadGuardPreloadStatusFound,
+                                   CandidateState(@"preloaded", 1));
+  dispatch_queue_t callbacks = dispatch_queue_create(
+      "read.guard.fetch-after-preload", DISPATCH_QUEUE_SERIAL);
+  __block NSUInteger implicit = 0;
+  QONRemoteConfigV2Manager *manager = Manager(storage, preloader,
+      QONRemoteConfigV2ReadGuardBuildModeRelease, callbacks, nil,
+      ^(QONRemoteConfigV2ReadGuardTelemetryEvent event) {
+    if (event == QONRemoteConfigV2ReadGuardTelemetryEventImplicitActivation) implicit += 1;
+  });
+  QONRemoteConfigV2Scope *scope = Scope(@"user");
+  PreloadOffMain(manager, scope);
+  [manager setScope:scope];
+  [manager acceptFetchedRelease:Release(@"fetched", 2, @"2") forScope:scope];
+
+  QONRemoteConfigV2State *durable = nil;
+  QONRemoteConfigV2Store *store = [[QONRemoteConfigV2Store alloc] initWithLocalStorage:storage];
+  QON_CHECK([store loadStateForScope:scope state:&durable] ==
+      QONRemoteConfigV2StoreLoadStatusFound &&
+      [durable.active.releaseUID isEqualToString:@"fetched"],
+      "a post-preload fetch must durably refresh the prepared Active before success");
+  NSUInteger readsBefore = storage.reads, writesBefore = storage.writes;
+  QON_CHECK([manager.currentSnapshot.releaseUID isEqualToString:@"fetched"],
+      "first current must activate the newest post-preload Candidate");
+  QON_CHECK(storage.reads == readsBefore && storage.writes == writesBefore,
+      "post-preload first current must remain memory-only");
+  Drain(callbacks);
+  QON_CHECK(implicit == 1, "the refreshed first-read activation must be observable once");
+}
+
+static void TestPersistenceRecoveryRearmsAndImmediateDoesNotReportImplicit(void) {
+  GuardStorage *storage = [GuardStorage new];
+  storage.failWrites = YES;
+  GuardPreloader *preloader = [GuardPreloader new];
+  preloader.result = PreloadResult(QONRemoteConfigV2ReadGuardPreloadStatusFound,
+                                   PendingState());
+  dispatch_queue_t callbacks = dispatch_queue_create(
+      "read.guard.persistence-recovery", DISPATCH_QUEUE_SERIAL);
+  __block NSUInteger implicit = 0;
+  QONRemoteConfigV2Manager *manager = Manager(storage, preloader,
+      QONRemoteConfigV2ReadGuardBuildModeRelease, callbacks, nil,
+      ^(QONRemoteConfigV2ReadGuardTelemetryEvent event) {
+    if (event == QONRemoteConfigV2ReadGuardTelemetryEventImplicitActivation) implicit += 1;
+  });
+  QONRemoteConfigV2Scope *scope = Scope(@"user");
+  QON_CHECK(PreloadOffMain(manager, scope) ==
+      QONRemoteConfigV2ReadGuardPreloadStatusPersistenceFailed,
+      "the initial prepared write must fail for the recovery scenario");
+  [manager setScope:scope];
+  storage.failWrites = NO;
+  [manager acceptFetchedRelease:Release(@"recovered", 3, @"3") forScope:scope];
+  QON_CHECK([manager.currentSnapshot.releaseUID isEqualToString:@"recovered"],
+      "a successful later fetch must re-arm first-read activation after persistence recovery");
+  Drain(callbacks);
+  QON_CHECK(implicit == 1, "recovered first-read activation must be reported once");
+
+  GuardPreloader *missing = [GuardPreloader new];
+  missing.result = PreloadResult(QONRemoteConfigV2ReadGuardPreloadStatusMissing, nil);
+  __block NSUInteger immediateImplicit = 0;
+  QONRemoteConfigV2Manager *immediateManager = Manager([GuardStorage new], missing,
+      QONRemoteConfigV2ReadGuardBuildModeRelease, callbacks, nil,
+      ^(QONRemoteConfigV2ReadGuardTelemetryEvent event) {
+    if (event == QONRemoteConfigV2ReadGuardTelemetryEventImplicitActivation) {
+      immediateImplicit += 1;
+    }
+  });
+  QONRemoteConfigV2Scope *immediateScope = Scope(@"immediate-user");
+  PreloadOffMain(immediateManager, immediateScope);
+  [immediateManager setScope:immediateScope];
+  [immediateManager acceptFetchedRelease:ImmediateRelease(@"immediate", 2, @"4")
+                                forScope:immediateScope];
+  QON_CHECK([immediateManager.currentSnapshot.releaseUID isEqualToString:@"immediate"],
+      "an immediate release must remain active on first current");
+  Drain(callbacks);
+  QON_CHECK(immediateImplicit == 0,
+      "an already-immediate activation must not be reported as implicit first-read activation");
+}
+
+static void TestDebugAssertionIsExactAndNeverImplicitlyActivates(void) {
+  GuardStorage *storage = [GuardStorage new];
+  GuardPreloader *preloader = [GuardPreloader new];
+  preloader.result = PreloadResult(QONRemoteConfigV2ReadGuardPreloadStatusFound,
+                                   CandidateState(@"candidate", 2));
+  dispatch_queue_t callbacks = dispatch_queue_create("read.guard.debug", DISPATCH_QUEUE_SERIAL);
+  __block NSString *message = nil;
+  __block NSUInteger assertions = 0;
+  QONRemoteConfigV2Manager *manager = Manager(storage, preloader,
+      QONRemoteConfigV2ReadGuardBuildModeDebug, callbacks, ^(NSString *value) {
+    assertions += 1; message = value;
+  }, nil);
+  QONRemoteConfigV2Scope *scope = Scope(@"user");
+  PreloadOffMain(manager, scope);
+  [manager setScope:scope];
+
+  QON_CHECK([manager.currentSnapshot.releaseUID isEqualToString:@"bundle"],
+      "debug read-before-activate must remain on the bundle");
+  QON_CHECK([message isEqualToString:QONRemoteConfigV2ReadBeforeActivateAssertionMessage] &&
+      [message isEqualToString:@"Remote Config read before activate(). Call activate() during SDK startup before reading currentSnapshot."],
+      "debug assertion must use the exact actionable contract message");
+  (void)manager.currentSnapshot;
+  QON_CHECK(assertions == 1, "debug assertion must be bounded once per generation");
+  QON_CHECK([manager activate], "explicit activation must remain available after the debug assertion");
+  QON_CHECK([manager.currentSnapshot.releaseUID isEqualToString:@"candidate"],
+      "explicit activation must expose the candidate after debug misuse");
+}
+
+static void TestUnavailablePreloadsAndPersistenceFailureStayOnPinnedBundle(void) {
+  NSArray<NSNumber *> *statuses = @[
+    @(QONRemoteConfigV2ReadGuardPreloadStatusMissing),
+    @(QONRemoteConfigV2ReadGuardPreloadStatusFailed),
+    @(QONRemoteConfigV2ReadGuardPreloadStatusCorrupt),
+  ];
+  for (NSNumber *statusValue in statuses) {
+    GuardStorage *storage = [GuardStorage new];
+    GuardPreloader *preloader = [GuardPreloader new];
+    QONRemoteConfigV2ReadGuardPreloadStatus status = statusValue.integerValue;
+    preloader.result = PreloadResult(status, nil);
+    dispatch_queue_t callbacks = dispatch_queue_create("read.guard.fail-safe", DISPATCH_QUEUE_SERIAL);
+    __block NSUInteger failSafeEvents = 0, misuseEvents = 0, implicitEvents = 0;
+    QONRemoteConfigV2Manager *manager = Manager(storage, preloader,
+        QONRemoteConfigV2ReadGuardBuildModeRelease, callbacks, nil,
+        ^(QONRemoteConfigV2ReadGuardTelemetryEvent event) {
+      if (event == QONRemoteConfigV2ReadGuardTelemetryEventPreloadAbsent ||
+          event == QONRemoteConfigV2ReadGuardTelemetryEventPreloadFailed ||
+          event == QONRemoteConfigV2ReadGuardTelemetryEventPreloadCorrupt) failSafeEvents += 1;
+      if (event == QONRemoteConfigV2ReadGuardTelemetryEventReadBeforeActivate) misuseEvents += 1;
+      if (event == QONRemoteConfigV2ReadGuardTelemetryEventImplicitActivation) implicitEvents += 1;
+    });
+    QONRemoteConfigV2Scope *scope = Scope(@"user");
+    QON_CHECK(PreloadOffMain(manager, scope) == status,
+        "absent, failed, and corrupt preload results must remain explicit");
+    [manager setScope:scope];
+    QON_CHECK([manager.currentSnapshot.releaseUID isEqualToString:@"bundle"],
+        "absent, failed, or corrupt preload must expose only the exact-scope bundle");
+    Drain(callbacks);
+    NSUInteger expectedImplicit =
+        status == QONRemoteConfigV2ReadGuardPreloadStatusMissing ? 1 : 0;
+    QON_CHECK(failSafeEvents == 1 && misuseEvents == 1 &&
+        implicitEvents == expectedImplicit,
+        "failed/corrupt preloads must not claim activation; missing may commit fallback activation");
+  }
+
+  GuardStorage *storage = [GuardStorage new]; storage.failWrites = YES;
+  GuardPreloader *preloader = [GuardPreloader new];
+  preloader.result = PreloadResult(QONRemoteConfigV2ReadGuardPreloadStatusFound,
+                                   PendingState());
+  dispatch_queue_t callbacks = dispatch_queue_create("read.guard.disk-full", DISPATCH_QUEUE_SERIAL);
+  __block NSUInteger persistenceFailures = 0, diskMisuse = 0, diskImplicit = 0;
+  QONRemoteConfigV2Manager *manager = Manager(storage, preloader,
+      QONRemoteConfigV2ReadGuardBuildModeRelease, callbacks, nil,
+      ^(QONRemoteConfigV2ReadGuardTelemetryEvent event) {
+    if (event == QONRemoteConfigV2ReadGuardTelemetryEventPreparedActivationPersistenceFailed) {
+      persistenceFailures += 1;
+    }
+    if (event == QONRemoteConfigV2ReadGuardTelemetryEventReadBeforeActivate) diskMisuse += 1;
+    if (event == QONRemoteConfigV2ReadGuardTelemetryEventImplicitActivation) diskImplicit += 1;
+  });
+  QONRemoteConfigV2Scope *scope = Scope(@"user");
+  QON_CHECK(PreloadOffMain(manager, scope) ==
+      QONRemoteConfigV2ReadGuardPreloadStatusPersistenceFailed,
+      "disk-full preparation must be an explicit preload failure");
+  [manager setScope:scope];
+  QON_CHECK([manager.currentSnapshot.releaseUID isEqualToString:@"active"],
+      "failed prepared activation must preserve the prior Active rather than Candidate");
+  Drain(callbacks);
+  QON_CHECK(persistenceFailures == 1 && diskMisuse == 1 && diskImplicit == 0,
+      "persistence failure must be observable without a false implicit-activation success");
+}
+
+static void TestReadGuardCallbacksAreReentrantAndNeverRunUnderStateLock(void) {
+  GuardStorage *storage = [GuardStorage new];
+  GuardPreloader *preloader = [GuardPreloader new];
+  preloader.result = PreloadResult(QONRemoteConfigV2ReadGuardPreloadStatusFound,
+                                   CandidateState(@"candidate", 2));
+  dispatch_queue_t callbacks = dispatch_queue_create(
+      "read.guard.reentrant-callbacks", DISPATCH_QUEUE_SERIAL);
+  dispatch_semaphore_t telemetryFinished = dispatch_semaphore_create(0);
+  dispatch_semaphore_t observerFinished = dispatch_semaphore_create(0);
+  __block QONRemoteConfigV2Manager *manager = nil;
+  __block BOOL telemetryReentered = NO;
+  __block BOOL observerReentered = NO;
+  manager = Manager(storage, preloader, QONRemoteConfigV2ReadGuardBuildModeRelease,
+      callbacks, nil, ^(QONRemoteConfigV2ReadGuardTelemetryEvent event) {
+    if (event == QONRemoteConfigV2ReadGuardTelemetryEventImplicitActivation) {
+      telemetryReentered = manager.currentSnapshot != nil;
+      dispatch_semaphore_signal(telemetryFinished);
+    }
+  });
+  [manager addUpdateObserver:^(__unused QONRemoteConfigUpdate *update) {
+    observerReentered = manager.currentSnapshot != nil;
+    dispatch_semaphore_signal(observerFinished);
+  }];
+  QONRemoteConfigV2Scope *scope = Scope(@"user");
+  PreloadOffMain(manager, scope);
+  [manager setScope:scope];
+  (void)manager.currentSnapshot;
+
+  QON_CHECK(dispatch_semaphore_wait(telemetryFinished,
+      dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC)) == 0 && telemetryReentered,
+      "telemetry callback must run outside the state lock and permit reentrant reads");
+  QON_CHECK(dispatch_semaphore_wait(observerFinished,
+      dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC)) == 0 && observerReentered,
+      "implicit activation observer must run outside the state lock and permit reentrant reads");
+
+  GuardPreloader *debugPreloader = [GuardPreloader new];
+  debugPreloader.result = PreloadResult(QONRemoteConfigV2ReadGuardPreloadStatusFound,
+                                        CandidateState(@"debug", 3));
+  __block QONRemoteConfigV2Manager *debugManager = nil;
+  __block BOOL assertionReentered = NO;
+  debugManager = Manager([GuardStorage new], debugPreloader,
+      QONRemoteConfigV2ReadGuardBuildModeDebug, callbacks, ^(__unused NSString *message) {
+    assertionReentered = debugManager.lastFetchedSnapshot != nil;
+  }, nil);
+  PreloadOffMain(debugManager, scope);
+  [debugManager setScope:scope];
+  (void)debugManager.currentSnapshot;
+  QON_CHECK(assertionReentered,
+      "debug assertion hook must run outside the state lock and permit reentrant reads");
+}
+
+static void TestConcurrentFirstReadersClaimOneImplicitAttempt(void) {
+  GuardStorage *storage = [GuardStorage new];
+  GuardPreloader *preloader = [GuardPreloader new];
+  preloader.result = PreloadResult(QONRemoteConfigV2ReadGuardPreloadStatusFound,
+                                   CandidateState(@"candidate", 2));
+  dispatch_queue_t callbacks = dispatch_queue_create("read.guard.concurrent.events", DISPATCH_QUEUE_SERIAL);
+  __block NSUInteger misuse = 0, implicitActivations = 0;
+  QONRemoteConfigV2Manager *manager = Manager(storage, preloader,
+      QONRemoteConfigV2ReadGuardBuildModeRelease, callbacks, nil,
+      ^(QONRemoteConfigV2ReadGuardTelemetryEvent event) {
+    if (event == QONRemoteConfigV2ReadGuardTelemetryEventReadBeforeActivate) misuse += 1;
+    if (event == QONRemoteConfigV2ReadGuardTelemetryEventImplicitActivation) {
+      implicitActivations += 1;
+    }
+  });
+  QONRemoteConfigV2Scope *scope = Scope(@"user");
+  PreloadOffMain(manager, scope);
+  [manager setScope:scope];
+  __block NSUInteger wrong = 0;
+  dispatch_apply(64, dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^(__unused size_t index) {
+    if (![manager.currentSnapshot.releaseUID isEqualToString:@"candidate"]) {
+      @synchronized (manager) { wrong += 1; }
+    }
+  });
+  Drain(callbacks);
+  QON_CHECK(wrong == 0 && misuse == 1 && implicitActivations == 1,
+      "concurrent first readers must observe one implicit attempt for the generation");
+}
+
+static void TestPreloadIsExactScopeBoundAndPreparedStateSurvivesRestart(void) {
+  GuardStorage *storage = [GuardStorage new];
+  GuardPreloader *preloader = [GuardPreloader new];
+  preloader.result = PreloadResult(QONRemoteConfigV2ReadGuardPreloadStatusFound,
+                                   CandidateState(@"private-a", 2));
+  dispatch_queue_t callbacks = dispatch_queue_create("read.guard.scope", DISPATCH_QUEUE_SERIAL);
+  QONRemoteConfigV2Manager *first = Manager(storage, preloader,
+      QONRemoteConfigV2ReadGuardBuildModeRelease, callbacks, nil, nil);
+  QONRemoteConfigV2Scope *userA = Scope(@"user-a");
+  QONRemoteConfigV2Scope *userB = Scope(@"user-b");
+  PreloadOffMain(first, userA);
+  [first setScope:userB];
+  QON_CHECK([first.currentSnapshot.releaseUID isEqualToString:@"bundle"],
+      "a preloaded user must never leak into a different current scope");
+  preloader.result = PreloadResult(QONRemoteConfigV2ReadGuardPreloadStatusFound,
+                                   CandidateState(@"private-a", 2));
+  PreloadOffMain(first, userA);
+  [first setScope:userA];
+  QON_CHECK([first.currentSnapshot.releaseUID isEqualToString:@"bundle"],
+      "a prior first-read opportunity must not be reset by a freshly preloaded scope");
+  QON_CHECK([first activate] &&
+      [first.currentSnapshot.releaseUID isEqualToString:@"private-a"],
+      "explicit activation must expose only the freshly preloaded exact-scope candidate");
+
+  QONRemoteConfigV2State *durable = nil;
+  QONRemoteConfigV2Store *store = [[QONRemoteConfigV2Store alloc] initWithLocalStorage:storage];
+  QON_CHECK([store loadStateForScope:userA state:&durable] == QONRemoteConfigV2StoreLoadStatusFound,
+      "prepared activation must be durable before first read");
+  GuardPreloader *restartPreloader = [GuardPreloader new];
+  restartPreloader.result = PreloadResult(QONRemoteConfigV2ReadGuardPreloadStatusFound, durable);
+  QONRemoteConfigV2Manager *restart = Manager(storage, restartPreloader,
+      QONRemoteConfigV2ReadGuardBuildModeRelease, callbacks, nil, nil);
+  PreloadOffMain(restart, userA);
+  [restart setScope:userA];
+  QON_CHECK([restart.currentSnapshot.releaseUID isEqualToString:@"private-a"],
+      "restart must expose the same durably prepared Active snapshot");
+}
+
+static void TestOutOfOrderPreloadsCannotPublishASupersededSlot(void) {
+  GuardStorage *storage = [GuardStorage new];
+  GuardAdversarialPreloader *preloader = [GuardAdversarialPreloader new];
+  preloader.firstStarted = dispatch_semaphore_create(0);
+  preloader.releaseFirst = dispatch_semaphore_create(0);
+  preloader.waitForSupersedingToken = YES;
+  preloader.resultA = PreloadResult(QONRemoteConfigV2ReadGuardPreloadStatusFound,
+                                    CandidateState(@"candidate-a", 2));
+  preloader.resultB = PreloadResult(QONRemoteConfigV2ReadGuardPreloadStatusFound,
+                                    CandidateState(@"candidate-b", 3));
+  dispatch_queue_t callbacks = dispatch_queue_create(
+      "read.guard.out-of-order", DISPATCH_QUEUE_SERIAL);
+  QONRemoteConfigV2Manager *manager = Manager(storage, preloader,
+      QONRemoteConfigV2ReadGuardBuildModeRelease, callbacks, nil, nil);
+  preloader.manager = manager;
+  QONRemoteConfigV2Scope *userA = Scope(@"user-a");
+  QONRemoteConfigV2Scope *userB = Scope(@"user-b");
+  dispatch_semaphore_t aFinished = dispatch_semaphore_create(0);
+  dispatch_semaphore_t bFinished = dispatch_semaphore_create(0);
+  __block QONRemoteConfigV2ReadGuardPreloadStatus aStatus =
+      QONRemoteConfigV2ReadGuardPreloadStatusFound;
+  __block QONRemoteConfigV2ReadGuardPreloadStatus bStatus =
+      QONRemoteConfigV2ReadGuardPreloadStatusFailed;
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    aStatus = [manager preloadScopeForReadGuard:userA];
+    dispatch_semaphore_signal(aFinished);
+  });
+  QON_CHECK(dispatch_semaphore_wait(preloader.firstStarted,
+      dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC)) == 0,
+      "first adversarial preload must start");
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    bStatus = [manager preloadScopeForReadGuard:userB];
+    dispatch_semaphore_signal(bFinished);
+  });
+  QON_CHECK(dispatch_semaphore_wait(aFinished,
+      dispatch_time(DISPATCH_TIME_NOW, 3 * NSEC_PER_SEC)) == 0 &&
+      dispatch_semaphore_wait(bFinished,
+      dispatch_time(DISPATCH_TIME_NOW, 3 * NSEC_PER_SEC)) == 0,
+      "adversarial preloads must finish without deadlock");
+  QON_CHECK(aStatus == QONRemoteConfigV2ReadGuardPreloadStatusFailed &&
+      bStatus == QONRemoteConfigV2ReadGuardPreloadStatusFound,
+      "the superseded preload must fail while the newest issued preload wins");
+  [manager setScope:userB];
+  QON_CHECK([manager.currentSnapshot.releaseUID isEqualToString:@"candidate-b"],
+      "out-of-order completion must not overwrite the newest exact slot");
+  [manager setScope:userA];
+  QON_CHECK([manager.currentSnapshot.releaseUID isEqualToString:@"bundle"],
+      "a superseded slot must never become eligible in a later scope generation");
+}
+
+static void TestScopeSelectionCancelsAnInFlightPreload(void) {
+  GuardStorage *storage = [GuardStorage new];
+  GuardAdversarialPreloader *preloader = [GuardAdversarialPreloader new];
+  preloader.firstStarted = dispatch_semaphore_create(0);
+  preloader.releaseFirst = dispatch_semaphore_create(0);
+  preloader.resultA = PreloadResult(QONRemoteConfigV2ReadGuardPreloadStatusFound,
+                                    CandidateState(@"late-a", 2));
+  preloader.resultB = PreloadResult(QONRemoteConfigV2ReadGuardPreloadStatusMissing, nil);
+  QONRemoteConfigV2Manager *manager = Manager(storage, preloader,
+      QONRemoteConfigV2ReadGuardBuildModeRelease,
+      dispatch_queue_create("read.guard.cancel", DISPATCH_QUEUE_SERIAL), nil, nil);
+  preloader.manager = manager;
+  QONRemoteConfigV2Scope *userA = Scope(@"user-a");
+  dispatch_semaphore_t finished = dispatch_semaphore_create(0);
+  __block QONRemoteConfigV2ReadGuardPreloadStatus status =
+      QONRemoteConfigV2ReadGuardPreloadStatusFound;
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    status = [manager preloadScopeForReadGuard:userA];
+    dispatch_semaphore_signal(finished);
+  });
+  QON_CHECK(dispatch_semaphore_wait(preloader.firstStarted,
+      dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC)) == 0,
+      "in-flight preload must reach the injected loading seam");
+  [manager setScope:Scope(@"user-b")];
+  dispatch_semaphore_signal(preloader.releaseFirst);
+  QON_CHECK(dispatch_semaphore_wait(finished,
+      dispatch_time(DISPATCH_TIME_NOW, 3 * NSEC_PER_SEC)) == 0 &&
+      status == QONRemoteConfigV2ReadGuardPreloadStatusFailed,
+      "scope selection must cancel a preload that has not completed");
+  [manager setScope:userA];
+  QON_CHECK([manager.currentSnapshot.releaseUID isEqualToString:@"bundle"],
+      "a preload completed after scope selection must not leak into a later generation");
+}
+
+static void TestScopeSelectionWaitsForAdmittedSaveAndFencesLateWrites(void) {
+  GuardBlockingStorage *storage = [GuardBlockingStorage new];
+  storage.blockNextWrite = YES;
+  GuardPreloader *preloader = [GuardPreloader new];
+  preloader.result = PreloadResult(QONRemoteConfigV2ReadGuardPreloadStatusFound,
+                                   CandidateState(@"candidate-a", 2));
+  QONRemoteConfigV2Manager *manager = Manager(storage, preloader,
+      QONRemoteConfigV2ReadGuardBuildModeRelease,
+      dispatch_queue_create("read.guard.atomic-save", DISPATCH_QUEUE_SERIAL), nil, nil);
+  QONRemoteConfigV2Scope *userA = Scope(@"user-a");
+  QONRemoteConfigV2Scope *userB = Scope(@"user-b");
+  dispatch_semaphore_t preloadFinished = dispatch_semaphore_create(0);
+  dispatch_semaphore_t scopeReturned = dispatch_semaphore_create(0);
+  __block QONRemoteConfigV2ReadGuardPreloadStatus status =
+      QONRemoteConfigV2ReadGuardPreloadStatusFailed;
+  __block NSUInteger writesAtScopeReturn = NSNotFound;
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    status = [manager preloadScopeForReadGuard:userA];
+    dispatch_semaphore_signal(preloadFinished);
+  });
+  QON_CHECK(dispatch_semaphore_wait(storage.writeStarted,
+      dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC)) == 0,
+      "preload must reach the blocking durable-save seam");
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    [manager setScope:userB];
+    writesAtScopeReturn = storage.writes;
+    dispatch_semaphore_signal(scopeReturned);
+  });
+
+  QON_CHECK(dispatch_semaphore_wait(scopeReturned,
+      dispatch_time(DISPATCH_TIME_NOW, 100 * NSEC_PER_MSEC)) != 0,
+      "setScope must not return while an admitted preload save can still write");
+  dispatch_semaphore_signal(storage.releaseWrite);
+  QON_CHECK(dispatch_semaphore_wait(preloadFinished,
+      dispatch_time(DISPATCH_TIME_NOW, 3 * NSEC_PER_SEC)) == 0 &&
+      dispatch_semaphore_wait(scopeReturned,
+      dispatch_time(DISPATCH_TIME_NOW, 3 * NSEC_PER_SEC)) == 0,
+      "preload save and scope selection must finish without deadlock");
+  QON_CHECK(status == QONRemoteConfigV2ReadGuardPreloadStatusFound,
+      "an admitted save must publish before the later scope selection invalidates it");
+  QON_CHECK(storage.writes == writesAtScopeReturn,
+      "no preload write may occur after setScope returns");
+  QON_CHECK([manager.currentSnapshot.releaseUID isEqualToString:@"bundle"],
+      "the selected identity must never expose the saved prior-identity candidate");
+}
+
+static void TestImplicitActivationOpportunityIsOncePerSDKLifetime(void) {
+  GuardStorage *storage = [GuardStorage new];
+  GuardPreloader *preloader = [GuardPreloader new];
+  dispatch_queue_t callbacks = dispatch_queue_create(
+      "read.guard.lifetime", DISPATCH_QUEUE_SERIAL);
+  __block NSUInteger implicit = 0;
+  QONRemoteConfigV2Manager *manager = Manager(storage, preloader,
+      QONRemoteConfigV2ReadGuardBuildModeRelease, callbacks, nil,
+      ^(QONRemoteConfigV2ReadGuardTelemetryEvent event) {
+    if (event == QONRemoteConfigV2ReadGuardTelemetryEventImplicitActivation) implicit += 1;
+  });
+  preloader.result = PreloadResult(QONRemoteConfigV2ReadGuardPreloadStatusFound,
+                                   CandidateState(@"candidate-a", 2));
+  PreloadOffMain(manager, Scope(@"user-a"));
+  [manager setScope:Scope(@"user-a")];
+  QON_CHECK([manager.currentSnapshot.releaseUID isEqualToString:@"candidate-a"],
+      "the first SDK-lifetime read may activate its durably prepared candidate");
+  NSUInteger writesAfterFirstActivation = storage.writes;
+
+  preloader.result = PreloadResult(QONRemoteConfigV2ReadGuardPreloadStatusFound,
+                                   CandidateState(@"candidate-b", 3));
+  PreloadOffMain(manager, Scope(@"user-b"));
+  QON_CHECK(storage.writes == writesAfterFirstActivation,
+      "a later scope must not persist another implicit activation after lifetime use");
+  [manager setScope:Scope(@"user-b")];
+  QON_CHECK([manager.currentSnapshot.releaseUID isEqualToString:@"bundle"],
+      "a later scope must require explicit activation after lifetime implicit use");
+  Drain(callbacks);
+  QON_CHECK(implicit == 1, "implicit activation telemetry must occur once per SDK lifetime");
+
+  GuardStorage *explicitStorage = [GuardStorage new];
+  GuardPreloader *explicitPreloader = [GuardPreloader new];
+  __block NSUInteger explicitImplicit = 0;
+  QONRemoteConfigV2Manager *explicitManager = Manager(explicitStorage, explicitPreloader,
+      QONRemoteConfigV2ReadGuardBuildModeRelease, callbacks, nil,
+      ^(QONRemoteConfigV2ReadGuardTelemetryEvent event) {
+    if (event == QONRemoteConfigV2ReadGuardTelemetryEventImplicitActivation) {
+      explicitImplicit += 1;
+    }
+  });
+  explicitPreloader.result = PreloadResult(QONRemoteConfigV2ReadGuardPreloadStatusFound,
+                                           CandidateState(@"explicit-a", 2));
+  PreloadOffMain(explicitManager, Scope(@"explicit-a"));
+  [explicitManager setScope:Scope(@"explicit-a")];
+  QON_CHECK([explicitManager activate],
+      "explicit activation must consume the SDK-lifetime implicit opportunity");
+  NSUInteger writesAfterExplicit = explicitStorage.writes;
+
+  explicitPreloader.result = PreloadResult(QONRemoteConfigV2ReadGuardPreloadStatusFound,
+                                           CandidateState(@"candidate-b", 3));
+  PreloadOffMain(explicitManager, Scope(@"explicit-b"));
+  QON_CHECK(explicitStorage.writes == writesAfterExplicit,
+      "explicit activation must prevent later implicit-preparation writes");
+  [explicitManager setScope:Scope(@"explicit-b")];
+  QON_CHECK([explicitManager.currentSnapshot.releaseUID isEqualToString:@"bundle"],
+      "a scope after explicit activation must not activate on first read");
+  Drain(callbacks);
+  QON_CHECK(explicitImplicit == 0,
+      "explicit activation must prevent all implicit-activation telemetry");
+}
+
+static void TestReadDuringPreloadBindWindowCannotConsumeTargetOpportunity(void) {
+  GuardStorage *storage = [GuardStorage new];
+  GuardAdversarialPreloader *preloader = [GuardAdversarialPreloader new];
+  preloader.firstStarted = dispatch_semaphore_create(0);
+  preloader.releaseFirst = dispatch_semaphore_create(0);
+  preloader.resultA = PreloadResult(QONRemoteConfigV2ReadGuardPreloadStatusFound,
+                                    CandidateState(@"candidate-a", 2));
+  preloader.resultB = PreloadResult(QONRemoteConfigV2ReadGuardPreloadStatusMissing, nil);
+  dispatch_queue_t callbacks = dispatch_queue_create(
+      "read.guard.bind-window", DISPATCH_QUEUE_SERIAL);
+  __block NSUInteger implicit = 0;
+  QONRemoteConfigV2Manager *manager = Manager(storage, preloader,
+      QONRemoteConfigV2ReadGuardBuildModeRelease, callbacks, nil,
+      ^(QONRemoteConfigV2ReadGuardTelemetryEvent event) {
+    if (event == QONRemoteConfigV2ReadGuardTelemetryEventImplicitActivation) implicit += 1;
+  });
+  preloader.manager = manager;
+  QONRemoteConfigV2Scope *userA = Scope(@"user-a");
+  QONRemoteConfigV2Scope *userB = Scope(@"user-b");
+  PreloadOffMain(manager, userB);
+  [manager setScope:userB];
+
+  dispatch_semaphore_t preloadFinished = dispatch_semaphore_create(0);
+  __block QONRemoteConfigV2ReadGuardPreloadStatus status =
+      QONRemoteConfigV2ReadGuardPreloadStatusFailed;
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    status = [manager preloadScopeForReadGuard:userA];
+    dispatch_semaphore_signal(preloadFinished);
+  });
+  QON_CHECK(dispatch_semaphore_wait(preloader.firstStarted,
+      dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC)) == 0,
+      "target preload must reach the bind-window seam");
+  QON_CHECK([manager.currentSnapshot.releaseUID isEqualToString:@"bundle"],
+      "a stale-scope read during target preload must stay on its safe fallback");
+  dispatch_semaphore_signal(preloader.releaseFirst);
+  QON_CHECK(dispatch_semaphore_wait(preloadFinished,
+      dispatch_time(DISPATCH_TIME_NOW, 3 * NSEC_PER_SEC)) == 0 &&
+      status == QONRemoteConfigV2ReadGuardPreloadStatusFound,
+      "target preload must finish after the stale-scope read");
+
+  [manager setScope:userA];
+  QON_CHECK([manager.currentSnapshot.releaseUID isEqualToString:@"candidate-a"],
+      "a stale-scope read must not consume the target scope implicit opportunity");
+  Drain(callbacks);
+  QON_CHECK(implicit == 1,
+      "the bound target scope must report exactly one implicit activation");
+}
+
+int main(void) {
+  @autoreleasepool {
+    TestReleaseFirstReadUsesDurablyPreparedCandidateOnlyOnce();
+    TestFetchAfterPreloadRefreshesDurableFirstReadPreparation();
+    TestPersistenceRecoveryRearmsAndImmediateDoesNotReportImplicit();
+    TestDebugAssertionIsExactAndNeverImplicitlyActivates();
+    TestUnavailablePreloadsAndPersistenceFailureStayOnPinnedBundle();
+    TestConcurrentFirstReadersClaimOneImplicitAttempt();
+    TestPreloadIsExactScopeBoundAndPreparedStateSurvivesRestart();
+    TestReadGuardCallbacksAreReentrantAndNeverRunUnderStateLock();
+    TestOutOfOrderPreloadsCannotPublishASupersededSlot();
+    TestScopeSelectionCancelsAnInFlightPreload();
+    TestScopeSelectionWaitsForAdmittedSaveAndFencesLateWrites();
+    TestImplicitActivationOpportunityIsOncePerSDKLifetime();
+    TestReadDuringPreloadBindWindowCannotConsumeTargetOpportunity();
+  }
+  if (failures == 0) fprintf(stdout, "QONRemoteConfigV2ReadGuardHarness: 13/13 passed\n");
+  return failures == 0 ? 0 : 1;
+}

--- a/QonversionTests/Models/QONRemoteConfigSnapshotTests.m
+++ b/QonversionTests/Models/QONRemoteConfigSnapshotTests.m
@@ -75,6 +75,63 @@
   XCTAssertEqualObjects(bundleOnly.value, @YES);
 }
 
+- (void)testDecoderErrorFallsBackFromCurrentToPreviousEvenWhenDecoderReturnsValue {
+  QONRemoteConfigV2Release *primary = [self release:@"release-2" number:2 values:@{
+    @"key": @"\"current\"",
+  }];
+  QONRemoteConfigV2Release *previous = [self release:@"release-1" number:1 values:@{
+    @"key": @"\"previous\"",
+  }];
+  QONRemoteConfigV2Release *fallback = [self release:@"bundle" number:1 values:@{
+    @"key": @"\"bundle\"",
+  }];
+  QONRemoteConfigSnapshot *snapshot = [[QONRemoteConfigSnapshot alloc]
+      initWithPrimaryRelease:primary previousRelease:previous fallbackRelease:fallback];
+
+  QONRemoteConfigValue *typed = [snapshot valueForKey:@"key" decoder:^id(NSData *data,
+                                                                             NSError **error) {
+    id value = [NSJSONSerialization JSONObjectWithData:data
+        options:NSJSONReadingFragmentsAllowed error:nil];
+    if ([value isEqual:@"current"]) {
+      *error = [NSError errorWithDomain:@"QONRemoteConfigSnapshotTests" code:1 userInfo:nil];
+    }
+    return value;
+  }];
+
+  XCTAssertEqual(typed.source, QONRemoteConfigValueSourceCache);
+  XCTAssertEqualObjects(typed.value, @"previous");
+  QONRemoteConfigValue *raw = [snapshot rawValueForKey:@"key"];
+  XCTAssertEqual(raw.source, QONRemoteConfigValueSourceServer);
+  XCTAssertEqualObjects(raw.value, @"current");
+}
+
+- (void)testDecoderErrorsFallBackFromCurrentAndPreviousToBundleEvenWhenReturningValues {
+  QONRemoteConfigV2Release *primary = [self release:@"release-2" number:2 values:@{
+    @"key": @"\"current\"",
+  }];
+  QONRemoteConfigV2Release *previous = [self release:@"release-1" number:1 values:@{
+    @"key": @"\"previous\"",
+  }];
+  QONRemoteConfigV2Release *fallback = [self release:@"bundle" number:1 values:@{
+    @"key": @"\"bundle\"",
+  }];
+  QONRemoteConfigSnapshot *snapshot = [[QONRemoteConfigSnapshot alloc]
+      initWithPrimaryRelease:primary previousRelease:previous fallbackRelease:fallback];
+
+  QONRemoteConfigValue *typed = [snapshot valueForKey:@"key" decoder:^id(NSData *data,
+                                                                             NSError **error) {
+    id value = [NSJSONSerialization JSONObjectWithData:data
+        options:NSJSONReadingFragmentsAllowed error:nil];
+    if (![value isEqual:@"bundle"]) {
+      *error = [NSError errorWithDomain:@"QONRemoteConfigSnapshotTests" code:2 userInfo:nil];
+    }
+    return value;
+  }];
+
+  XCTAssertEqual(typed.source, QONRemoteConfigValueSourceFallback);
+  XCTAssertEqualObjects(typed.value, @"bundle");
+}
+
 - (void)testSnapshotAndReturnedValuesDoNotObserveCallerMutation {
   NSMutableData *raw = [[self utf8Data:@"{\"enabled\":true}"] mutableCopy];
   QONRemoteConfigV2Entry *entry = [[QONRemoteConfigV2Entry alloc]

--- a/Sources/Qonversion/Public/QONRemoteConfigSnapshot.m
+++ b/Sources/Qonversion/Public/QONRemoteConfigSnapshot.m
@@ -97,7 +97,7 @@
     if (!rawData) continue;
     NSError *error = nil;
     id value = decoder([rawData copy], &error);
-    if (value) {
+    if (value && !error) {
       return [self resolvedValueForEntry:entry source:[candidate[1] integerValue] value:value];
     }
   }

--- a/Sources/Qonversion/Qonversion/Main/QONRemoteConfigV2Manager/QONRemoteConfigV2Manager.h
+++ b/Sources/Qonversion/Qonversion/Main/QONRemoteConfigV2Manager/QONRemoteConfigV2Manager.h
@@ -3,12 +3,54 @@
 #import "QONRemoteConfigUpdate.h"
 
 @class QONRemoteConfigV2AdmissionToken, QONRemoteConfigV2EnvelopeExpectation;
-@class QONRemoteConfigV2Release, QONRemoteConfigV2Scope, QONRemoteConfigV2Store;
+@class QONRemoteConfigV2Release, QONRemoteConfigV2Scope, QONRemoteConfigV2State;
+@class QONRemoteConfigV2Store;
 @protocol QONRemoteConfigV2EnvelopeDecoding;
 
 NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^QONRemoteConfigV2UpdateObserver)(QONRemoteConfigUpdate *update);
+
+FOUNDATION_EXPORT NSString *const QONRemoteConfigV2ReadBeforeActivateAssertionMessage;
+
+typedef NS_ENUM(NSInteger, QONRemoteConfigV2ReadGuardBuildMode) {
+  QONRemoteConfigV2ReadGuardBuildModeDebug,
+  QONRemoteConfigV2ReadGuardBuildModeRelease,
+};
+
+typedef NS_ENUM(NSInteger, QONRemoteConfigV2ReadGuardPreloadStatus) {
+  QONRemoteConfigV2ReadGuardPreloadStatusFound,
+  QONRemoteConfigV2ReadGuardPreloadStatusMissing,
+  QONRemoteConfigV2ReadGuardPreloadStatusFailed,
+  QONRemoteConfigV2ReadGuardPreloadStatusCorrupt,
+  QONRemoteConfigV2ReadGuardPreloadStatusPersistenceFailed,
+};
+
+typedef NS_ENUM(NSInteger, QONRemoteConfigV2ReadGuardTelemetryEvent) {
+  QONRemoteConfigV2ReadGuardTelemetryEventReadBeforeActivate,
+  QONRemoteConfigV2ReadGuardTelemetryEventImplicitActivation,
+  QONRemoteConfigV2ReadGuardTelemetryEventPreloadAbsent,
+  QONRemoteConfigV2ReadGuardTelemetryEventPreloadFailed,
+  QONRemoteConfigV2ReadGuardTelemetryEventPreloadCorrupt,
+  QONRemoteConfigV2ReadGuardTelemetryEventPreparedActivationPersistenceFailed,
+};
+
+typedef void (^QONRemoteConfigV2ReadGuardAssertionHandler)(NSString *message);
+typedef void (^QONRemoteConfigV2ReadGuardTelemetryHandler)(
+    QONRemoteConfigV2ReadGuardTelemetryEvent event);
+
+/** Immutable output of an injected, off-main persistent-state preload. */
+@interface QONRemoteConfigV2ReadGuardPreloadResult : NSObject
+@property (nonatomic, assign, readonly) QONRemoteConfigV2ReadGuardPreloadStatus status;
+@property (nonatomic, strong, nullable, readonly) QONRemoteConfigV2State *state;
+- (nullable instancetype)initWithStatus:(QONRemoteConfigV2ReadGuardPreloadStatus)status
+                                  state:(nullable QONRemoteConfigV2State *)state;
+@end
+
+@protocol QONRemoteConfigV2ScopePreloading <NSObject>
+- (QONRemoteConfigV2ReadGuardPreloadResult *)preloadResultForScope:
+    (QONRemoteConfigV2Scope *)scope;
+@end
 
 typedef NS_ENUM(NSInteger, QONRemoteConfigV2TransitionStatus) {
   QONRemoteConfigV2TransitionStatusAccepted,
@@ -46,6 +88,23 @@ typedef NS_ENUM(NSInteger, QONRemoteConfigV2TransitionStatus) {
             fallbackEnvironment:(nullable NSString *)fallbackEnvironment
                  envelopeDecoder:(id<QONRemoteConfigV2EnvelopeDecoding>)envelopeDecoder
                 callbackExecutor:(dispatch_queue_t)callbackExecutor NS_DESIGNATED_INITIALIZER;
+/** Internal dark-launch seam. Existing initializers leave the guard disabled. */
+- (instancetype)initWithStore:(QONRemoteConfigV2Store *)store
+               fallbackRelease:(nullable QONRemoteConfigV2Release *)fallbackRelease
+             fallbackProjectKey:(nullable NSString *)fallbackProjectKey
+            fallbackEnvironment:(nullable NSString *)fallbackEnvironment
+                 envelopeDecoder:(id<QONRemoteConfigV2EnvelopeDecoding>)envelopeDecoder
+                callbackExecutor:(dispatch_queue_t)callbackExecutor
+              readGuardBuildMode:(QONRemoteConfigV2ReadGuardBuildMode)buildMode
+                assertionHandler:(nullable QONRemoteConfigV2ReadGuardAssertionHandler)assertionHandler
+                telemetryHandler:(nullable QONRemoteConfigV2ReadGuardTelemetryHandler)telemetryHandler
+                  scopePreloader:(id<QONRemoteConfigV2ScopePreloading>)scopePreloader;
+/**
+ Performs all persistent read and durable prepared-activation work synchronously.
+ The SDK bootstrap must call it off main before setScope/readiness.
+ */
+- (QONRemoteConfigV2ReadGuardPreloadStatus)preloadScopeForReadGuard:
+    (QONRemoteConfigV2Scope *)scope;
 /**
  Changes current scope and generation synchronously on the state queue without
  waiting for the callback executor. Queued or not-yet-claimed old-generation

--- a/Sources/Qonversion/Qonversion/Main/QONRemoteConfigV2Manager/QONRemoteConfigV2Manager.m
+++ b/Sources/Qonversion/Qonversion/Main/QONRemoteConfigV2Manager/QONRemoteConfigV2Manager.m
@@ -4,6 +4,38 @@
 #import "QONRemoteConfigV2Models.h"
 #import "QONRemoteConfigV2Store.h"
 
+NSString *const QONRemoteConfigV2ReadBeforeActivateAssertionMessage =
+    @"Remote Config read before activate(). Call activate() during SDK startup before reading currentSnapshot.";
+static void *QONRemoteConfigV2ReadGuardPreloadQueueKey =
+    &QONRemoteConfigV2ReadGuardPreloadQueueKey;
+
+@implementation QONRemoteConfigV2ReadGuardPreloadResult
+
+- (instancetype)initWithStatus:(QONRemoteConfigV2ReadGuardPreloadStatus)status
+                          state:(QONRemoteConfigV2State *)state {
+  if (status < QONRemoteConfigV2ReadGuardPreloadStatusFound ||
+      status > QONRemoteConfigV2ReadGuardPreloadStatusPersistenceFailed) return nil;
+  if ((status == QONRemoteConfigV2ReadGuardPreloadStatusFound) != (state != nil)) return nil;
+  self = [super init];
+  if (self) {
+    _status = status;
+    _state = state;
+  }
+  return self;
+}
+
+@end
+
+@interface QONRemoteConfigV2ReadGuardPreparedSlot : NSObject
+@property (nonatomic, strong) QONRemoteConfigV2Scope *scope;
+@property (nonatomic, strong) QONRemoteConfigV2State *loadedState;
+@property (nonatomic, strong, nullable) QONRemoteConfigV2State *preparedState;
+@property (nonatomic, assign) QONRemoteConfigV2ReadGuardPreloadStatus status;
+@end
+
+@implementation QONRemoteConfigV2ReadGuardPreparedSlot
+@end
+
 @interface QONRemoteConfigV2Delivery : NSObject
 @property (nonatomic, strong) QONRemoteConfigUpdate *update;
 @property (nonatomic, copy) NSArray<QONRemoteConfigV2UpdateObserver> *observers;
@@ -46,6 +78,23 @@
 @property (nonatomic, strong) dispatch_queue_t callbackExecutor;
 @property (nonatomic, strong) NSObject *callbackExecutorToken;
 @property (nonatomic, assign) BOOL callbackExecutorIsMain;
+@property (nonatomic, assign) BOOL readGuardEnabled;
+@property (nonatomic, assign) QONRemoteConfigV2ReadGuardBuildMode readGuardBuildMode;
+@property (nonatomic, copy, nullable) QONRemoteConfigV2ReadGuardAssertionHandler readGuardAssertionHandler;
+@property (nonatomic, copy, nullable) QONRemoteConfigV2ReadGuardTelemetryHandler readGuardTelemetryHandler;
+@property (nonatomic, strong, nullable) id<QONRemoteConfigV2ScopePreloading> scopePreloader;
+@property (nonatomic, strong, nullable) QONRemoteConfigV2ReadGuardPreparedSlot *preloadedSlot;
+@property (nonatomic, strong, nullable) NSUUID *latestReadGuardPreloadToken;
+@property (nonatomic, assign) NSUInteger readGuardScopeSelectionEpoch;
+@property (nonatomic, strong, nullable) dispatch_queue_t readGuardPreloadQueue;
+@property (nonatomic, strong, nullable) QONRemoteConfigV2State *readGuardBaseState;
+@property (nonatomic, strong, nullable) QONRemoteConfigV2State *readGuardPreparedState;
+@property (nonatomic, assign) BOOL readGuardFirstReadActivationArmed;
+@property (nonatomic, assign) BOOL readGuardFirstReadClaimed;
+@property (nonatomic, assign) BOOL readGuardExplicitActivationCalled;
+@property (nonatomic, assign) BOOL readGuardLifetimeActivationConsumed;
+@property (nonatomic, assign) BOOL readGuardScopeUnavailable;
+@property (nonatomic, assign) BOOL readGuardFailSafeEventClaimed;
 @end
 
 @implementation QONRemoteConfigV2Manager
@@ -103,6 +152,117 @@
   return self;
 }
 
+- (instancetype)initWithStore:(QONRemoteConfigV2Store *)store
+               fallbackRelease:(QONRemoteConfigV2Release *)fallbackRelease
+             fallbackProjectKey:(NSString *)fallbackProjectKey
+            fallbackEnvironment:(NSString *)fallbackEnvironment
+                 envelopeDecoder:(id<QONRemoteConfigV2EnvelopeDecoding>)envelopeDecoder
+                callbackExecutor:(dispatch_queue_t)callbackExecutor
+              readGuardBuildMode:(QONRemoteConfigV2ReadGuardBuildMode)buildMode
+                assertionHandler:(QONRemoteConfigV2ReadGuardAssertionHandler)assertionHandler
+                telemetryHandler:(QONRemoteConfigV2ReadGuardTelemetryHandler)telemetryHandler
+                  scopePreloader:(id<QONRemoteConfigV2ScopePreloading>)scopePreloader {
+  if (!scopePreloader || buildMode < QONRemoteConfigV2ReadGuardBuildModeDebug ||
+      buildMode > QONRemoteConfigV2ReadGuardBuildModeRelease) return nil;
+  self = [self initWithStore:store fallbackRelease:fallbackRelease
+      fallbackProjectKey:fallbackProjectKey fallbackEnvironment:fallbackEnvironment
+      envelopeDecoder:envelopeDecoder callbackExecutor:callbackExecutor];
+  if (self) {
+    _readGuardEnabled = YES;
+    _readGuardBuildMode = buildMode;
+    _readGuardAssertionHandler = [assertionHandler copy];
+    _readGuardTelemetryHandler = [telemetryHandler copy];
+    _scopePreloader = scopePreloader;
+    _readGuardPreloadQueue = dispatch_queue_create(
+        "io.qonversion.remote-config-v2-read-guard-preload", DISPATCH_QUEUE_SERIAL);
+    dispatch_queue_set_specific(_readGuardPreloadQueue,
+        QONRemoteConfigV2ReadGuardPreloadQueueKey,
+        QONRemoteConfigV2ReadGuardPreloadQueueKey, NULL);
+  }
+  return self;
+}
+
+- (QONRemoteConfigV2State *)emptyState {
+  return [[QONRemoteConfigV2State alloc]
+      initWithCandidate:nil active:nil previous:nil didActivate:NO];
+}
+
+- (QONRemoteConfigV2State *)preparedActivationStateFromState:(QONRemoteConfigV2State *)state {
+  QONRemoteConfigV2Release *candidate = state.candidate;
+  if (candidate && !(state.didActivate && [self release:candidate
+      representsSameLocalAdmissionAs:state.active])) {
+    return [[QONRemoteConfigV2State alloc] initWithCandidate:candidate active:candidate
+        previous:state.active didActivate:YES
+        latestAdmissionOrdinal:MAX(state.latestAdmissionOrdinal, candidate.admissionOrdinal)];
+  }
+  if (!state.didActivate) {
+    return [[QONRemoteConfigV2State alloc] initWithCandidate:state.candidate active:state.active
+        previous:state.previous didActivate:YES
+        latestAdmissionOrdinal:state.latestAdmissionOrdinal];
+  }
+  return state;
+}
+
+- (QONRemoteConfigV2ReadGuardPreloadStatus)preloadScopeForReadGuard:
+    (QONRemoteConfigV2Scope *)scope {
+  if (!self.readGuardEnabled || !scope || NSThread.isMainThread ||
+      dispatch_get_specific(QONRemoteConfigV2ReadGuardPreloadQueueKey)) {
+    return QONRemoteConfigV2ReadGuardPreloadStatusFailed;
+  }
+  NSUUID *token = NSUUID.UUID;
+  __block NSUInteger selectionEpoch = 0;
+  dispatch_sync(self.stateQueue, ^{
+    self.latestReadGuardPreloadToken = token;
+    self.preloadedSlot = nil;
+    selectionEpoch = self.readGuardScopeSelectionEpoch;
+  });
+
+  __block QONRemoteConfigV2ReadGuardPreloadStatus status =
+      QONRemoteConfigV2ReadGuardPreloadStatusFailed;
+  dispatch_sync(self.readGuardPreloadQueue, ^{
+    QONRemoteConfigV2ReadGuardPreloadResult *result = nil;
+    @try { result = [self.scopePreloader preloadResultForScope:scope]; }
+    @catch (__unused NSException *exception) {}
+    status = result ? result.status : QONRemoteConfigV2ReadGuardPreloadStatusFailed;
+    QONRemoteConfigV2State *loaded = nil;
+    if (status == QONRemoteConfigV2ReadGuardPreloadStatusFound) {
+      loaded = result.state;
+      if (!loaded) status = QONRemoteConfigV2ReadGuardPreloadStatusCorrupt;
+    } else if (status == QONRemoteConfigV2ReadGuardPreloadStatusMissing) {
+      loaded = [self emptyState];
+    }
+    if (!loaded) loaded = [self emptyState];
+
+    QONRemoteConfigV2ReadGuardPreparedSlot *slot = [QONRemoteConfigV2ReadGuardPreparedSlot new];
+    slot.scope = [scope copy];
+    slot.loadedState = loaded;
+    dispatch_sync(self.stateQueue, ^{
+      if (![self.latestReadGuardPreloadToken isEqual:token] ||
+          self.readGuardScopeSelectionEpoch != selectionEpoch) {
+        status = QONRemoteConfigV2ReadGuardPreloadStatusFailed;
+        return;
+      }
+      QONRemoteConfigV2State *prepared = nil;
+      BOOL canPrepare =
+          self.readGuardBuildMode == QONRemoteConfigV2ReadGuardBuildModeRelease &&
+          !self.readGuardLifetimeActivationConsumed &&
+          (status == QONRemoteConfigV2ReadGuardPreloadStatusFound ||
+           status == QONRemoteConfigV2ReadGuardPreloadStatusMissing);
+      if (canPrepare) {
+        prepared = [self preparedActivationStateFromState:loaded];
+        if (prepared != loaded && ![self.store saveState:prepared forScope:scope]) {
+          prepared = nil;
+          status = QONRemoteConfigV2ReadGuardPreloadStatusPersistenceFailed;
+        }
+      }
+      slot.preparedState = prepared;
+      slot.status = status;
+      self.preloadedSlot = slot;
+    });
+  });
+  return status;
+}
+
 - (QONRemoteConfigV2Release *)fallbackReleaseForCurrentScopeLocked {
   if (!self.fallbackRelease || !self.currentScope) return self.fallbackRelease;
   NSString *projectKey = self.fallbackProjectKey;
@@ -118,9 +278,79 @@
       previousRelease:state.previous fallbackRelease:[self fallbackReleaseForCurrentScopeLocked]];
 }
 
+- (void)emitReadGuardTelemetry:(QONRemoteConfigV2ReadGuardTelemetryEvent)event {
+  QONRemoteConfigV2ReadGuardTelemetryHandler handler = self.readGuardTelemetryHandler;
+  if (!handler) return;
+  dispatch_async(self.callbackExecutor, ^{
+    @try { handler(event); }
+    @catch (__unused NSException *exception) {}
+  });
+}
+
+- (void)scheduleReadGuardDeliveryDrain {
+  dispatch_async(self.callbackExecutor, ^{ [self drainDeliveriesOnCallbackExecutor]; });
+}
+
 - (QONRemoteConfigSnapshot *)currentSnapshot {
   __block QONRemoteConfigSnapshot *snapshot = nil;
-  dispatch_sync(self.stateQueue, ^{ snapshot = [self snapshotForState:self.state]; });
+  __block QONRemoteConfigV2ReadGuardAssertionHandler assertionHandler = nil;
+  __block BOOL emitReadBeforeActivate = NO;
+  __block BOOL emitImplicitActivation = NO;
+  __block BOOL emitPreloadAbsent = NO;
+  __block BOOL drainDeliveries = NO;
+  dispatch_sync(self.stateQueue, ^{
+    BOOL scopeBindingPending = self.latestReadGuardPreloadToken != nil;
+    if (self.readGuardEnabled && !scopeBindingPending &&
+        !self.readGuardExplicitActivationCalled &&
+        !self.readGuardFirstReadClaimed) {
+      self.readGuardFirstReadClaimed = YES;
+      if (self.readGuardBuildMode == QONRemoteConfigV2ReadGuardBuildModeDebug) {
+        assertionHandler = self.readGuardAssertionHandler;
+      } else {
+        emitReadBeforeActivate = YES;
+        BOOL activationArmed = !self.readGuardLifetimeActivationConsumed &&
+            self.readGuardFirstReadActivationArmed;
+        self.readGuardLifetimeActivationConsumed = YES;
+        self.readGuardFirstReadActivationArmed = NO;
+        if (activationArmed && self.readGuardPreparedState &&
+            self.state == self.readGuardBaseState) {
+          emitImplicitActivation = self.readGuardPreparedState != self.readGuardBaseState;
+          QONRemoteConfigSnapshot *oldSnapshot = [self snapshotForState:self.state];
+          self.state = self.readGuardPreparedState;
+          self.nextAdmissionOrdinal = MAX(self.nextAdmissionOrdinal,
+                                           self.state.latestAdmissionOrdinal);
+          QONRemoteConfigUpdate *update = [self updateFromSnapshot:oldSnapshot
+                                                           toState:self.state];
+          if (update.changedKeys.count > 0) {
+            [self enqueueUpdateLocked:update];
+            drainDeliveries = YES;
+          }
+        }
+        self.readGuardBaseState = nil;
+        self.readGuardPreparedState = nil;
+      }
+    }
+    if (self.readGuardEnabled && !self.currentScope &&
+        !self.readGuardFailSafeEventClaimed) {
+      self.readGuardFailSafeEventClaimed = YES;
+      emitPreloadAbsent = YES;
+    }
+    snapshot = [self snapshotForState:self.state];
+  });
+  if (assertionHandler) {
+    @try { assertionHandler(QONRemoteConfigV2ReadBeforeActivateAssertionMessage); }
+    @catch (__unused NSException *exception) {}
+  }
+  if (emitReadBeforeActivate) {
+    [self emitReadGuardTelemetry:QONRemoteConfigV2ReadGuardTelemetryEventReadBeforeActivate];
+  }
+  if (emitImplicitActivation) {
+    [self emitReadGuardTelemetry:QONRemoteConfigV2ReadGuardTelemetryEventImplicitActivation];
+  }
+  if (emitPreloadAbsent) {
+    [self emitReadGuardTelemetry:QONRemoteConfigV2ReadGuardTelemetryEventPreloadAbsent];
+  }
+  if (drainDeliveries) [self scheduleReadGuardDeliveryDrain];
   return snapshot;
 }
 
@@ -172,6 +402,84 @@
 }
 
 - (void)applyScopeLocked:(QONRemoteConfigV2Scope *)scope {
+  if (self.readGuardEnabled) {
+    __block BOOL emitFailSafe = NO;
+    __block QONRemoteConfigV2ReadGuardTelemetryEvent failSafeEvent =
+        QONRemoteConfigV2ReadGuardTelemetryEventPreloadAbsent;
+    dispatch_sync(self.stateQueue, ^{
+      self.readGuardScopeSelectionEpoch += 1;
+      self.latestReadGuardPreloadToken = nil;
+      QONRemoteConfigV2ReadGuardPreparedSlot *availableSlot = self.preloadedSlot;
+      self.preloadedSlot = nil;
+      BOOL sameScope = (self.currentScope == nil && scope == nil) ||
+          [self.currentScope isEqual:scope];
+      BOOL hasExactPreload = scope && [availableSlot.scope isEqual:scope];
+      if (sameScope && !hasExactPreload) return;
+
+      if (!sameScope) {
+        self.currentScope = [scope copy];
+        self.state = [self emptyState];
+        self.scopeLoadFailed = NO;
+        self.nextAdmissionOrdinal = 0;
+        self.scopeGeneration += 1;
+      } else if (hasExactPreload) {
+        // A freshly preloaded state starts a new read/observer generation even
+        // when the logical scope is unchanged.
+        self.scopeGeneration += 1;
+      }
+      self.readGuardBaseState = nil;
+      self.readGuardPreparedState = nil;
+      self.readGuardFirstReadActivationArmed = NO;
+      self.readGuardFirstReadClaimed = NO;
+      self.readGuardExplicitActivationCalled = NO;
+      self.readGuardScopeUnavailable = scope != nil;
+      self.readGuardFailSafeEventClaimed = NO;
+
+      if (!scope) return;
+      if (hasExactPreload) {
+        QONRemoteConfigV2ReadGuardPreparedSlot *slot = availableSlot;
+        self.state = slot.loadedState;
+        self.nextAdmissionOrdinal = slot.loadedState.latestAdmissionOrdinal;
+        self.readGuardBaseState = slot.loadedState;
+        self.readGuardPreparedState = slot.preparedState;
+        self.readGuardFirstReadActivationArmed =
+            self.readGuardBuildMode == QONRemoteConfigV2ReadGuardBuildModeRelease &&
+            !self.readGuardLifetimeActivationConsumed &&
+            slot.status != QONRemoteConfigV2ReadGuardPreloadStatusFailed &&
+            slot.status != QONRemoteConfigV2ReadGuardPreloadStatusCorrupt;
+        self.readGuardScopeUnavailable =
+            slot.status == QONRemoteConfigV2ReadGuardPreloadStatusFailed ||
+            slot.status == QONRemoteConfigV2ReadGuardPreloadStatusCorrupt;
+        switch (slot.status) {
+          case QONRemoteConfigV2ReadGuardPreloadStatusFound:
+            break;
+          case QONRemoteConfigV2ReadGuardPreloadStatusMissing:
+            failSafeEvent = QONRemoteConfigV2ReadGuardTelemetryEventPreloadAbsent;
+            emitFailSafe = YES;
+            break;
+          case QONRemoteConfigV2ReadGuardPreloadStatusFailed:
+            failSafeEvent = QONRemoteConfigV2ReadGuardTelemetryEventPreloadFailed;
+            emitFailSafe = YES;
+            break;
+          case QONRemoteConfigV2ReadGuardPreloadStatusCorrupt:
+            failSafeEvent = QONRemoteConfigV2ReadGuardTelemetryEventPreloadCorrupt;
+            emitFailSafe = YES;
+            break;
+          case QONRemoteConfigV2ReadGuardPreloadStatusPersistenceFailed:
+            failSafeEvent =
+                QONRemoteConfigV2ReadGuardTelemetryEventPreparedActivationPersistenceFailed;
+            emitFailSafe = YES;
+            break;
+        }
+      } else {
+        failSafeEvent = QONRemoteConfigV2ReadGuardTelemetryEventPreloadAbsent;
+        emitFailSafe = YES;
+      }
+      if (emitFailSafe) self.readGuardFailSafeEventClaimed = YES;
+    });
+    if (emitFailSafe) [self emitReadGuardTelemetry:failSafeEvent];
+    return;
+  }
   dispatch_sync(self.stateQueue, ^{
     BOOL sameScope = (self.currentScope == nil && scope == nil) || [self.currentScope isEqual:scope];
     if (sameScope && !(scope && self.scopeLoadFailed)) return;
@@ -213,8 +521,36 @@
 }
 
 - (BOOL)ensureCurrentScopeLoadedLocked {
+  if (self.readGuardEnabled) {
+    return self.currentScope != nil && !self.readGuardScopeUnavailable;
+  }
   if (self.currentScope && self.scopeLoadFailed) [self loadScopeStateLocked:self.currentScope];
   return self.currentScope != nil && !self.scopeLoadFailed;
+}
+
+- (void)invalidateReadGuardPreparationLocked {
+  if (!self.readGuardEnabled) return;
+  self.readGuardBaseState = nil;
+  self.readGuardPreparedState = nil;
+  self.readGuardFirstReadActivationArmed = NO;
+}
+
+- (QONRemoteConfigV2State *)durableStateForReadGuardProposedStateLocked:
+    (QONRemoteConfigV2State *)proposedState {
+  if (!self.readGuardEnabled || !self.readGuardFirstReadActivationArmed) {
+    return proposedState;
+  }
+  return [self preparedActivationStateFromState:proposedState];
+}
+
+- (void)didCommitReadGuardProposedStateLocked:(QONRemoteConfigV2State *)proposedState
+                                 durableState:(QONRemoteConfigV2State *)durableState {
+  if (self.readGuardEnabled && self.readGuardFirstReadActivationArmed) {
+    self.readGuardBaseState = proposedState;
+    self.readGuardPreparedState = durableState;
+  } else {
+    [self invalidateReadGuardPreparationLocked];
+  }
 }
 
 - (NSSet<NSString *> *)changedKeysFrom:(QONRemoteConfigSnapshot *)oldSnapshot
@@ -240,8 +576,11 @@
       active:candidate previous:self.state.active didActivate:YES
       latestAdmissionOrdinal:latestAdmissionOrdinal];
   QONRemoteConfigV2Scope *scope = self.currentScope;
-  if (!scope || ![self.store saveState:nextState forScope:scope]) return nil;
+  QONRemoteConfigV2State *durableState =
+      [self durableStateForReadGuardProposedStateLocked:nextState];
+  if (!scope || ![self.store saveState:durableState forScope:scope]) return nil;
   self.state = nextState;
+  [self didCommitReadGuardProposedStateLocked:nextState durableState:durableState];
   QONRemoteConfigSnapshot *newSnapshot = [self snapshotForState:self.state];
   NSSet *changed = [self changedKeysFrom:oldSnapshot to:newSnapshot];
   NSMutableDictionary *metadata = [NSMutableDictionary new];
@@ -412,12 +751,15 @@
                  previous:immediate ? self.state.active : self.state.previous
               didActivate:immediate ? YES : self.state.didActivate
    latestAdmissionOrdinal:admissionToken.ordinal];
-    if (!nextState || !self.currentScope ||
-        ![self.store saveState:nextState forScope:self.currentScope]) {
+    QONRemoteConfigV2State *durableState = nextState ?
+        [self durableStateForReadGuardProposedStateLocked:nextState] : nil;
+    if (!durableState || !self.currentScope ||
+        ![self.store saveState:durableState forScope:self.currentScope]) {
       status = QONRemoteConfigV2TransitionStatusPersistenceFailed;
       return;
     }
     self.state = nextState;
+    [self didCommitReadGuardProposedStateLocked:nextState durableState:durableState];
     if (immediate) {
       QONRemoteConfigUpdate *update = [self updateFromSnapshot:oldSnapshot toState:nextState];
       [self enqueueUpdateLocked:update];
@@ -460,7 +802,12 @@
       update = [self transitionToCandidateLocked:orderedRelease];
     } else {
       QONRemoteConfigV2Scope *currentScope = self.currentScope;
-      if (currentScope && [self.store saveState:nextState forScope:currentScope]) self.state = nextState;
+      QONRemoteConfigV2State *durableState =
+          [self durableStateForReadGuardProposedStateLocked:nextState];
+      if (currentScope && [self.store saveState:durableState forScope:currentScope]) {
+        self.state = nextState;
+        [self didCommitReadGuardProposedStateLocked:nextState durableState:durableState];
+      }
     }
     if (update) [self enqueueUpdateLocked:update];
   });
@@ -471,7 +818,24 @@
   __block BOOL changed = NO;
   __block QONRemoteConfigUpdate *update = nil;
   dispatch_sync(self.stateQueue, ^{
+    if (self.readGuardEnabled) {
+      self.readGuardExplicitActivationCalled = YES;
+      self.readGuardLifetimeActivationConsumed = YES;
+    }
     if (![self ensureCurrentScopeLoadedLocked]) return;
+    if (self.readGuardEnabled && self.readGuardPreparedState &&
+        self.state == self.readGuardBaseState) {
+      QONRemoteConfigSnapshot *oldSnapshot = [self snapshotForState:self.state];
+      self.state = self.readGuardPreparedState;
+      self.nextAdmissionOrdinal = MAX(self.nextAdmissionOrdinal,
+                                       self.state.latestAdmissionOrdinal);
+      update = [self updateFromSnapshot:oldSnapshot toState:self.state];
+      changed = update.changedKeys.count > 0;
+      [self invalidateReadGuardPreparationLocked];
+      if (update) [self enqueueUpdateLocked:update];
+      return;
+    }
+    [self invalidateReadGuardPreparationLocked];
     if (self.state.candidate) {
       if (self.state.didActivate && [self release:self.state.candidate
           representsSameLocalAdmissionAs:self.state.active]) return;


### PR DESCRIPTION
## Summary\n\nImplements the customer-contract read-before-activate guard on top of the Remote Config v2 fetch-policy branch.\n\n- preloads the exact project/environment/identity/generation scope off the getter path\n- debug builds assert when a getter is used before activation\n- release builds allow one SDK-lifetime implicit activation and emit one diagnostic\n- keeps storage I/O outside getters and callbacks outside locks\n- fences stale preload/save/publish work across identity, generation, and mutation epochs\n- makes prepared activation crash-safe and recovers corrupt persisted state\n- preserves identity isolation and deterministic observer delivery\n- treats any decoder NSError as a typed-read failure even when the decoder also returned a value, so resolution continues to PreviousActive or bundle while raw stays Current\n\n## Reliability evidence\n\n- Objective-C concurrency harness: 13/13 scenarios\n- harness repeated 20/20 without failure\n- decoder error ladder reproduced RED, then fixed GREEN for Current→PreviousActive and Current+PreviousActive→bundle\n- manager and snapshot XCTest sources compiled with Wall/Wextra/Werror\n- project file lint and git diff check passed\n- independent concurrency, privacy and decoder reviews: CLEAN\n- hosted common-checks, lint, SPM and tests: green\n\n## Stack\n\nBase: codex/rc-v2-fetch-policy (#757)\n\nThis is a draft reliability increment. It does not enable a production rollout.